### PR TITLE
feat(#27): InlineSessionCardAdder — + insight button per session row

### DIFF
--- a/src/components/dashboard/edit/InlineSessionCardAdder.tsx
+++ b/src/components/dashboard/edit/InlineSessionCardAdder.tsx
@@ -1,4 +1,78 @@
 "use client";
-export default function InlineSessionCardAdder({ sessionId: _sessionId }: { sessionId: string }) {
-  return null;
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createInsightCard, setTrainerCardStatus } from "@/lib/actions/insightCards";
+
+export default function InlineSessionCardAdder({ sessionId }: { sessionId: string }) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [front, setFront] = useState("");
+  const [context, setContext] = useState("");
+
+  function handleSave() {
+    if (!front.trim()) return;
+    startTransition(async () => {
+      const res = await createInsightCard(sessionId, {
+        frontText: front,
+        contextText: context || null,
+      });
+      if (!res.success) {
+        alert(res.error);
+        return;
+      }
+      await setTrainerCardStatus(res.id, "approved");
+      setFront("");
+      setContext("");
+      setOpen(false);
+      router.refresh();
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="flex-shrink-0 w-9 h-9 rounded-xl bg-surface-card text-primary text-lg font-black active:scale-95 transition-transform"
+        title="Add insight card"
+      >
+        +
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 bg-background/80 flex items-end sm:items-center justify-center p-4" onClick={() => setOpen(false)}>
+          <div className="bg-surface-card rounded-3xl p-6 w-full max-w-md space-y-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-black tracking-tight">New insight card</h3>
+            <textarea
+              value={front}
+              onChange={(e) => setFront(e.target.value)}
+              placeholder="One principle, one line"
+              rows={2}
+              autoFocus
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none border border-border-dim focus:border-primary focus:outline-none"
+            />
+            <textarea
+              value={context}
+              onChange={(e) => setContext(e.target.value)}
+              placeholder="When to use it (optional)"
+              rows={2}
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none border border-border-dim focus:border-primary focus:outline-none"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={handleSave}
+                disabled={isPending || !front.trim()}
+                className="flex-1 py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary disabled:opacity-40"
+              >
+                {isPending ? "Saving…" : "Add"}
+              </button>
+              <button onClick={() => setOpen(false)} className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface">
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #27

## What

- Implemented `InlineSessionCardAdder`: a `+` button on each session row in trainer mode that opens a compact modal for adding an insight card
- Form fields: `front` text (required) + `context` (optional)
- Calls `createInsightCard(sessionId, { frontText, contextText })` then immediately `setTrainerCardStatus(id, "approved")` — auto-approves since the trainer is the author
- On success: resets form, closes modal, calls `router.refresh()`

## Test plan

- [ ] Open a student's dashboard as trainer
- [ ] Click `+` on a session row → modal appears
- [ ] Enter a principle and optional context → click Add
- [ ] Card appears in `/sessions/<id>/insights` as approved

https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRRbDpoYMgnNVhFjMcbQS9)_