### PR TITLE
feat(#30): Create Student button + modal on /trainer/students

### DIFF
--- a/src/app/trainer/students/page.tsx
+++ b/src/app/trainer/students/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
+import CreateStudentButton from "@/components/trainer/CreateStudentButton";
 
 export default async function TrainerStudentsPage() {
   const user = await getSession();
@@ -19,7 +20,7 @@ export default async function TrainerStudentsPage() {
   // For each student, get goal & session counts
   interface StudentWithStats {
     id: string;
-    email: string;
+    email: string | null;
     full_name: string | null;
     avatar_url: string | null;
     active_goals: number;
@@ -41,7 +42,7 @@ export default async function TrainerStudentsPage() {
 
       return {
         id: student.id as string,
-        email: student.email as string,
+        email: student.email as string | null,
         full_name: student.full_name as string | null,
         avatar_url: student.avatar_url as string | null,
         active_goals: goalCount || 0,
@@ -53,12 +54,13 @@ export default async function TrainerStudentsPage() {
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
-          Ученики
-        </span>
-        <Link href="/dashboard" className="text-on-surface-variant">
-          <span className="material-symbols-outlined">close</span>
-        </Link>
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">Ученики</span>
+        <div className="flex items-center gap-3">
+          <CreateStudentButton />
+          <Link href="/dashboard" className="text-on-surface-variant">
+            <span className="material-symbols-outlined">close</span>
+          </Link>
+        </div>
       </header>
 
       <main className="px-5 pt-6 pb-36 max-w-4xl mx-auto">
@@ -97,7 +99,7 @@ export default async function TrainerStudentsPage() {
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="font-semibold text-on-surface">
-                    {student.full_name || student.email}
+                    {student.full_name || student.email || "Unnamed"}
                   </p>
                   <div className="flex gap-3 mt-1">
                     <span className="text-[11px] text-on-surface-variant">

--- a/src/components/trainer/CreateStudentButton.tsx
+++ b/src/components/trainer/CreateStudentButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createShadowStudent } from "@/lib/actions/students";
+
+export default function CreateStudentButton() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [fullName, setFullName] = useState("");
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  function handleCreate() {
+    if (!fullName.trim()) return;
+    startTransition(async () => {
+      try {
+        const res = await createShadowStudent({ full_name: fullName.trim() });
+        setCreatedUrl(res.claimUrl);
+        router.refresh();
+      } catch (err) {
+        alert(err instanceof Error ? err.message : "Failed to create student");
+      }
+    });
+  }
+
+  function handleCopy() {
+    if (!createdUrl) return;
+    navigator.clipboard.writeText(createdUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  function handleClose() {
+    setOpen(false);
+    setFullName("");
+    setCreatedUrl(null);
+  }
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)} className="kinetic-gradient text-on-primary font-black py-2 px-4 rounded-xl text-sm active:scale-[0.98] transition-transform">
+        + Create student
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 bg-background/80 flex items-end sm:items-center justify-center p-4" onClick={handleClose}>
+          <div className="bg-surface-card rounded-3xl p-6 w-full max-w-md space-y-4" onClick={(e) => e.stopPropagation()}>
+            {!createdUrl ? (
+              <>
+                <h3 className="text-lg font-black tracking-tight">New student</h3>
+                <input
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  placeholder="Full name"
+                  autoFocus
+                  className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+                />
+                <div className="flex gap-2">
+                  <button onClick={handleCreate} disabled={isPending || !fullName.trim()} className="flex-1 py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary disabled:opacity-40">
+                    {isPending ? "Creating…" : "Create"}
+                  </button>
+                  <button onClick={handleClose} className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface">
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h3 className="text-lg font-black tracking-tight">Student created</h3>
+                <p className="text-sm text-on-surface-variant">Share this link with the student to claim their profile:</p>
+                <div className="bg-surface-elevated rounded-xl p-3 flex items-center gap-2">
+                  <code className="text-xs text-on-surface flex-1 truncate">{createdUrl}</code>
+                  <button onClick={handleCopy} className="text-xs font-bold uppercase tracking-wider text-primary px-2">
+                    {copied ? "✓" : "Copy"}
+                  </button>
+                </div>
+                <button onClick={handleClose} className="w-full py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary">Done</button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #30

## What

- New `CreateStudentButton` component: opens a modal with a full-name input, calls `createShadowStudent`, then shows the generated invite URL with a copy button
- Updated `/trainer/students` header to include `CreateStudentButton` + close link in a flex group
- Fixed null-safe display of student name: `full_name || email || "Unnamed"` (email can be null for shadow students)
- Fixed `StudentWithStats.email` type from `string` to `string | null`

## Adaptation from plan

Plan referenced `res.success`/`res.token`/`res.error` — adapted to actual `createShadowStudent` return type `{ studentId, claimUrl, claimToken, expiresAt }` with try/catch error handling.

## Test plan

- [ ] Navigate to `/trainer/students` as a trainer
- [ ] Click "+ Create student", enter a name, click Create
- [ ] Verify invite URL is shown and copy button works
- [ ] Dismiss modal, verify new student appears in the list (shadow student with null email shows name correctly)
- [ ] Verify "Unnamed" fallback if both name and email are null

https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9)_