### PR TITLE
feat(auth): pass ?claim= token through /api/auth/grechka

### DIFF
--- a/src/app/api/auth/grechka/route.ts
+++ b/src/app/api/auth/grechka/route.ts
@@ -2,10 +2,13 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { randomBytes } from "crypto";
 
-export async function GET() {
-  const state = randomBytes(16).toString("hex");
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const claim = searchParams.get("claim");
 
+  const state = randomBytes(16).toString("hex");
   const cookieStore = await cookies();
+
   cookieStore.set("__grechka_state", state, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
@@ -13,6 +16,19 @@ export async function GET() {
     maxAge: 600, // 10 min
     path: "/",
   });
+
+  if (claim) {
+    cookieStore.set("__grechka_claim", claim, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 600, // 10 min — must outlive the round-trip
+      path: "/",
+    });
+  } else {
+    // Defensive: clear any stale claim cookie.
+    cookieStore.delete("__grechka_claim");
+  }
 
   const grechkaUrl = process.env.NEXT_PUBLIC_GRECHKA_URL?.trim();
   const nivelUrl = process.env.NEXT_PUBLIC_NIVEL_URL?.trim();


### PR DESCRIPTION
Closes #16

## Что сделано
- `GET /api/auth/grechka` теперь принимает `?claim=<token>`
- Если `claim` присутствует — сохраняет в httpOnly cookie `__grechka_claim` (10 мин TTL)
- Если `claim` отсутствует — удаляет cookie `__grechka_claim` (защита от stale)
- `__grechka_state` генерируется и сохраняется как прежде

## Файлы
- `src/app/api/auth/grechka/route.ts` — добавлена обработка `?claim=` параметра

## Проверка
Открыть `/api/auth/grechka?claim=testtoken` — ответ должен содержать:
- `Set-Cookie: __grechka_claim=testtoken; ...`
- `Set-Cookie: __grechka_state=<hex>; ...`
- Редирект на `grecha.one/auth-nivel.html`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9)_