### PR TITLE
feat: master plan — structured diagnostic profile for each student

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,143 @@
 @AGENTS.md
+
+# Nivel — Padel Coaching Platform
+
+## Что за проект
+
+Nivel — приложение для тренеров по паделю и их учеников. Тренер ведёт сессии, записывает insight-карточки (разборы ошибок), ставит цели. Ученик видит свой прогресс и карточки.
+
+Аутентификация — через Гречка (https://www.grecha.one) — внешняя падел-платформа с базой игроков. OAuth-like flow: Nivel → grecha.one/auth-nivel.html → Firebase ID token → HMAC-подписанная сессионная кука.
+
+## Стек
+
+| Слой | Технология |
+|------|-----------|
+| Framework | Next.js 16.2.2 (App Router) |
+| UI | React 19, Tailwind CSS v4 |
+| Auth | Firebase Auth (project: grechka-6bdb7) + jose для верификации JWT |
+| База данных | Supabase (Postgres) — project: gqcyaxxhvyvpzuhoysis |
+| Деплой | Vercel |
+| Сессии | HMAC JWT в httpOnly cookie `__session` (14 дней, SESSION_SECRET) |
+
+## Архитектура
+
+```
+src/
+  app/
+    api/
+      auth/
+        grechka/          — инициирует OAuth: ставит state-cookie, редиректит на grecha.one
+        grechka-callback/ — принимает token+state, вызывает createSession(), редиректит на /dashboard
+        session/          — POST: Google Sign-In fallback (напрямую Firebase token → сессия)
+        logout/           — DELETE __session cookie
+    dashboard/            — главный экран тренера/ученика
+    goals/                — цели тренировок
+    sessions/             — история тренировочных сессий
+    insights/             — карточки разбора ошибок
+    trainer/              — управление учениками (только role=trainer)
+    login/                — страница входа
+  lib/
+    auth/session.ts       — createSession / getSession / deleteSession (НЕ "use server")
+    firebase/
+      client.ts           — lazy getFirebaseAuth() для клиента
+      admin.ts            — verifyFirebaseIdToken() через JWKS (без firebase-admin)
+    supabase/server.ts    — createClient() с SERVICE_ROLE_KEY (bypasses RLS)
+    actions/              — Server Actions (формы, мутации)
+  proxy.ts                — auth gate: проверяет __session, редиректит неавторизованных
+```
+
+## Ключевые решения
+
+- **Нет firebase-admin**: верификация токенов через Google JWKS (`jose` + `createRemoteJWKSet`) — не нужен service account
+- **Supabase без RLS**: используем service role key, авторизация на уровне приложения через сессию
+- **profiles.id**: обычный `gen_random_uuid()`, НЕ FK на auth.users (мы не используем Supabase Auth)
+- **session.ts без "use server"**: файл — обычный модуль, вызывается из Route Handlers и Server Actions
+- **proxy.ts, не middleware.ts**: Next.js 16 использует `proxy.ts` как точку входа для middleware-логики
+
+## ENV переменные
+
+```
+NEXT_PUBLIC_FIREBASE_API_KEY
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=grechka-6bdb7
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+NEXT_PUBLIC_FIREBASE_APP_ID
+NEXT_PUBLIC_NIVEL_URL          — http://localhost:3000 (dev) / https://nivel-five.vercel.app (prod)
+NEXT_PUBLIC_GRECHKA_URL        — https://www.grecha.one
+SESSION_SECRET                 — 64-char hex, для подписи HMAC JWT
+SUPABASE_SERVICE_ROLE_KEY      — server-only, bypasses RLS
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+NEXT_PUBLIC_SUPABASE_URL
+```
+
+---
+
+## Git-правила
+
+**Никогда не пушить напрямую в `main`.** Только через feature-ветки и PR.
+
+```bash
+# Правильный workflow:
+git checkout -b feat/my-feature   # или fix/, chore/, refactor/
+# ... работа ...
+git push -u origin feat/my-feature
+gh pr create --title "..." --body "..."
+# После апрува — merge через GitHub UI
+```
+
+Называй ветки так: `feat/<что>`, `fix/<что>`, `chore/<что>`.
+
+Один PR — одна логическая задача. Не смешивай фичи и рефакторинг.
+
+---
+
+## Работа с GitHub Issues
+
+### Взять задачу
+
+1. Найди открытый issue с лейблом `ready-for-agent` (или `in-progress` если уже назначен)
+2. Переведи его в `in-progress`, убери `ready-for-agent`
+3. Создай ветку: `feat/<issue-number>-<slug>`
+
+```bash
+gh issue edit <number> --add-label "in-progress" --remove-label "ready-for-agent"
+git checkout -b feat/<number>-<slug>
+```
+
+### Завершить задачу
+
+1. Создай PR, в теле упомяни `Closes #<number>`
+2. Переведи issue в `in_review`, убери `in-progress`
+3. Оставь комментарий с результатом (что сделано, PR ссылка, что проверить)
+
+```bash
+gh pr create --title "feat: ..." --body "Closes #<number>\n\n..."
+gh issue edit <number> --add-label "in_review" --remove-label "in-progress"
+gh issue comment <number> --body "✅ Готово. PR: <url>\n\nЧто сделано:\n- ...\n\nЧто проверить:\n- ..."
+```
+
+### Заблокирован?
+
+Если задача требует решения человека (доступы, неясные требования, конфликт с архитектурой):
+
+```bash
+gh issue edit <number> --add-label "blocked" --remove-label "in-progress"
+gh issue comment <number> --body "🚫 Заблокировано: <причина>\n\nЧто нужно: <что именно>"
+```
+
+---
+
+## Перед началом работы
+
+1. Проверь открытые `in-progress` issues — они уже показаны в SessionStart hook
+2. Прочитай `node_modules/next/dist/docs/` если работаешь с незнакомым API Next.js 16
+3. После изменений в схеме Supabase — применяй через Management API (MCP read-only):
+
+```bash
+curl -s -X POST \
+  "https://api.supabase.com/v1/projects/gqcyaxxhvyvpzuhoysis/database/query" \
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "..."}'
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "**" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,21 +1,17 @@
 import { createClient } from "@/lib/supabase/server";
-import { DEMO_USER } from "@/lib/supabase/demoUser";
+import { getSession } from "@/lib/auth/session";
 import { redirect } from "next/navigation";
 import { calculateSkillLevel } from "@/lib/types";
 import Link from "next/link";
 import ProgressBar from "@/components/ui/ProgressBar";
+import { getMasterPlan } from "@/lib/actions/masterPlan";
 
 export default async function DashboardPage() {
+  const user = await getSession();
+  if (!user) redirect("/login");
+
+  const profile = user;
   const supabase = await createClient();
-
-  const user = DEMO_USER;
-const { data: profile } = await supabase
-    .from("profiles")
-    .select("*")
-    .eq("id", user.id)
-    .single();
-
-  if (!profile) redirect("/login");
 
   const { data: goalsRaw } = await supabase
     .from("goals")
@@ -124,6 +120,9 @@ const { data: profile } = await supabase
     pendingCounts.set(sid, (pendingCounts.get(sid) ?? 0) + 1);
   });
 
+  const masterPlan = await getMasterPlan(user.id);
+  const masterPlanPreview = masterPlan?.sections.slice(0, 2) ?? [];
+
   const firstName = profile.full_name?.split(" ")[0] || "Player";
   const isEmpty = goals.length === 0 && skillProgress.length === 0;
 
@@ -205,6 +204,38 @@ const { data: profile } = await supabase
                 <span className="material-symbols-outlined text-2xl">
                   arrow_forward
                 </span>
+              </div>
+            </Link>
+          )}
+
+          {masterPlan && (
+            <Link
+              href="/masterplan"
+              className="block bg-surface-low rounded-2xl p-4 active:bg-surface-card transition-colors"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <p className="text-secondary text-[10px] font-black uppercase tracking-[0.2em]">
+                  Master Plan
+                </p>
+                <span className="material-symbols-outlined text-on-surface-variant opacity-40 text-base">
+                  chevron_right
+                </span>
+              </div>
+              <div className="space-y-1.5">
+                {masterPlanPreview.map((section) => (
+                  <div key={section.id} className="flex items-center gap-2">
+                    <span className="w-1.5 h-1.5 rounded-full bg-secondary opacity-60 flex-shrink-0" />
+                    <p className="text-sm text-on-surface-variant truncate">{section.title}</p>
+                    <span className="text-[10px] text-on-surface-variant opacity-40 flex-shrink-0">
+                      {section.items.length} items
+                    </span>
+                  </div>
+                ))}
+                {masterPlan.sections.length > 2 && (
+                  <p className="text-xs text-on-surface-variant opacity-40 pl-3.5">
+                    + {masterPlan.sections.length - 2} more sections
+                  </p>
+                )}
               </div>
             </Link>
           )}

--- a/src/app/masterplan/layout.tsx
+++ b/src/app/masterplan/layout.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
-import type { Profile } from "@/lib/types";
 import BottomNav from "@/components/navigation/BottomNav";
 
 export default async function MasterPlanLayout({
@@ -10,12 +9,11 @@ export default async function MasterPlanLayout({
 }) {
   const user = await getSession();
   if (!user) redirect("/login");
-  const profile = { role: user.role };
 
   return (
     <div className="relative mx-auto min-h-screen max-w-[430px] bg-background">
       {children}
-      <BottomNav role={(profile as Pick<Profile, "role">).role} />
+      <BottomNav role={user.role} />
     </div>
   );
 }

--- a/src/app/masterplan/layout.tsx
+++ b/src/app/masterplan/layout.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import type { Profile } from "@/lib/types";
+import BottomNav from "@/components/navigation/BottomNav";
+
+export default async function MasterPlanLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getSession();
+  if (!user) redirect("/login");
+  const profile = { role: user.role };
+
+  return (
+    <div className="relative mx-auto min-h-screen max-w-[430px] bg-background">
+      {children}
+      <BottomNav role={(profile as Pick<Profile, "role">).role} />
+    </div>
+  );
+}

--- a/src/app/masterplan/page.tsx
+++ b/src/app/masterplan/page.tsx
@@ -1,0 +1,95 @@
+import { getSession } from "@/lib/auth/session";
+import { getMasterPlan } from "@/lib/actions/masterPlan";
+import { redirect } from "next/navigation";
+import type { MasterPlanCategory } from "@/lib/types";
+
+const CATEGORY_LABELS: Record<MasterPlanCategory, string> = {
+  strength: "Strengths",
+  technique: "Technique",
+  tactics: "Tactics",
+  custom: "Other",
+};
+
+const CATEGORY_COLORS: Record<MasterPlanCategory, string> = {
+  strength: "#cafd00",
+  technique: "#00f4fe",
+  tactics: "#ff7351",
+  custom: "#888",
+};
+
+export default async function MasterPlanPage() {
+  const user = await getSession();
+  if (!user) redirect("/login");
+
+  const plan = await getMasterPlan(user.id);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
+          Master Plan
+        </span>
+      </header>
+
+      <main className="px-5 pt-6 pb-36 max-w-4xl mx-auto">
+        {!plan ? (
+          <div className="flex flex-col items-center justify-center py-20 space-y-4">
+            <span className="material-symbols-outlined text-5xl text-on-surface-variant opacity-30">
+              sports_tennis
+            </span>
+            <p className="text-on-surface-variant text-sm text-center max-w-xs">
+              Your trainer hasn&apos;t created a master plan for you yet.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {plan.sections.map((section) => (
+              <section key={section.id}>
+                <div className="flex items-center gap-2 mb-3">
+                  <div
+                    className="w-1 h-5 rounded-full"
+                    style={{ background: CATEGORY_COLORS[section.category] }}
+                  />
+                  <span
+                    className="text-[10px] font-black uppercase tracking-[0.2em]"
+                    style={{ color: CATEGORY_COLORS[section.category] }}
+                  >
+                    {CATEGORY_LABELS[section.category]}
+                  </span>
+                </div>
+                <h2 className="text-lg font-black tracking-tight mb-3 pl-3">{section.title}</h2>
+
+                <div className="space-y-3">
+                  {section.items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="bg-surface-card rounded-2xl overflow-hidden"
+                      style={{ borderLeft: `3px solid ${CATEGORY_COLORS[section.category]}` }}
+                    >
+                      {item.image_url && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={item.image_url}
+                          alt=""
+                          className="w-full object-cover max-h-64"
+                        />
+                      )}
+                      <div className="p-4">
+                        <p className="font-bold text-sm">{item.title}</p>
+                        {item.description && (
+                          <p className="text-sm text-on-surface-variant mt-1 leading-relaxed">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/masterplan/page.tsx
+++ b/src/app/masterplan/page.tsx
@@ -1,6 +1,7 @@
 import { getSession } from "@/lib/auth/session";
 import { getMasterPlan } from "@/lib/actions/masterPlan";
 import { redirect } from "next/navigation";
+import Image from "next/image";
 import type { MasterPlanCategory } from "@/lib/types";
 
 const CATEGORY_LABELS: Record<MasterPlanCategory, string> = {
@@ -10,11 +11,25 @@ const CATEGORY_LABELS: Record<MasterPlanCategory, string> = {
   custom: "Other",
 };
 
-const CATEGORY_COLORS: Record<MasterPlanCategory, string> = {
-  strength: "#cafd00",
-  technique: "#00f4fe",
-  tactics: "#ff7351",
-  custom: "#888",
+const CATEGORY_BORDER_CLASSES: Record<MasterPlanCategory, string> = {
+  strength: "border-l-primary",
+  technique: "border-l-secondary",
+  tactics: "border-l-error",
+  custom: "border-l-on-surface-variant",
+};
+
+const CATEGORY_TEXT_CLASSES: Record<MasterPlanCategory, string> = {
+  strength: "text-primary",
+  technique: "text-secondary",
+  tactics: "text-error",
+  custom: "text-on-surface-variant",
+};
+
+const CATEGORY_BG_CLASSES: Record<MasterPlanCategory, string> = {
+  strength: "bg-primary",
+  technique: "bg-secondary",
+  tactics: "bg-error",
+  custom: "bg-on-surface-variant",
 };
 
 export default async function MasterPlanPage() {
@@ -31,7 +46,7 @@ export default async function MasterPlanPage() {
         </span>
       </header>
 
-      <main className="px-5 pt-6 pb-36 max-w-4xl mx-auto">
+      <main className="px-5 pt-6 pb-36 mx-auto">
         {!plan ? (
           <div className="flex flex-col items-center justify-center py-20 space-y-4">
             <span className="material-symbols-outlined text-5xl text-on-surface-variant opacity-30">
@@ -46,14 +61,8 @@ export default async function MasterPlanPage() {
             {plan.sections.map((section) => (
               <section key={section.id}>
                 <div className="flex items-center gap-2 mb-3">
-                  <div
-                    className="w-1 h-5 rounded-full"
-                    style={{ background: CATEGORY_COLORS[section.category] }}
-                  />
-                  <span
-                    className="text-[10px] font-black uppercase tracking-[0.2em]"
-                    style={{ color: CATEGORY_COLORS[section.category] }}
-                  >
+                  <div className={`w-1 h-5 rounded-full ${CATEGORY_BG_CLASSES[section.category]}`} />
+                  <span className={`text-[10px] font-black uppercase tracking-[0.2em] ${CATEGORY_TEXT_CLASSES[section.category]}`}>
                     {CATEGORY_LABELS[section.category]}
                   </span>
                 </div>
@@ -63,16 +72,19 @@ export default async function MasterPlanPage() {
                   {section.items.map((item) => (
                     <div
                       key={item.id}
-                      className="bg-surface-card rounded-2xl overflow-hidden"
-                      style={{ borderLeft: `3px solid ${CATEGORY_COLORS[section.category]}` }}
+                      className={`bg-surface-card rounded-2xl overflow-hidden border-l-[3px] ${CATEGORY_BORDER_CLASSES[section.category]}`}
                     >
                       {item.image_url && (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          src={item.image_url}
-                          alt=""
-                          className="w-full object-cover max-h-64"
-                        />
+                        <div className="relative w-full max-h-64 overflow-hidden">
+                          <Image
+                            src={item.image_url}
+                            alt=""
+                            width={800}
+                            height={450}
+                            className="w-full object-cover"
+                            unoptimized
+                          />
+                        </div>
                       )}
                       <div className="p-4">
                         <p className="font-bold text-sm">{item.title}</p>

--- a/src/app/trainer/students/[id]/page.tsx
+++ b/src/app/trainer/students/[id]/page.tsx
@@ -1,25 +1,22 @@
 import { createClient } from "@/lib/supabase/server";
-import { DEMO_USER } from "@/lib/supabase/demoUser";
 import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import { calculateSkillLevel } from "@/lib/types";
 import ProgressBar from "@/components/ui/ProgressBar";
+import { getMasterPlan } from "@/lib/actions/masterPlan";
+import MasterPlanEditor from "@/components/masterPlan/MasterPlanEditor";
 
 export default async function TrainerStudentDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") redirect("/dashboard");
+
   const { id: studentId } = await params;
   const supabase = await createClient();
-
-  const user = DEMO_USER;
-// Verify trainer
-  const { data: myProfile } = await supabase
-    .from("profiles")
-    .select("role")
-    .eq("id", user.id)
-    .single();
 
   // Get student profile
   const { data: student } = await supabase
@@ -101,6 +98,8 @@ export default async function TrainerStudentDetailPage({
     .limit(20);
 
   const sessions = sessionsRaw || [];
+
+  const masterPlan = await getMasterPlan(studentId);
 
   const studentName = student.full_name || student.email;
 
@@ -252,6 +251,8 @@ export default async function TrainerStudentDetailPage({
             </div>
           </section>
         )}
+
+        <MasterPlanEditor studentId={studentId} plan={masterPlan} />
       </main>
     </div>
   );

--- a/src/components/masterPlan/MasterPlanEditor.tsx
+++ b/src/components/masterPlan/MasterPlanEditor.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { createMasterPlan, addSection, addItem, deleteSection, deleteItem } from "@/lib/actions/masterPlan";
+import type { MasterPlan, MasterPlanCategory } from "@/lib/types";
+
+const CATEGORY_LABELS: Record<MasterPlanCategory, string> = {
+  strength: "Strengths",
+  technique: "Technique",
+  tactics: "Tactics",
+  custom: "Other",
+};
+
+const CATEGORY_COLORS: Record<MasterPlanCategory, string> = {
+  strength: "#cafd00",
+  technique: "#00f4fe",
+  tactics: "#ff7351",
+  custom: "#888",
+};
+
+interface Props {
+  studentId: string;
+  plan: MasterPlan | null;
+}
+
+export default function MasterPlanEditor({ studentId, plan: initialPlan }: Props) {
+  const [plan, setPlan] = useState(initialPlan);
+  const [isPending, startTransition] = useTransition();
+  const [addingSectionTo, setAddingSectionTo] = useState<string | null>(null);
+  const [newSectionTitle, setNewSectionTitle] = useState("");
+  const [newSectionCategory, setNewSectionCategory] = useState<MasterPlanCategory>("technique");
+  const [addingItemTo, setAddingItemTo] = useState<string | null>(null);
+  const [newItemTitle, setNewItemTitle] = useState("");
+  const [newItemDesc, setNewItemDesc] = useState("");
+  const [newItemImage, setNewItemImage] = useState("");
+
+  function handleCreatePlan() {
+    startTransition(async () => {
+      const res = await createMasterPlan(studentId);
+      if (res.success) {
+        setPlan({ id: res.id, student_id: studentId, trainer_id: "", created_at: "", updated_at: "", sections: [] });
+      }
+    });
+  }
+
+  function handleAddSection(planId: string) {
+    if (!newSectionTitle.trim()) return;
+    startTransition(async () => {
+      const res = await addSection(planId, studentId, {
+        title: newSectionTitle,
+        category: newSectionCategory,
+        sortOrder: plan?.sections.length ?? 0,
+      });
+      if (res.success) {
+        setPlan((prev) => prev ? {
+          ...prev,
+          sections: [...prev.sections, { id: res.id, plan_id: planId, title: newSectionTitle, category: newSectionCategory, sort_order: prev.sections.length, items: [] }],
+        } : prev);
+        setNewSectionTitle("");
+        setAddingSectionTo(null);
+      }
+    });
+  }
+
+  function handleDeleteSection(sectionId: string) {
+    startTransition(async () => {
+      const res = await deleteSection(sectionId, studentId);
+      if (res.success) {
+        setPlan((prev) => prev ? { ...prev, sections: prev.sections.filter((s) => s.id !== sectionId) } : prev);
+      }
+    });
+  }
+
+  function handleAddItem(sectionId: string) {
+    if (!newItemTitle.trim()) return;
+    startTransition(async () => {
+      const res = await addItem(sectionId, studentId, {
+        title: newItemTitle,
+        description: newItemDesc || null,
+        imageUrl: newItemImage || null,
+        sortOrder: plan?.sections.find((s) => s.id === sectionId)?.items.length ?? 0,
+      });
+      if (res.success) {
+        setPlan((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            sections: prev.sections.map((s) =>
+              s.id !== sectionId ? s : {
+                ...s,
+                items: [...s.items, { id: res.id, section_id: sectionId, title: newItemTitle, description: newItemDesc || null, image_url: newItemImage || null, sort_order: s.items.length }],
+              }
+            ),
+          };
+        });
+        setNewItemTitle("");
+        setNewItemDesc("");
+        setNewItemImage("");
+        setAddingItemTo(null);
+      }
+    });
+  }
+
+  function handleDeleteItem(sectionId: string, itemId: string) {
+    startTransition(async () => {
+      const res = await deleteItem(itemId, studentId);
+      if (res.success) {
+        setPlan((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            sections: prev.sections.map((s) =>
+              s.id !== sectionId ? s : { ...s, items: s.items.filter((it) => it.id !== itemId) }
+            ),
+          };
+        });
+      }
+    });
+  }
+
+  if (!plan) {
+    return (
+      <section>
+        <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant mb-4">
+          Master Plan
+        </h3>
+        <div className="bg-surface-card rounded-2xl p-6 flex flex-col items-center gap-3">
+          <p className="text-on-surface-variant text-sm text-center">No master plan yet</p>
+          <button
+            onClick={handleCreatePlan}
+            disabled={isPending}
+            className="kinetic-gradient text-on-primary font-black py-2.5 px-6 rounded-xl text-sm active:scale-[0.98] transition-transform disabled:opacity-50"
+          >
+            Create Master Plan
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant">
+          Master Plan
+        </h3>
+        <button
+          onClick={() => setAddingSectionTo(plan.id)}
+          className="text-primary text-xs font-bold uppercase tracking-wider"
+        >
+          + Section
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        {plan.sections.map((section) => (
+          <div
+            key={section.id}
+            className="bg-surface-card rounded-2xl p-4"
+            style={{ borderTop: `2px solid ${CATEGORY_COLORS[section.category]}` }}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <span className="text-[10px] font-black uppercase tracking-widest" style={{ color: CATEGORY_COLORS[section.category] }}>
+                  {CATEGORY_LABELS[section.category]}
+                </span>
+                <p className="font-bold text-sm mt-0.5">{section.title}</p>
+              </div>
+              <button
+                onClick={() => handleDeleteSection(section.id)}
+                disabled={isPending}
+                className="text-error text-xs opacity-60 hover:opacity-100"
+              >
+                <span className="material-symbols-outlined text-base">delete</span>
+              </button>
+            </div>
+
+            <div className="space-y-2 mb-3">
+              {section.items.map((item) => (
+                <div key={item.id} className="bg-surface-low rounded-xl p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold">{item.title}</p>
+                      {item.description && (
+                        <p className="text-xs text-on-surface-variant mt-0.5 leading-relaxed">{item.description}</p>
+                      )}
+                      {item.image_url && (
+                        <img
+                          src={item.image_url}
+                          alt=""
+                          className="mt-2 rounded-lg w-full object-cover max-h-48"
+                        />
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleDeleteItem(section.id, item.id)}
+                      disabled={isPending}
+                      className="text-error opacity-40 hover:opacity-100 flex-shrink-0"
+                    >
+                      <span className="material-symbols-outlined text-sm">close</span>
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {addingItemTo === section.id ? (
+              <div className="bg-surface-low rounded-xl p-3 space-y-2">
+                <input
+                  className="w-full bg-transparent text-sm font-semibold outline-none placeholder:text-on-surface-variant/50"
+                  placeholder="Item title"
+                  value={newItemTitle}
+                  onChange={(e) => setNewItemTitle(e.target.value)}
+                  autoFocus
+                />
+                <textarea
+                  className="w-full bg-transparent text-xs text-on-surface-variant outline-none resize-none placeholder:text-on-surface-variant/40"
+                  placeholder="Description (optional)"
+                  rows={2}
+                  value={newItemDesc}
+                  onChange={(e) => setNewItemDesc(e.target.value)}
+                />
+                <input
+                  className="w-full bg-transparent text-xs text-on-surface-variant outline-none placeholder:text-on-surface-variant/40"
+                  placeholder="Image URL (optional)"
+                  value={newItemImage}
+                  onChange={(e) => setNewItemImage(e.target.value)}
+                />
+                <div className="flex gap-2 pt-1">
+                  <button
+                    onClick={() => handleAddItem(section.id)}
+                    disabled={isPending || !newItemTitle.trim()}
+                    className="text-xs font-black text-primary uppercase tracking-wider disabled:opacity-40"
+                  >
+                    Add
+                  </button>
+                  <button
+                    onClick={() => { setAddingItemTo(null); setNewItemTitle(""); setNewItemDesc(""); setNewItemImage(""); }}
+                    className="text-xs text-on-surface-variant uppercase tracking-wider"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setAddingItemTo(section.id)}
+                className="text-xs text-on-surface-variant uppercase tracking-widest font-bold opacity-50 hover:opacity-100"
+              >
+                + Add item
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {addingSectionTo === plan.id && (
+        <div className="mt-4 bg-surface-card rounded-2xl p-4 space-y-3">
+          <input
+            className="w-full bg-transparent text-sm font-semibold outline-none placeholder:text-on-surface-variant/50"
+            placeholder="Section title (e.g. Volley technique)"
+            value={newSectionTitle}
+            onChange={(e) => setNewSectionTitle(e.target.value)}
+            autoFocus
+          />
+          <select
+            className="w-full bg-surface-low rounded-lg px-3 py-2 text-xs font-bold text-on-surface outline-none"
+            value={newSectionCategory}
+            onChange={(e) => setNewSectionCategory(e.target.value as MasterPlanCategory)}
+          >
+            <option value="strength">Strengths</option>
+            <option value="technique">Technique</option>
+            <option value="tactics">Tactics</option>
+            <option value="custom">Other</option>
+          </select>
+          <div className="flex gap-3">
+            <button
+              onClick={() => handleAddSection(plan.id)}
+              disabled={isPending || !newSectionTitle.trim()}
+              className="text-xs font-black text-primary uppercase tracking-wider disabled:opacity-40"
+            >
+              Add Section
+            </button>
+            <button
+              onClick={() => { setAddingSectionTo(null); setNewSectionTitle(""); }}
+              className="text-xs text-on-surface-variant uppercase tracking-wider"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/masterPlan/MasterPlanEditor.tsx
+++ b/src/components/masterPlan/MasterPlanEditor.tsx
@@ -11,11 +11,18 @@ const CATEGORY_LABELS: Record<MasterPlanCategory, string> = {
   custom: "Other",
 };
 
-const CATEGORY_COLORS: Record<MasterPlanCategory, string> = {
-  strength: "#cafd00",
-  technique: "#00f4fe",
-  tactics: "#ff7351",
-  custom: "#888",
+const CATEGORY_BORDER_CLASSES: Record<MasterPlanCategory, string> = {
+  strength: "border-t-primary",
+  technique: "border-t-secondary",
+  tactics: "border-t-error",
+  custom: "border-t-on-surface-variant",
+};
+
+const CATEGORY_TEXT_CLASSES: Record<MasterPlanCategory, string> = {
+  strength: "text-primary",
+  technique: "text-secondary",
+  tactics: "text-error",
+  custom: "text-on-surface-variant",
 };
 
 interface Props {
@@ -45,11 +52,12 @@ export default function MasterPlanEditor({ studentId, plan: initialPlan }: Props
 
   function handleAddSection(planId: string) {
     if (!newSectionTitle.trim()) return;
+    const currentSortOrder = plan?.sections.length ?? 0;
     startTransition(async () => {
       const res = await addSection(planId, studentId, {
         title: newSectionTitle,
         category: newSectionCategory,
-        sortOrder: plan?.sections.length ?? 0,
+        sortOrder: currentSortOrder,
       });
       if (res.success) {
         setPlan((prev) => prev ? {
@@ -73,12 +81,13 @@ export default function MasterPlanEditor({ studentId, plan: initialPlan }: Props
 
   function handleAddItem(sectionId: string) {
     if (!newItemTitle.trim()) return;
+    const currentSortOrder = plan?.sections.find((s) => s.id === sectionId)?.items.length ?? 0;
     startTransition(async () => {
       const res = await addItem(sectionId, studentId, {
         title: newItemTitle,
         description: newItemDesc || null,
         imageUrl: newItemImage || null,
-        sortOrder: plan?.sections.find((s) => s.id === sectionId)?.items.length ?? 0,
+        sortOrder: currentSortOrder,
       });
       if (res.success) {
         setPlan((prev) => {
@@ -156,12 +165,11 @@ export default function MasterPlanEditor({ studentId, plan: initialPlan }: Props
         {plan.sections.map((section) => (
           <div
             key={section.id}
-            className="bg-surface-card rounded-2xl p-4"
-            style={{ borderTop: `2px solid ${CATEGORY_COLORS[section.category]}` }}
+            className={`bg-surface-card rounded-2xl p-4 border-t-[2px] ${CATEGORY_BORDER_CLASSES[section.category]}`}
           >
             <div className="flex items-center justify-between mb-3">
               <div>
-                <span className="text-[10px] font-black uppercase tracking-widest" style={{ color: CATEGORY_COLORS[section.category] }}>
+                <span className={`text-[10px] font-black uppercase tracking-widest ${CATEGORY_TEXT_CLASSES[section.category]}`}>
                   {CATEGORY_LABELS[section.category]}
                 </span>
                 <p className="font-bold text-sm mt-0.5">{section.title}</p>
@@ -185,6 +193,7 @@ export default function MasterPlanEditor({ studentId, plan: initialPlan }: Props
                         <p className="text-xs text-on-surface-variant mt-0.5 leading-relaxed">{item.description}</p>
                       )}
                       {item.image_url && (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src={item.image_url}
                           alt=""

--- a/src/lib/actions/masterPlan.ts
+++ b/src/lib/actions/masterPlan.ts
@@ -18,6 +18,9 @@ async function requireTrainer() {
 }
 
 export async function getMasterPlan(studentId: string): Promise<MasterPlan | null> {
+  const user = await getSession();
+  if (!user) return null;
+  if (user.role !== "trainer" && user.id !== studentId) return null;
   const supabase = await createClient();
   const { data: plan } = await supabase
     .from("master_plans")

--- a/src/lib/actions/masterPlan.ts
+++ b/src/lib/actions/masterPlan.ts
@@ -1,0 +1,144 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import type { MasterPlan, MasterPlanCategory } from "@/lib/types";
+
+type Result<T = void> =
+  | (T extends void ? { success: true } : { success: true } & T)
+  | { success: false; error: string };
+
+async function requireTrainer() {
+  const user = await getSession();
+  if (!user || user.role !== "trainer")
+    return { ok: false as const, error: "Not authorized" };
+  const supabase = await createClient();
+  return { ok: true as const, supabase, userId: user.id };
+}
+
+export async function getMasterPlan(studentId: string): Promise<MasterPlan | null> {
+  const supabase = await createClient();
+  const { data: plan } = await supabase
+    .from("master_plans")
+    .select("*")
+    .eq("student_id", studentId)
+    .single();
+  if (!plan) return null;
+
+  const { data: sections } = await supabase
+    .from("master_plan_sections")
+    .select("*, master_plan_items(*)")
+    .eq("plan_id", plan.id)
+    .order("sort_order");
+
+  return {
+    ...plan,
+    sections: (sections ?? []).map((s: Record<string, unknown>) => ({
+      ...(s as object),
+      items: ((s.master_plan_items as unknown[]) ?? []),
+    })),
+  } as MasterPlan;
+}
+
+export async function createMasterPlan(
+  studentId: string
+): Promise<Result<{ id: string }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { data, error } = await auth.supabase
+    .from("master_plans")
+    .insert({ student_id: studentId, trainer_id: auth.userId })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  revalidatePath(`/trainer/students/${studentId}`);
+  return { success: true, id: data.id };
+}
+
+export async function addSection(
+  planId: string,
+  studentId: string,
+  payload: { title: string; category: MasterPlanCategory; sortOrder?: number }
+): Promise<Result<{ id: string }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { data, error } = await auth.supabase
+    .from("master_plan_sections")
+    .insert({
+      plan_id: planId,
+      title: payload.title.trim(),
+      category: payload.category,
+      sort_order: payload.sortOrder ?? 0,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  revalidatePath(`/trainer/students/${studentId}`);
+  return { success: true, id: data.id };
+}
+
+export async function deleteSection(
+  sectionId: string,
+  studentId: string
+): Promise<Result> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { error } = await auth.supabase
+    .from("master_plan_sections")
+    .delete()
+    .eq("id", sectionId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/trainer/students/${studentId}`);
+  return { success: true };
+}
+
+export async function addItem(
+  sectionId: string,
+  studentId: string,
+  payload: { title: string; description?: string | null; imageUrl?: string | null; sortOrder?: number }
+): Promise<Result<{ id: string }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { data, error } = await auth.supabase
+    .from("master_plan_items")
+    .insert({
+      section_id: sectionId,
+      title: payload.title.trim(),
+      description: payload.description?.trim() || null,
+      image_url: payload.imageUrl?.trim() || null,
+      sort_order: payload.sortOrder ?? 0,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  revalidatePath(`/trainer/students/${studentId}`);
+  revalidatePath(`/masterplan`);
+  return { success: true, id: data.id };
+}
+
+export async function deleteItem(
+  itemId: string,
+  studentId: string
+): Promise<Result> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { error } = await auth.supabase
+    .from("master_plan_items")
+    .delete()
+    .eq("id", itemId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath(`/trainer/students/${studentId}`);
+  revalidatePath(`/masterplan`);
+  return { success: true };
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -146,3 +146,32 @@ export function calculateSkillLevel(points: number): {
   const points_in_level = points >= 50 ? 10 : points % 10;
   return { level, points_in_level };
 }
+
+export type MasterPlanCategory = "strength" | "technique" | "tactics" | "custom";
+
+export interface MasterPlanItem {
+  id: string;
+  section_id: string;
+  title: string;
+  description: string | null;
+  image_url: string | null;
+  sort_order: number;
+}
+
+export interface MasterPlanSection {
+  id: string;
+  plan_id: string;
+  title: string;
+  category: MasterPlanCategory;
+  sort_order: number;
+  items: MasterPlanItem[];
+}
+
+export interface MasterPlan {
+  id: string;
+  student_id: string;
+  trainer_id: string;
+  created_at: string;
+  updated_at: string;
+  sections: MasterPlanSection[];
+}

--- a/supabase/migrations/007_master_plan.sql
+++ b/supabase/migrations/007_master_plan.sql
@@ -1,0 +1,25 @@
+create table if not exists master_plans (
+  id uuid primary key default gen_random_uuid(),
+  student_id uuid not null references profiles(id) on delete cascade,
+  trainer_id uuid not null references profiles(id),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique(student_id)
+);
+
+create table if not exists master_plan_sections (
+  id uuid primary key default gen_random_uuid(),
+  plan_id uuid not null references master_plans(id) on delete cascade,
+  title text not null,
+  category text not null check (category in ('strength','technique','tactics','custom')),
+  sort_order int not null default 0
+);
+
+create table if not exists master_plan_items (
+  id uuid primary key default gen_random_uuid(),
+  section_id uuid not null references master_plan_sections(id) on delete cascade,
+  title text not null,
+  description text,
+  image_url text,
+  sort_order int not null default 0
+);


### PR DESCRIPTION
Closes #3

## Summary

- Добавлены 3 таблицы Supabase: `master_plans`, `master_plan_sections`, `master_plan_items`
- Тренер создаёт и редактирует мастер-план на `/trainer/students/[id]` (оптимистичные обновления без перезагрузки)
- Студент видит свой мастер-план на `/masterplan` и превью на `/dashboard`
- Профиль Оли создан (`olya@nivel.app`), план заполнен из диагностического документа — 10 пунктов по 3 категориям (Strengths, Technique, Tactics) с фотографиями

## Commits

| Коммит | Что |
|--------|-----|
| `b2e20f1` | Миграция БД |
| `00662ad` | TypeScript типы |
| `d710c81` | Server Actions (CRUD) |
| `c8e709b` | Страница /masterplan (студент) |
| `f9b614b` | Превью на /dashboard |
| `eef75d0` | MasterPlanEditor (тренер) |
| `1d39876` | Fix: next/image, design tokens, auth guard, stale closure |

## Test plan

- [ ] Войти как тренер → `/trainer/students/<OLYA_ID>` → секция «Master Plan» с данными Оли
- [ ] Добавить новую секцию/пункт → изменения появляются без перезагрузки
- [ ] Войти как Оля (`olya@nivel.app`) → `/dashboard` → видно превью мастер-плана
- [ ] Перейти на `/masterplan` → полный план с фотографиями
- [ ] Убедиться, что студент не может получить чужой план (auth guard в `getMasterPlan`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)