### PR TITLE
feat(db): migration 008 — shadow student profiles + claim tokens

### DIFF
--- a/supabase/migrations/008_shadow_student_claim.sql
+++ b/supabase/migrations/008_shadow_student_claim.sql
@@ -1,0 +1,34 @@
+-- ============================================
+-- 008 — Shadow student profiles + claim tokens
+-- ============================================
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS firebase_uid     TEXT,
+  ADD COLUMN IF NOT EXISTS claim_token      TEXT,
+  ADD COLUMN IF NOT EXISTS claim_expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS claimed_at       TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS created_by       UUID REFERENCES public.profiles(id) ON DELETE SET NULL;
+
+-- Email is now optional: shadow rows are created with email = NULL,
+-- and the claim flow writes the real Firebase email at first sign-in.
+ALTER TABLE public.profiles ALTER COLUMN email DROP NOT NULL;
+
+-- A firebase_uid can map to at most one profile.
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_firebase_uid_key
+  ON public.profiles(firebase_uid)
+  WHERE firebase_uid IS NOT NULL;
+
+-- A claim_token is unique while live.
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_claim_token_key
+  ON public.profiles(claim_token)
+  WHERE claim_token IS NOT NULL;
+
+-- Lookup index for the claim landing page.
+CREATE INDEX IF NOT EXISTS idx_profiles_claim_token ON public.profiles(claim_token);
+CREATE INDEX IF NOT EXISTS idx_profiles_created_by  ON public.profiles(created_by);
+
+COMMENT ON COLUMN public.profiles.firebase_uid     IS 'Firebase Auth UID. NULL until the profile is claimed.';
+COMMENT ON COLUMN public.profiles.claim_token      IS 'Single-use invite token (32+ chars hex). NULL after claim or revoke.';
+COMMENT ON COLUMN public.profiles.claim_expires_at IS 'Invite expiration; ignored when claim_token is NULL.';
+COMMENT ON COLUMN public.profiles.claimed_at       IS 'Set when student first signs in via the invite.';
+COMMENT ON COLUMN public.profiles.created_by       IS 'Trainer profile.id that created this shadow row.';


### PR DESCRIPTION
Closes #11

## Что сделано
- Создан `supabase/migrations/008_shadow_student_claim.sql`
- Применена миграция через Supabase Management API
- `email` теперь nullable (shadow-профили создаются без email)
- Добавлены колонки: `firebase_uid TEXT`, `claim_token TEXT`, `claim_expires_at TIMESTAMPTZ`, `claimed_at TIMESTAMPTZ`, `created_by UUID REFERENCES profiles(id)`
- Уникальные partial индексы на `firebase_uid` и `claim_token` (только когда NOT NULL)
- Lookup индексы на `claim_token` и `created_by`

## Файлы
- `supabase/migrations/008_shadow_student_claim.sql` — новый файл

## Проверка
SQL-проверка подтверждает наличие всех новых колонок с `is_nullable = YES`:
```sql
SELECT column_name, data_type, is_nullable
FROM information_schema.columns
WHERE table_schema='public' AND table_name='profiles'
ORDER BY ordinal_position;
```
Результат включает: `firebase_uid`, `claim_token`, `claim_expires_at`, `claimed_at`, `created_by` — все nullable. Колонка `email` теперь `is_nullable = YES`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt9afMbbLpX5We9TE7KEe5)_