### PR TITLE
feat(dashboard): InlineGoalCreator modal for trainer view

### DIFF
--- a/src/components/dashboard/edit/InlineGoalCreator.tsx
+++ b/src/components/dashboard/edit/InlineGoalCreator.tsx
@@ -1,4 +1,103 @@
+// src/components/dashboard/edit/InlineGoalCreator.tsx
 "use client";
-export default function InlineGoalCreator({ studentId: _studentId }: { studentId: string }) {
-  return <span className="text-primary text-xs font-bold uppercase tracking-wider opacity-30">+ new</span>;
+
+import { useState, useTransition, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { createGoalForStudent } from "@/lib/actions/goals";
+import { createClient } from "@/lib/supabase/client";
+
+interface Problem {
+  id: number;
+  name: string;
+  category_id: number;
+}
+
+export default function InlineGoalCreator({ studentId }: { studentId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [problems, setProblems] = useState<Problem[]>([]);
+  const [problemId, setProblemId] = useState<number | "">("");
+  const [customProblem, setCustomProblem] = useState("");
+
+  useEffect(() => {
+    if (!open || problems.length) return;
+    const supabase = createClient();
+    supabase
+      .from("problems")
+      .select("id, category_id, name_ru")
+      .order("sort_order")
+      .then(({ data }) => {
+        if (data) {
+          setProblems(
+            data.map((p: Record<string, unknown>) => ({
+              id: p.id as number,
+              category_id: p.category_id as number,
+              name: (p.name_ru as string) ?? "",
+            }))
+          );
+        }
+      });
+  }, [open, problems.length]);
+
+  function handleSave() {
+    if (!problemId && !customProblem.trim()) return;
+    startTransition(async () => {
+      const res = await createGoalForStudent(
+        studentId,
+        problemId === "" ? null : Number(problemId),
+        customProblem.trim() || null
+      );
+      if (!res.success) {
+        alert(res.error);
+        return;
+      }
+      setOpen(false);
+      setProblemId("");
+      setCustomProblem("");
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <button onClick={() => setOpen(true)} className="text-primary text-xs font-bold uppercase tracking-wider">
+        + new
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 bg-background/80 flex items-end sm:items-center justify-center p-4" onClick={() => setOpen(false)}>
+          <div className="bg-surface-card rounded-3xl p-6 w-full max-w-md space-y-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black tracking-tight">New goal</h3>
+            <textarea
+              value={customProblem}
+              onChange={(e) => setCustomProblem(e.target.value)}
+              placeholder="Describe the problem (or leave empty and pick from list)"
+              rows={2}
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none border border-border-dim focus:border-primary focus:outline-none"
+            />
+            <select
+              value={problemId}
+              onChange={(e) => setProblemId(e.target.value ? Number(e.target.value) : "")}
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+            >
+              <option value="">— Link a problem (optional) —</option>
+              {problems.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+            </select>
+            <div className="flex gap-2">
+              <button
+                onClick={handleSave}
+                disabled={isPending || (!problemId && !customProblem.trim())}
+                className="flex-1 py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary disabled:opacity-40"
+              >
+                {isPending ? "Saving…" : "Save"}
+              </button>
+              <button onClick={() => setOpen(false)} className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface">
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #25

## Что сделано
- Заменён стаб `InlineGoalCreator` на полную реализацию модалки
- Тренер может создать цель для ученика прямо на странице: ввести произвольный текст и/или выбрать задачу из списка `problems`
- После сохранения список обновляется через `router.refresh()` без перезагрузки страницы
- Список проблем загружается лениво при первом открытии модалки (через Supabase anon client)

## Файлы
- `src/components/dashboard/edit/InlineGoalCreator.tsx` — полная реализация (заменяет стаб)

## Проверка
1. Зайти под тренером на страницу ученика `/trainer/students/[id]`
2. Нажать кнопку `+ new` рядом с секцией целей
3. Ввести текст цели и/или выбрать проблему из списка
4. Нажать Save — цель должна появиться в списке без перезагрузки страницы

https://claude.ai/code/session_01Hovr2oKpU64XmJN2QrJSqF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hovr2oKpU64XmJN2QrJSqF)_