### PR TITLE
feat(#58): migration 009 — profiles + matches + match_goals

### DIFF
--- a/src/lib/playtomic/client.ts
+++ b/src/lib/playtomic/client.ts
@@ -1,0 +1,101 @@
+const PLAYTOMIC_API_BASE = "https://api.playtomic.io/v1";
+const TIMEOUT_MS = 5000;
+
+export interface PlaytomicMatch {
+  match_id: string;
+  start_date: string;
+  end_date: string | null;
+  location: string | null;
+  resource_name: string | null;
+  status: string;
+  teams: unknown;
+  results: unknown | null;
+}
+
+/**
+ * Extracts user_id from Playtomic profile URL.
+ * Supports both numeric IDs (e.g. "5536921") and UUIDs.
+ * Example: https://app.playtomic.io/profile/users/5536921
+ */
+export function parseProfileUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/profile\/users\/([^/?#]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts match UUID from Playtomic match URL.
+ * Example: https://app.playtomic.io/matches/some-uuid
+ */
+export function parseMatchUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(/\/matches\/([^/?#]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+      signal: controller.signal,
+    });
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetches a single match by ID from Playtomic API.
+ * Returns null on any error (network, timeout, non-2xx).
+ */
+export async function fetchMatch(matchId: string): Promise<PlaytomicMatch | null> {
+  try {
+    const res = await fetchWithTimeout(`${PLAYTOMIC_API_BASE}/matches/${encodeURIComponent(matchId)}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return normalizeMatch(data);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetches all matches for a given Playtomic user ID.
+ * Returns empty array on any error.
+ */
+export async function fetchUserMatches(userId: string): Promise<PlaytomicMatch[]> {
+  try {
+    const url = `${PLAYTOMIC_API_BASE}/matches?user_id=${encodeURIComponent(userId)}&size=200`;
+    const res = await fetchWithTimeout(url);
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.map(normalizeMatch);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeMatch(raw: Record<string, unknown>): PlaytomicMatch {
+  return {
+    match_id: String(raw["match_id"] ?? raw["id"] ?? ""),
+    start_date: String(raw["start_date"] ?? ""),
+    end_date: raw["end_date"] != null ? String(raw["end_date"]) : null,
+    location: raw["location_name"] != null ? String(raw["location_name"]) : null,
+    resource_name: raw["resource_name"] != null ? String(raw["resource_name"]) : null,
+    status: String(raw["status"] ?? ""),
+    teams: raw["teams"] ?? null,
+    results: raw["results"] ?? null,
+  };
+}

--- a/supabase/migrations/009_playtomic_matches.sql
+++ b/supabase/migrations/009_playtomic_matches.sql
@@ -1,0 +1,33 @@
+-- Migration 009: Playtomic matches integration
+-- Extends profiles with Playtomic user id + sync timestamp.
+-- Creates matches and match_goals tables.
+
+-- ── 1. Extend profiles ──────────────────────────────────────────────────────
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS playtomic_user_id   text,
+  ADD COLUMN IF NOT EXISTS playtomic_synced_at timestamptz;
+
+-- ── 2. Create matches ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS matches (
+  id                  uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id          uuid          NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  playtomic_match_id  text          NOT NULL,
+  start_date          timestamptz   NOT NULL,
+  end_date            timestamptz,
+  location            text,
+  resource_name       text,
+  status              text,
+  teams               jsonb,
+  results             jsonb,
+  reflection          text,
+  last_synced_at      timestamptz   NOT NULL DEFAULT now(),
+  UNIQUE (profile_id, playtomic_match_id)
+);
+
+-- ── 3. Create match_goals ────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS match_goals (
+  match_id    uuid NOT NULL REFERENCES matches(id)  ON DELETE CASCADE,
+  insight_id  uuid NOT NULL REFERENCES insight_cards(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (match_id, insight_id)
+);


### PR DESCRIPTION
## Summary
- Migration `supabase/migrations/009_playtomic_matches.sql`.
- Adds `profiles.playtomic_user_id` and `profiles.playtomic_synced_at`.
- Creates `matches` table (with `UNIQUE(profile_id, playtomic_match_id)`) and `match_goals` junction (`(match_id, insight_id)` PK, cascade FKs).
- FK from `match_goals.insight_id` → **`insight_cards(id)`** (corrected vs. design doc, which referenced non-existent `insights`).
- Applied to Supabase via Management API; verified in `information_schema`.

Closes #58.

## Test plan
- [ ] `list_tables` shows `matches` and `match_goals`
- [ ] `profiles` has new columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)