### PR TITLE
feat(goals): add createGoalForStudent for trainer-side goal creation

### DIFF
--- a/src/lib/actions/goals.ts
+++ b/src/lib/actions/goals.ts
@@ -45,6 +45,57 @@ export async function createGoal(
   }
 }
 
+export async function createGoalForStudent(
+  studentId: string,
+  problemId: number | null,
+  customProblem: string | null
+): Promise<{ success: true; goalId: string } | { success: false; error: string }> {
+  try {
+    const user = await getSession();
+    if (!user) return { success: false, error: "Not authenticated" };
+    if (user.role !== "trainer") return { success: false, error: "Forbidden" };
+
+    const supabase = await createClient();
+
+    const { data: student } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("id", studentId)
+      .single();
+    if (!student) return { success: false, error: "Student not found" };
+
+    const { data: goal, error: goalError } = await supabase
+      .from("goals")
+      .insert({ user_id: studentId, custom_problem: customProblem })
+      .select("id")
+      .single();
+
+    if (goalError || !goal) {
+      return { success: false, error: goalError?.message ?? "Failed to create goal" };
+    }
+
+    if (problemId) {
+      const { error: problemsError } = await supabase
+        .from("goal_problems")
+        .insert({ goal_id: goal.id, problem_id: problemId });
+
+      if (problemsError) {
+        return { success: false, error: problemsError.message };
+      }
+    }
+
+    revalidatePath(`/trainer/students/${studentId}`);
+    revalidatePath(`/dashboard`);
+
+    return { success: true, goalId: goal.id };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "An unexpected error occurred",
+    };
+  }
+}
+
 export async function cancelGoal(
   goalId: string
 ): Promise<{ success: true } | { success: false; error: string }> {


### PR DESCRIPTION
Closes #20

## Что сделано
- Добавлена server action `createGoalForStudent(studentId, problemId, customProblem)` в `src/lib/actions/goals.ts`
- Проверяет, что вызывающий — `role=trainer`
- Проверяет, что студент существует в `profiles`
- Создаёт goal с `user_id=studentId`, опционально привязывает `goal_problems`
- Ревалидирует `/trainer/students/[studentId]` и `/dashboard`

## Файлы
- `src/lib/actions/goals.ts` — добавлена одна новая функция в конец файла

## Проверка
SQL после вызова action:
```sql
select id, user_id, custom_problem from goals order by created_at desc limit 5;
```
Запись должна содержать `user_id = studentId`, переданный тренером.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ba8xJ4M4hTn1ozepMETc7E)_