### PR TITLE
feat(#17): branch grechka-callback through claimSession when claim cookie present

### DIFF
--- a/src/app/api/auth/grechka-callback/route.ts
+++ b/src/app/api/auth/grechka-callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
-import { createSession } from "@/lib/auth/session";
+import { ClaimError, claimSession, createSession } from "@/lib/auth/session";
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -9,16 +9,26 @@ export async function GET(request: Request) {
 
   const cookieStore = await cookies();
   const savedState = cookieStore.get("__grechka_state")?.value;
+  const claimToken = cookieStore.get("__grechka_claim")?.value ?? null;
   cookieStore.delete("__grechka_state");
+  cookieStore.delete("__grechka_claim");
 
   if (!token || !state || state !== savedState) {
     return NextResponse.redirect(`${origin}/login?error=invalid_state`);
   }
 
   try {
-    await createSession(token);
+    if (claimToken) {
+      await claimSession(token, claimToken);
+    } else {
+      await createSession(token);
+    }
     return NextResponse.redirect(`${origin}/dashboard`);
   } catch (err) {
+    if (err instanceof ClaimError) {
+      console.error("[grechka-callback] claimSession failed:", err.code);
+      return NextResponse.redirect(`${origin}/login?error=claim_${err.code}`);
+    }
     console.error("[grechka-callback] createSession failed:", err);
     return NextResponse.redirect(`${origin}/login?error=auth_failed`);
   }


### PR DESCRIPTION
Closes #17

## What

Updates `src/app/api/auth/grechka-callback/route.ts` to branch on `__grechka_claim` cookie:

- If `__grechka_claim` cookie is present → call `claimSession(token, claimToken)` to bind the Firebase identity to the shadow student profile
- If absent → fall through to normal `createSession(token)`
- In both cases the `__grechka_claim` cookie is deleted after reading
- `ClaimError` is caught and redirects to `/login?error=claim_<code>` for user-friendly messaging

## Test plan

- [ ] Normal login (no claim cookie): redirects to `/dashboard` as before
- [ ] Claim flow: visit `/invite/<token>` → click Гречка login → after OAuth callback, profile is claimed and redirected to `/dashboard`
- [ ] Expired/invalid claim token: redirects to `/login?error=claim_expired` or `claim_invalid`

https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9)_