### PR TITLE
feat(#59): connect Playtomic profile from dashboard

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -9,6 +9,7 @@ import InlineSessionCreator from "@/components/dashboard/edit/InlineSessionCreat
 import InlineProfileHeader from "@/components/dashboard/edit/InlineProfileHeader";
 import InlineSessionCardAdder from "@/components/dashboard/edit/InlineSessionCardAdder";
 import MasterPlanEditor from "@/components/masterPlan/MasterPlanEditor";
+import PlaytomicConnectBlock from "@/components/playtomic/PlaytomicConnectBlock";
 
 export interface DashboardViewEditable {
   studentId: string;
@@ -52,6 +53,11 @@ export default function DashboardView({ data, locale, editable }: Props) {
             {firstName} <span className="kinetic-text">👋</span>
           </h1>
         </div>
+      )}
+
+      {/* Playtomic connect block — student only */}
+      {!isTrainer && (
+        <PlaytomicConnectBlock currentUserId={profile.playtomic_user_id ?? null} />
       )}
 
       {/* Empty state — student only */}

--- a/src/components/playtomic/PlaytomicConnectBlock.tsx
+++ b/src/components/playtomic/PlaytomicConnectBlock.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { connectPlaytomicProfile } from "@/lib/actions/playtomic";
+
+interface Props {
+  currentUserId: string | null;
+}
+
+/**
+ * Shows a "Connect Playtomic" form when the user has no playtomic_user_id,
+ * and a "Connected" badge with masked id when they do.
+ *
+ * Note: `currentUserId` is the playtomic_user_id (string | null),
+ * NOT the Nivel profile id.
+ */
+export default function PlaytomicConnectBlock({ currentUserId }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  // Already connected — show masked id
+  if (currentUserId) {
+    const masked =
+      currentUserId.length > 6
+        ? currentUserId.slice(0, 3) + "•••" + currentUserId.slice(-3)
+        : currentUserId;
+
+    return (
+      <div className="bg-surface-card rounded-2xl p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-primary mb-0.5">
+              Playtomic подключён
+            </p>
+            <p className="text-sm text-on-surface-variant font-mono">{masked}</p>
+          </div>
+          <span className="material-symbols-outlined text-primary text-2xl">check_circle</span>
+        </div>
+      </div>
+    );
+  }
+
+  function handleConnect() {
+    setError(null);
+    startTransition(async () => {
+      const result = await connectPlaytomicProfile(url);
+      if (!result.success) {
+        setError(result.error);
+      }
+      // On success, server action redirects to /matches — no extra client code needed
+    });
+  }
+
+  return (
+    <div className="bg-surface-card rounded-2xl p-4 space-y-3">
+      <div>
+        <p className="text-[10px] font-black uppercase tracking-[0.2em] text-on-surface-variant mb-1">
+          Подключи Playtomic
+        </p>
+        <p className="text-xs text-on-surface-variant">
+          Вставь ссылку на свой профиль, чтобы видеть предстоящие матчи.
+        </p>
+      </div>
+
+      <input
+        type="url"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="https://app.playtomic.io/profile/users/…"
+        className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+        disabled={isPending}
+      />
+
+      {error && (
+        <p className="text-xs text-red-400">{error}</p>
+      )}
+
+      <button
+        onClick={handleConnect}
+        disabled={isPending || !url.trim()}
+        className="w-full py-2.5 rounded-xl font-black text-sm kinetic-gradient text-on-primary disabled:opacity-40"
+      >
+        {isPending ? "Подключение…" : "Подключить"}
+      </button>
+    </div>
+  );
+}

--- a/src/lib/actions/playtomic.ts
+++ b/src/lib/actions/playtomic.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import { parseProfileUrl } from "@/lib/playtomic/client";
+import { syncUserMatches } from "@/lib/playtomic/sync";
+
+export type ConnectPlaytomicResult =
+  | { success: true }
+  | { success: false; error: string };
+
+/**
+ * Validates the given Playtomic profile URL, writes playtomic_user_id to the
+ * current user's profile, triggers a forced match sync, then redirects to /matches.
+ */
+export async function connectPlaytomicProfile(
+  url: string
+): Promise<ConnectPlaytomicResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  const trimmed = url.trim();
+  const userId = parseProfileUrl(trimmed);
+  if (!userId) {
+    return {
+      success: false,
+      error:
+        "Не удалось распознать ссылку. Ожидается: https://app.playtomic.io/profile/users/…",
+    };
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("profiles")
+    .update({ playtomic_user_id: userId })
+    .eq("id", session.id);
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  // Force sync — fire-and-forget errors; user can retry on /matches
+  try {
+    await syncUserMatches(session.id, { force: true });
+  } catch {
+    // non-fatal — profile is saved, matches will sync on next visit
+  }
+
+  redirect("/matches");
+}

--- a/src/lib/dashboard/data.ts
+++ b/src/lib/dashboard/data.ts
@@ -44,6 +44,7 @@ export interface DashboardProfile {
   email: string | null;
   full_name: string | null;
   avatar_url: string | null;
+  playtomic_user_id: string | null;
 }
 
 export interface DashboardData {
@@ -65,7 +66,7 @@ export async function loadDashboardData(
 
   const { data: profileRow } = await supabase
     .from("profiles")
-    .select("id, email, full_name, avatar_url")
+    .select("id, email, full_name, avatar_url, playtomic_user_id")
     .eq("id", userId)
     .single();
   if (!profileRow) return null;
@@ -203,6 +204,7 @@ export async function loadDashboardData(
       email: (profileRow.email as string) ?? null,
       full_name: (profileRow.full_name as string) ?? null,
       avatar_url: (profileRow.avatar_url as string) ?? null,
+      playtomic_user_id: (profileRow.playtomic_user_id as string) ?? null,
     },
     goals,
     skillProgress,


### PR DESCRIPTION
Closes #59

## Что сделано
- Новый server action `connectPlaytomicProfile(url)` в `src/lib/actions/playtomic.ts`:
  - Валидирует URL через `parseProfileUrl` (из существующего `client.ts`)
  - Пишет `playtomic_user_id` в `profiles`
  - Вызывает `syncUserMatches(force=true)`
  - Делает `redirect('/matches')`
- Новый клиентский компонент `PlaytomicConnectBlock` (`src/components/playtomic/PlaytomicConnectBlock.tsx`):
  - Если `playtomic_user_id` не задан — показывает форму с полем URL и кнопкой «Подключить»
  - Если подключён — показывает бейдж «Playtomic подключён» с маскированным ID
- `DashboardProfile` расширен полем `playtomic_user_id`
- `loadDashboardData` теперь запрашивает `playtomic_user_id` из `profiles`
- Блок добавлен в `DashboardView` только для студентов (не для тренера)

## Файлы
- `src/lib/actions/playtomic.ts` — новый server action
- `src/components/playtomic/PlaytomicConnectBlock.tsx` — новый UI компонент
- `src/lib/dashboard/data.ts` — добавлено поле в интерфейс и SELECT
- `src/components/dashboard/DashboardView.tsx` — добавлен блок для студента

## Проверка
- `npx tsc --noEmit` — прошло без ошибок
- Колонки `playtomic_user_id` и `playtomic_synced_at` подтверждены в БД через `information_schema`
- Acceptance: ученик вставляет ссылку вида `https://app.playtomic.io/profile/users/5536921` → action парсит id `5536921` → пишет в profiles → синхронизирует матчи → редиректит на `/matches`