### PR TITLE
feat(proxy): allow /invite/* without session

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,8 @@ export async function proxy(request: NextRequest) {
 
   const isPublic =
     pathname === "/login" ||
-    pathname.startsWith("/api/auth/");
+    pathname.startsWith("/api/auth/") ||
+    pathname.startsWith("/invite/");
 
   const session = request.cookies.get("__session")?.value;
 
@@ -16,7 +17,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  // Logged in — redirect away from login
+  // Logged in — redirect away from login (but allow invite re-entry).
   if (pathname === "/" || pathname === "/login") {
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";


### PR DESCRIPTION
Closes #18

## Что сделано
- Добавлен `pathname.startsWith("/invite/")` в `isPublic` в `src/proxy.ts`
- Неаутентифицированные пользователи теперь могут открывать `/invite/*` без редиректа на `/login`
- Обновлён комментарий в ветке для авторизованных пользователей

## Файлы
- `src/proxy.ts` — добавлена строка `/invite/` в allowlist + обновлён комментарий

## Проверка
1. Открыть `/invite/does-not-exist` в инкогнито-окне
2. Должен рендериться invite page (с сообщением «недоступно»), НЕ редиректить на `/login`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9)_