### PR TITLE
feat(#63): страница /matches со списком и вкладками

### DIFF
--- a/src/app/matches/layout.tsx
+++ b/src/app/matches/layout.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import { getLocale } from "@/lib/i18n";
+import type { Profile } from "@/lib/types";
+import BottomNav from "@/components/navigation/BottomNav";
+
+export default async function MatchesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getSession();
+  if (!user) redirect("/login");
+  const locale = await getLocale();
+  const profile = { role: user.role };
+
+  return (
+    <div className="relative mx-auto min-h-screen max-w-[430px] bg-background">
+      {children}
+      <BottomNav role={(profile as Pick<Profile, "role">).role} locale={locale} />
+    </div>
+  );
+}

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -1,0 +1,165 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import { syncUserMatches } from "@/lib/playtomic/sync";
+import { getLocale } from "@/lib/i18n";
+import { t } from "@/lib/i18n/dict";
+import MatchCard, { type MatchRow } from "@/components/matches/MatchCard";
+import MatchesTabs from "@/components/matches/MatchesTabs";
+import RefreshMatchesButton from "@/components/matches/RefreshMatchesButton";
+import AddMatchByUrlModal from "@/components/matches/AddMatchByUrlModal";
+import { Suspense } from "react";
+
+const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
+
+interface PageProps {
+  searchParams: Promise<{ tab?: string }>;
+}
+
+export default async function MatchesPage({ searchParams }: PageProps) {
+  const user = await getSession();
+  if (!user) redirect("/login");
+
+  const locale = await getLocale();
+  const { tab } = await searchParams;
+  const activeTab: "upcoming" | "past" = tab === "past" ? "past" : "upcoming";
+
+  // Lazy sync (10-min cooldown)
+  await syncUserMatches(user.id);
+
+  const supabase = await createClient();
+
+  // Check if Playtomic is connected
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("playtomic_user_id")
+    .eq("id", user.id)
+    .single();
+
+  const playtomicConnected = !!(profile as { playtomic_user_id: string | null } | null)
+    ?.playtomic_user_id;
+
+  // Fetch matches with goal counts
+  let upcomingMatches: MatchRow[] = [];
+  let pastMatches: MatchRow[] = [];
+
+  if (playtomicConnected) {
+    const { data: allMatches } = await supabase
+      .from("matches")
+      .select(
+        `
+        id,
+        start_date,
+        end_date,
+        location,
+        resource_name,
+        status,
+        teams,
+        match_goals(count)
+      `
+      )
+      .eq("profile_id", user.id)
+      .order("start_date", { ascending: activeTab === "upcoming" });
+
+    const rows = (allMatches ?? []) as Array<{
+      id: string;
+      start_date: string;
+      end_date: string | null;
+      location: string | null;
+      resource_name: string | null;
+      status: string | null;
+      teams: unknown;
+      match_goals: Array<{ count: number }>;
+    }>;
+
+    const mapped: MatchRow[] = rows.map((r) => ({
+      id: r.id,
+      start_date: r.start_date,
+      end_date: r.end_date,
+      location: r.location,
+      resource_name: r.resource_name,
+      status: r.status,
+      teams: r.teams,
+      goalsCount: r.match_goals?.[0]?.count ?? 0,
+    }));
+
+    upcomingMatches = mapped.filter((m) =>
+      UPCOMING_STATUSES.includes(m.status ?? "")
+    );
+    pastMatches = mapped.filter(
+      (m) => !UPCOMING_STATUSES.includes(m.status ?? "")
+    );
+  }
+
+  const displayedMatches = activeTab === "upcoming" ? upcomingMatches : pastMatches;
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-30 glass-nav h-16 flex items-center justify-between px-6">
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
+          {t(locale, "matches.title")}
+        </span>
+        {playtomicConnected && (
+          <div className="flex items-center gap-2">
+            <RefreshMatchesButton locale={locale} />
+            <AddMatchByUrlModal locale={locale} />
+          </div>
+        )}
+      </header>
+
+      <main className="px-4 pt-4 pb-36 max-w-[430px] mx-auto space-y-4">
+        {!playtomicConnected ? (
+          /* Empty state: Playtomic not connected */
+          <div className="mt-12 flex flex-col items-center gap-4 text-center px-4">
+            <span className="material-symbols-outlined text-5xl text-on-surface-variant">
+              sports_tennis
+            </span>
+            <p className="text-sm text-on-surface-variant">
+              {t(locale, "matches.noPlaytomic")}
+            </p>
+            <Link
+              href="/dashboard"
+              className="px-5 py-2.5 rounded-xl kinetic-gradient text-on-primary text-xs font-black uppercase tracking-widest"
+            >
+              {t(locale, "matches.goToSettings")}
+            </Link>
+          </div>
+        ) : (
+          <>
+            {/* Tabs */}
+            <Suspense>
+              <MatchesTabs activeTab={activeTab} locale={locale} />
+            </Suspense>
+
+            {/* Match list */}
+            {displayedMatches.length === 0 ? (
+              <div className="mt-8 flex flex-col items-center gap-3 text-center">
+                <span className="material-symbols-outlined text-4xl text-on-surface-variant">
+                  event_busy
+                </span>
+                <p className="text-sm text-on-surface-variant">
+                  {activeTab === "upcoming"
+                    ? t(locale, "matches.emptyUpcoming")
+                    : t(locale, "matches.emptyPast")}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {displayedMatches.map((match) => (
+                  <MatchCard
+                    key={match.id}
+                    match={match}
+                    isUpcoming={activeTab === "upcoming"}
+                    locale={locale}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/matches/AddMatchByUrlModal.tsx
+++ b/src/components/matches/AddMatchByUrlModal.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { addMatchByUrlAction } from "@/lib/actions/playtomic";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface Props {
+  locale: Locale;
+}
+
+export default function AddMatchByUrlModal({ locale }: Props) {
+  const [open, setOpen] = useState(false);
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleOpen() {
+    setUrl("");
+    setError(null);
+    setOpen(true);
+  }
+
+  function handleClose() {
+    if (isPending) return;
+    setOpen(false);
+  }
+
+  function handleSubmit() {
+    setError(null);
+    startTransition(async () => {
+      const result = await addMatchByUrlAction(url);
+      if (!result.success) {
+        setError(result.error);
+      } else {
+        setOpen(false);
+        setUrl("");
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-primary/10 text-xs font-black uppercase tracking-widest text-primary hover:bg-primary/20 transition-colors"
+      >
+        <span className="material-symbols-outlined text-[18px]">add_link</span>
+        {t(locale, "matches.addByUrl")}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm px-4 pb-8"
+          onClick={handleClose}
+        >
+          <div
+            className="w-full max-w-[430px] bg-surface-card rounded-3xl p-6 space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-sm font-black uppercase tracking-widest text-on-surface">
+              {t(locale, "matches.addByUrl")}
+            </p>
+
+            <input
+              type="url"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder={t(locale, "matches.addByUrlPlaceholder")}
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+              disabled={isPending}
+              autoFocus
+            />
+
+            {error && <p className="text-xs text-error">{error}</p>}
+
+            <div className="flex gap-3">
+              <button
+                onClick={handleClose}
+                disabled={isPending}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest text-on-surface-variant bg-surface-elevated hover:bg-border-dim disabled:opacity-40 transition-colors"
+              >
+                {t(locale, "common.cancel")}
+              </button>
+              <button
+                onClick={handleSubmit}
+                disabled={isPending || !url.trim()}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest kinetic-gradient text-on-primary disabled:opacity-40"
+              >
+                {isPending
+                  ? t(locale, "matches.addByUrlAdding")
+                  : t(locale, "matches.addByUrlSubmit")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface Player {
+  name?: string;
+  level?: number;
+  [key: string]: unknown;
+}
+
+interface Team {
+  players?: Player[];
+  [key: string]: unknown;
+}
+
+export interface MatchRow {
+  id: string;
+  start_date: string;
+  end_date: string | null;
+  location: string | null;
+  resource_name: string | null;
+  status: string | null;
+  teams: unknown;
+  goalsCount?: number;
+}
+
+interface Props {
+  match: MatchRow;
+  isUpcoming: boolean;
+  locale: Locale;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function extractPlayers(teams: unknown): Player[] {
+  if (!Array.isArray(teams)) return [];
+  const players: Player[] = [];
+  for (const team of teams as Team[]) {
+    if (Array.isArray(team.players)) {
+      for (const p of team.players as Player[]) {
+        players.push(p);
+      }
+    }
+  }
+  return players.slice(0, 4);
+}
+
+export default function MatchCard({ match, isUpcoming, locale }: Props) {
+  const players = extractPlayers(match.teams);
+
+  return (
+    <Link
+      href={`/matches/${match.id}`}
+      className="block bg-surface-card rounded-2xl p-4 space-y-3 hover:bg-surface-elevated transition-colors"
+    >
+      {/* Date + location */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-0.5">
+          <p className="text-sm font-bold text-on-surface">
+            {formatDate(match.start_date)}
+          </p>
+          {match.location && (
+            <p className="text-xs text-on-surface-variant">{match.location}</p>
+          )}
+          {match.resource_name && (
+            <p className="text-xs text-on-surface-variant">{match.resource_name}</p>
+          )}
+        </div>
+        <span
+          className={`text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg shrink-0 ${
+            isUpcoming
+              ? "bg-primary/15 text-primary"
+              : "bg-surface-elevated text-on-surface-variant"
+          }`}
+        >
+          {match.status ?? "—"}
+        </span>
+      </div>
+
+      {/* Players */}
+      {players.length > 0 && (
+        <div className="grid grid-cols-2 gap-1.5">
+          {players.map((p, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-1.5 bg-surface-elevated rounded-xl px-2.5 py-1.5"
+            >
+              <span className="material-symbols-outlined text-[16px] text-on-surface-variant">
+                person
+              </span>
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-on-surface truncate">
+                  {p.name ?? "—"}
+                </p>
+                {p.level != null && (
+                  <p className="text-[10px] text-on-surface-variant">
+                    {Number(p.level).toFixed(1)}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Goals CTA (upcoming only) */}
+      {isUpcoming && (
+        <div className="flex items-center gap-2">
+          <span className="material-symbols-outlined text-[16px] text-primary">
+            flag
+          </span>
+          {(match.goalsCount ?? 0) > 0 ? (
+            <span className="text-xs text-primary font-bold">
+              {match.goalsCount} {t(locale, "matches.goalsCount")}
+            </span>
+          ) : (
+            <span className="text-xs text-on-surface-variant">
+              {t(locale, "matches.setGoals")}
+            </span>
+          )}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/src/components/matches/MatchesTabs.tsx
+++ b/src/components/matches/MatchesTabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface Props {
+  activeTab: "upcoming" | "past";
+  locale: Locale;
+}
+
+export default function MatchesTabs({ activeTab, locale }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  function switchTab(tab: "upcoming" | "past") {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", tab);
+    startTransition(() => {
+      router.replace(`${pathname}?${params.toString()}`);
+    });
+  }
+
+  return (
+    <div className="flex rounded-2xl bg-surface-elevated p-1 gap-1">
+      {(["upcoming", "past"] as const).map((tab) => {
+        const isActive = activeTab === tab;
+        const label =
+          tab === "upcoming"
+            ? t(locale, "matches.tabUpcoming")
+            : t(locale, "matches.tabPast");
+        return (
+          <button
+            key={tab}
+            onClick={() => switchTab(tab)}
+            className={`flex-1 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-colors ${
+              isActive
+                ? "bg-primary text-on-primary"
+                : "text-on-surface-variant hover:text-on-surface"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/matches/RefreshMatchesButton.tsx
+++ b/src/components/matches/RefreshMatchesButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTransition } from "react";
+import { refreshMatches } from "@/lib/actions/playtomic";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface Props {
+  locale: Locale;
+}
+
+export default function RefreshMatchesButton({ locale }: Props) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleRefresh() {
+    startTransition(async () => {
+      await refreshMatches();
+    });
+  }
+
+  return (
+    <button
+      onClick={handleRefresh}
+      disabled={isPending}
+      className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-xs font-black uppercase tracking-widest text-on-surface-variant hover:text-on-surface disabled:opacity-40 transition-colors"
+    >
+      <span
+        className={`material-symbols-outlined text-[18px] ${isPending ? "animate-spin" : ""}`}
+      >
+        refresh
+      </span>
+      {isPending ? t(locale, "matches.refreshing") : t(locale, "matches.refresh")}
+    </button>
+  );
+}

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -33,6 +33,13 @@ const tabs: Tab[] = [
     match: (p) => p.startsWith("/insights"),
     roles: ["student", "trainer"],
   },
+  {
+    labelKey: "nav.matches",
+    icon: "sports_tennis",
+    href: "/matches",
+    match: (p) => p.startsWith("/matches"),
+    roles: ["student"],
+  },
 ];
 
 export default function BottomNav({ role, locale }: BottomNavProps) {

--- a/src/lib/actions/playtomic.ts
+++ b/src/lib/actions/playtomic.ts
@@ -1,10 +1,11 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
 import { parseProfileUrl } from "@/lib/playtomic/client";
-import { syncUserMatches } from "@/lib/playtomic/sync";
+import { syncUserMatches, addMatchByUrl } from "@/lib/playtomic/sync";
 
 export type ConnectPlaytomicResult =
   | { success: true }
@@ -48,4 +49,48 @@ export async function connectPlaytomicProfile(
   }
 
   redirect("/matches");
+}
+
+export type RefreshMatchesResult = { success: true } | { success: false; error: string };
+
+/**
+ * Forces a Playtomic sync for the current user and revalidates /matches.
+ */
+export async function refreshMatches(): Promise<RefreshMatchesResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  try {
+    await syncUserMatches(session.id, { force: true });
+  } catch (e) {
+    return { success: false, error: String(e) };
+  }
+
+  revalidatePath("/matches");
+  return { success: true };
+}
+
+export type AddMatchByUrlResult = { success: true } | { success: false; error: string };
+
+/**
+ * Adds a single match by its Playtomic URL and revalidates /matches.
+ */
+export async function addMatchByUrlAction(url: string): Promise<AddMatchByUrlResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  const trimmed = url.trim();
+  if (!trimmed) return { success: false, error: "URL не может быть пустым" };
+
+  try {
+    await addMatchByUrl(session.id, trimmed);
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  revalidatePath("/matches");
+  return { success: true };
 }

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -32,6 +32,7 @@ const ru = {
   // Nav
   "nav.home": "Главная",
   "nav.insights": "Карточки",
+  "nav.matches": "Матчи",
   "nav.logout": "Выйти",
 
   // Dashboard
@@ -105,6 +106,23 @@ const ru = {
   "masterPlan.sectionTitle": "Название раздела",
   "masterPlan.itemText": "Текст пункта",
 
+  // Matches
+  "matches.title": "Матчи",
+  "matches.tabUpcoming": "Предстоящие",
+  "matches.tabPast": "Прошедшие",
+  "matches.refresh": "Обновить",
+  "matches.addByUrl": "Добавить по ссылке",
+  "matches.addByUrlPlaceholder": "https://app.playtomic.io/matches/…",
+  "matches.addByUrlSubmit": "Добавить",
+  "matches.addByUrlAdding": "Добавление…",
+  "matches.emptyUpcoming": "Нет предстоящих матчей",
+  "matches.emptyPast": "Нет прошедших матчей",
+  "matches.noPlaytomic": "Подключи Playtomic, чтобы видеть матчи.",
+  "matches.goToSettings": "Настройки профиля",
+  "matches.goalsCount": "целей",
+  "matches.setGoals": "Поставь цели",
+  "matches.refreshing": "Обновление…",
+
   // Language switcher
   "lang.label": "Язык",
   "lang.ru": "Русский",
@@ -139,6 +157,7 @@ const en: Record<keyof typeof ru, string> = {
 
   "nav.home": "Home",
   "nav.insights": "Insights",
+  "nav.matches": "Matches",
   "nav.logout": "Sign out",
 
   "dashboard.welcome": "Welcome,",
@@ -209,6 +228,23 @@ const en: Record<keyof typeof ru, string> = {
   "lang.label": "Language",
   "lang.ru": "Русский",
   "lang.en": "English",
+
+  // Matches
+  "matches.title": "Matches",
+  "matches.tabUpcoming": "Upcoming",
+  "matches.tabPast": "Past",
+  "matches.refresh": "Refresh",
+  "matches.addByUrl": "Add by link",
+  "matches.addByUrlPlaceholder": "https://app.playtomic.io/matches/…",
+  "matches.addByUrlSubmit": "Add",
+  "matches.addByUrlAdding": "Adding…",
+  "matches.emptyUpcoming": "No upcoming matches",
+  "matches.emptyPast": "No past matches",
+  "matches.noPlaytomic": "Connect Playtomic to see your matches.",
+  "matches.goToSettings": "Profile settings",
+  "matches.goalsCount": "goals",
+  "matches.setGoals": "Set goals",
+  "matches.refreshing": "Refreshing…",
 };
 
 export type DictKey = keyof typeof ru;


### PR DESCRIPTION
Closes #63

## Что сделано
- `src/app/matches/layout.tsx` — layout с BottomNav (аналог insights layout)
- `src/app/matches/page.tsx` — Server Component: ленивый `syncUserMatches`, запрос матчей с подсчётом целей, передача в компоненты
- `src/components/matches/MatchesTabs.tsx` — client-компонент переключения вкладок через URL `?tab=upcoming|past`
- `src/components/matches/MatchCard.tsx` — карточка матча: дата, клуб, корт, 4 игрока с уровнями; для предстоящих — счётчик целей или CTA
- `src/components/matches/RefreshMatchesButton.tsx` — кнопка «Обновить» (force sync + revalidatePath)
- `src/components/matches/AddMatchByUrlModal.tsx` — модалка «Добавить по ссылке» (вызывает `addMatchByUrlAction`)
- `src/lib/actions/playtomic.ts` — добавлены `refreshMatches` и `addMatchByUrlAction` server actions
- `src/lib/i18n/dict.ts` — добавлены ключи `matches.*` и `nav.matches` (ru + en)
- `src/components/navigation/BottomNav.tsx` — добавлена вкладка «Матчи» для роли student

## Файлы
- `src/app/matches/layout.tsx` (новый)
- `src/app/matches/page.tsx` (новый)
- `src/components/matches/MatchesTabs.tsx` (новый)
- `src/components/matches/MatchCard.tsx` (новый)
- `src/components/matches/RefreshMatchesButton.tsx` (новый)
- `src/components/matches/AddMatchByUrlModal.tsx` (новый)
- `src/lib/actions/playtomic.ts` (расширен)
- `src/lib/i18n/dict.ts` (расширен)
- `src/components/navigation/BottomNav.tsx` (расширен)

## Проверка
- `npx next build` — успешно, маршрут `/matches` виден в output
- `npx tsc --noEmit` — 0 ошибок
- Empty state при отсутствии `playtomic_user_id` показывает ссылку на настройки профиля
- Кнопка «Обновить» вызывает `syncUserMatches(force=true)` и `revalidatePath('/matches')`
- Добавление по ссылке проходит через `addMatchByUrl` с валидацией URL