### PR TITLE
feat(#65): карточка матча /matches/[id] + прикрепление инсайтов

### DIFF
--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -1,0 +1,279 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import { getLocale } from "@/lib/i18n";
+import { t } from "@/lib/i18n/dict";
+import AttachInsightModal from "@/components/matches/AttachInsightModal";
+import { getVaultCards } from "@/lib/actions/insightCards";
+
+const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
+
+interface Player {
+  name?: string;
+  level?: number;
+  playtomic_user_id?: string;
+  [key: string]: unknown;
+}
+
+interface Team {
+  players?: Player[];
+  [key: string]: unknown;
+}
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("ru-RU", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function extractTeams(raw: unknown): Team[] {
+  if (!Array.isArray(raw)) return [];
+  return raw as Team[];
+}
+
+export default async function MatchDetailPage({ params }: PageProps) {
+  const user = await getSession();
+  if (!user) redirect("/login");
+
+  const { id } = await params;
+  const locale = await getLocale();
+  const supabase = await createClient();
+
+  // Fetch match with attached insight ids
+  const { data: matchRaw, error } = await supabase
+    .from("matches")
+    .select(
+      `
+      id,
+      start_date,
+      end_date,
+      location,
+      resource_name,
+      status,
+      teams,
+      results,
+      match_goals(insight_id)
+    `
+    )
+    .eq("id", id)
+    .eq("profile_id", user.id)
+    .single();
+
+  if (error || !matchRaw) notFound();
+
+  const match = matchRaw as {
+    id: string;
+    start_date: string;
+    end_date: string | null;
+    location: string | null;
+    resource_name: string | null;
+    status: string | null;
+    teams: unknown;
+    results: unknown;
+    match_goals: Array<{ insight_id: string }>;
+  };
+
+  const attachedIds = match.match_goals.map((g) => g.insight_id);
+  const isUpcoming = UPCOMING_STATUSES.includes(match.status ?? "");
+
+  // Fetch profile for playtomic_user_id to highlight "me"
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("playtomic_user_id")
+    .eq("id", user.id)
+    .single();
+
+  const myPlaytomicId = (
+    profile as { playtomic_user_id: string | null } | null
+  )?.playtomic_user_id;
+
+  const teams = extractTeams(match.teams);
+
+  // Fetch insight vault (taken cards only) for the attach modal
+  const vaultCards = await getVaultCards();
+  const insightOptions = vaultCards.map((c) => ({
+    id: c.id,
+    front_text: c.front_text,
+    problem: c.problem,
+  }));
+
+  // Fetch full insight data for attached ones to display in the list
+  let attachedInsights: Array<{
+    id: string;
+    front_text: string;
+    problem: { name: string } | null;
+  }> = [];
+
+  if (attachedIds.length > 0) {
+    const { data: insightRows } = await supabase
+      .from("insight_cards")
+      .select("id, front_text, problem:problems(id, name)")
+      .in("id", attachedIds);
+
+    attachedInsights = (insightRows ?? []).map((r) => {
+      const prob = r.problem as unknown;
+      const problemObj =
+        prob != null && !Array.isArray(prob) && typeof prob === "object"
+          ? (prob as { name: string })
+          : null;
+      return {
+        id: r.id,
+        front_text: r.front_text,
+        problem: problemObj,
+      };
+    });
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-30 glass-nav h-16 flex items-center gap-3 px-4">
+        <Link
+          href="/matches"
+          className="flex items-center justify-center w-9 h-9 rounded-xl bg-surface-elevated hover:bg-border-dim transition-colors"
+        >
+          <span className="material-symbols-outlined text-[20px] text-on-surface-variant">
+            arrow_back
+          </span>
+        </Link>
+        <span className="text-base font-black text-primary uppercase italic tracking-tight">
+          {match.location ?? t(locale, "matches.title")}
+        </span>
+        <span
+          className={`ml-auto text-[10px] font-black uppercase tracking-widest px-2 py-1 rounded-lg ${
+            isUpcoming
+              ? "bg-primary/15 text-primary"
+              : "bg-surface-elevated text-on-surface-variant"
+          }`}
+        >
+          {match.status ?? "—"}
+        </span>
+      </header>
+
+      <main className="px-4 pt-4 pb-36 space-y-5">
+        {/* Date & Court */}
+        <section className="bg-surface-card rounded-2xl p-4 space-y-1">
+          <p className="text-sm font-bold text-on-surface capitalize">
+            {formatDate(match.start_date)}
+          </p>
+          {match.location && (
+            <p className="text-xs text-on-surface-variant">{match.location}</p>
+          )}
+          {match.resource_name && (
+            <p className="text-xs text-on-surface-variant">
+              {t(locale, "matches.detail.court")}: {match.resource_name}
+            </p>
+          )}
+        </section>
+
+        {/* Teams */}
+        {teams.length > 0 && (
+          <section className="space-y-2">
+            {teams.map((team, teamIdx) => (
+              <div key={teamIdx} className="bg-surface-card rounded-2xl p-4 space-y-2">
+                {(team.players ?? []).map((player, playerIdx) => {
+                  const isMe =
+                    myPlaytomicId != null &&
+                    player.playtomic_user_id === myPlaytomicId;
+                  return (
+                    <div
+                      key={playerIdx}
+                      className={`flex items-center gap-2 rounded-xl px-3 py-2 ${
+                        isMe
+                          ? "bg-primary/15 border border-primary/40"
+                          : "bg-surface-elevated"
+                      }`}
+                    >
+                      <span
+                        className={`material-symbols-outlined text-[18px] ${
+                          isMe ? "text-primary" : "text-on-surface-variant"
+                        }`}
+                      >
+                        {isMe ? "person_check" : "person"}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className={`text-sm font-semibold truncate ${
+                            isMe ? "text-primary" : "text-on-surface"
+                          }`}
+                        >
+                          {player.name ?? "—"}
+                        </p>
+                        {player.level != null && (
+                          <p className="text-[10px] text-on-surface-variant">
+                            {Number(player.level).toFixed(1)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* Goals block — only for upcoming matches */}
+        {isUpcoming && (
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-black uppercase tracking-widest text-on-surface">
+                {t(locale, "matches.detail.goals")}
+              </p>
+              <AttachInsightModal
+                matchId={match.id}
+                locale={locale}
+                allInsights={insightOptions}
+                attachedIds={attachedIds}
+              />
+            </div>
+
+            {attachedInsights.length === 0 ? (
+              <div className="flex flex-col items-center gap-3 py-6 text-center bg-surface-card rounded-2xl">
+                <span className="material-symbols-outlined text-3xl text-on-surface-variant">
+                  flag
+                </span>
+                <p className="text-sm text-on-surface-variant">
+                  {t(locale, "matches.detail.noGoals")}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {attachedInsights.map((insight) => (
+                  <div
+                    key={insight.id}
+                    className="bg-surface-card rounded-2xl p-4 flex items-start gap-3"
+                  >
+                    <span className="material-symbols-outlined text-[20px] text-primary mt-0.5 shrink-0">
+                      flag
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-on-surface leading-snug">
+                        {insight.front_text}
+                      </p>
+                      {insight.problem?.name && (
+                        <p className="text-xs text-on-surface-variant mt-0.5">
+                          {insight.problem.name}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -122,9 +122,10 @@ export default async function MatchDetailPage({ params }: PageProps) {
 
     attachedInsights = (insightRows ?? []).map((r) => {
       const prob = r.problem as unknown;
+      const probNormalized = Array.isArray(prob) ? prob[0] : prob;
       const problemObj =
-        prob != null && !Array.isArray(prob) && typeof prob === "object"
-          ? (prob as { name: string })
+        probNormalized != null && typeof probNormalized === "object"
+          ? (probNormalized as { name: string })
           : null;
       return {
         id: r.id,

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 export default function DashboardView({ data, locale, editable }: Props) {
   const dateLocale = locale === "ru" ? "ru-RU" : "en-US";
-  const { profile, goals, skillProgress, sessions, nextSession, masterPlan, totalPendingCards, firstPendingSessionId } = data;
+  const { profile, goals, skillProgress, sessions, nextSession, masterPlan, totalPendingCards, firstPendingSessionId, upcomingMatches } = data;
   const isTrainer = !!editable;
 
   const displayName = profile.full_name || profile.email || "Unnamed";
@@ -101,6 +101,137 @@ export default function DashboardView({ data, locale, editable }: Props) {
               </div>
             </Link>
           )}
+
+          {/* Актуальное — student only */}
+          {!isTrainer && (() => {
+            // Build unified timeline: upcoming sessions + upcoming matches, sorted by date asc
+            type TimelineItem =
+              | { kind: "session"; id: string; session_number: number; scheduled_at: string | null; date: number }
+              | { kind: "match"; id: string; start_date: string; location: string | null; resource_name: string | null; goalsCount: number; date: number };
+
+            const now = Date.now();
+
+            const sessionItems: TimelineItem[] = sessions
+              .filter((s) => s.status === "planned")
+              .map((s) => ({
+                kind: "session" as const,
+                id: s.id,
+                session_number: s.session_number,
+                scheduled_at: null,
+                date: new Date(s.created_at).getTime(),
+              }));
+
+            // Also include nextSession if it has a scheduled_at
+            const nextSessionItems: TimelineItem[] = nextSession?.scheduled_at
+              ? [{
+                  kind: "session" as const,
+                  id: nextSession.id,
+                  session_number: nextSession.session_number,
+                  scheduled_at: nextSession.scheduled_at,
+                  date: new Date(nextSession.scheduled_at).getTime(),
+                }]
+              : [];
+
+            const matchItems: TimelineItem[] = (upcomingMatches ?? []).map((m) => ({
+              kind: "match" as const,
+              id: m.id,
+              start_date: m.start_date,
+              location: m.location,
+              resource_name: m.resource_name,
+              goalsCount: m.goalsCount,
+              date: new Date(m.start_date).getTime(),
+            }));
+
+            // Merge: nextSession (has scheduled_at) + session items without duplicating nextSession + matches
+            const sessionSet = new Set(sessionItems.map((s) => s.id));
+            const uniqueNextSession = nextSessionItems.filter((ns) => !sessionSet.has(ns.id));
+
+            const allItems = [...sessionItems, ...uniqueNextSession, ...matchItems]
+              .filter((item) => item.date >= now - 60 * 60 * 1000) // at most 1hr past
+              .sort((a, b) => a.date - b.date)
+              .slice(0, 5);
+
+            return (
+              <section>
+                <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant mb-3 px-1">
+                  {t(locale, "dashboard.upcoming")}
+                </h3>
+                {allItems.length === 0 ? (
+                  <p className="text-on-surface-variant text-sm bg-surface-card rounded-2xl p-4">
+                    {t(locale, "dashboard.upcomingEmpty")}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {allItems.map((item) => {
+                      if (item.kind === "session") {
+                        const dateStr = item.scheduled_at
+                          ? new Date(item.scheduled_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit" })
+                          : null;
+                        return (
+                          <Link
+                            key={`session-${item.id}`}
+                            href={`/sessions/${item.id}`}
+                            className="flex items-center gap-4 bg-surface-low rounded-2xl px-4 py-3.5 active:bg-surface-card transition-colors"
+                          >
+                            <div className="w-10 h-10 rounded-xl bg-surface-card text-primary flex items-center justify-center font-black text-sm flex-shrink-0">
+                              {item.session_number}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <p className="font-semibold text-sm">
+                                {t(locale, "dashboard.session")} {item.session_number}
+                              </p>
+                              {dateStr && (
+                                <p className="text-[11px] text-on-surface-variant">{dateStr}</p>
+                              )}
+                            </div>
+                            <span className="material-symbols-outlined text-on-surface-variant opacity-40 text-base">chevron_right</span>
+                          </Link>
+                        );
+                      }
+                      // match
+                      const dateStr = new Date(item.start_date).toLocaleDateString(dateLocale, {
+                        day: "numeric",
+                        month: "short",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      });
+                      return (
+                        <Link
+                          key={`match-${item.id}`}
+                          href={`/matches/${item.id}`}
+                          className="flex items-center gap-4 bg-surface-low rounded-2xl px-4 py-3.5 active:bg-surface-card transition-colors"
+                        >
+                          <div className="w-10 h-10 rounded-xl bg-primary/15 text-primary flex items-center justify-center flex-shrink-0">
+                            <span className="material-symbols-outlined text-[20px]">sports_tennis</span>
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p className="font-semibold text-sm">
+                              {t(locale, "dashboard.upcomingMatch")}
+                              {item.location ? ` · ${item.location}` : ""}
+                            </p>
+                            <p className="text-[11px] text-on-surface-variant">
+                              {dateStr}
+                              {item.resource_name ? ` · ${item.resource_name}` : ""}
+                            </p>
+                            {item.goalsCount > 0 ? (
+                              <p className="text-[10px] text-primary font-bold mt-0.5">
+                                {item.goalsCount} {t(locale, "matches.goalsCount")}
+                              </p>
+                            ) : (
+                              <p className="text-[10px] text-on-surface-variant mt-0.5">
+                                {t(locale, "matches.setGoals")}
+                              </p>
+                            )}
+                          </div>
+                          <span className="material-symbols-outlined text-on-surface-variant opacity-40 text-base">chevron_right</span>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            );
+          })()}
 
           {/* Master plan: trainer edits, student previews */}
           {isTrainer ? (

--- a/src/components/matches/AttachInsightModal.tsx
+++ b/src/components/matches/AttachInsightModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { attachInsightToMatch, detachInsightFromMatch } from "@/lib/actions/playtomic";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface InsightOption {
+  id: string;
+  front_text: string;
+  problem?: { name: string } | null;
+}
+
+interface Props {
+  matchId: string;
+  locale: Locale;
+  allInsights: InsightOption[];
+  attachedIds: string[];
+}
+
+export default function AttachInsightModal({
+  matchId,
+  locale,
+  allInsights,
+  attachedIds,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  // Local selection state — starts from currently attached
+  const [selected, setSelected] = useState<Set<string>>(new Set(attachedIds));
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleOpen() {
+    setSelected(new Set(attachedIds));
+    setError(null);
+    setOpen(true);
+  }
+
+  function handleClose() {
+    if (isPending) return;
+    setOpen(false);
+  }
+
+  function toggleInsight(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function handleSave() {
+    setError(null);
+    startTransition(async () => {
+      const toAttach = [...selected].filter((id) => !attachedIds.includes(id));
+      const toDetach = attachedIds.filter((id) => !selected.has(id));
+
+      try {
+        await Promise.all([
+          ...toAttach.map((id) => attachInsightToMatch(matchId, id)),
+          ...toDetach.map((id) => detachInsightFromMatch(matchId, id)),
+        ]);
+        setOpen(false);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={handleOpen}
+        className="flex items-center gap-1.5 px-4 py-2.5 rounded-xl kinetic-gradient text-on-primary text-xs font-black uppercase tracking-widest"
+      >
+        <span className="material-symbols-outlined text-[16px]">flag</span>
+        {t(locale, "matches.detail.attachInsight")}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm px-4 pb-8"
+          onClick={handleClose}
+        >
+          <div
+            className="w-full max-w-[430px] bg-surface-card rounded-3xl p-6 space-y-4 max-h-[80vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-sm font-black uppercase tracking-widest text-on-surface shrink-0">
+              {t(locale, "matches.detail.modalTitle")}
+            </p>
+
+            <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+              {allInsights.length === 0 ? (
+                <p className="text-sm text-on-surface-variant text-center py-4">
+                  {t(locale, "matches.detail.modalEmpty")}
+                </p>
+              ) : (
+                allInsights.map((insight) => {
+                  const isChecked = selected.has(insight.id);
+                  return (
+                    <button
+                      key={insight.id}
+                      type="button"
+                      onClick={() => toggleInsight(insight.id)}
+                      className={`w-full text-left flex items-start gap-3 px-3 py-3 rounded-xl transition-colors ${
+                        isChecked
+                          ? "bg-primary/15 border border-primary/40"
+                          : "bg-surface-elevated border border-transparent hover:bg-border-dim"
+                      }`}
+                    >
+                      <span
+                        className={`material-symbols-outlined text-[20px] mt-0.5 shrink-0 ${
+                          isChecked ? "text-primary" : "text-on-surface-variant"
+                        }`}
+                      >
+                        {isChecked ? "check_circle" : "radio_button_unchecked"}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-on-surface leading-snug">
+                          {insight.front_text}
+                        </p>
+                        {insight.problem?.name && (
+                          <p className="text-xs text-on-surface-variant mt-0.5">
+                            {insight.problem.name}
+                          </p>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+
+            {error && <p className="text-xs text-error shrink-0">{error}</p>}
+
+            <div className="flex gap-3 shrink-0">
+              <button
+                onClick={handleClose}
+                disabled={isPending}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest text-on-surface-variant bg-surface-elevated hover:bg-border-dim disabled:opacity-40 transition-colors"
+              >
+                {t(locale, "matches.detail.modalCancel")}
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={isPending}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest kinetic-gradient text-on-primary disabled:opacity-40"
+              >
+                {isPending
+                  ? t(locale, "matches.detail.modalSaving")
+                  : t(locale, "matches.detail.modalSave")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/actions/playtomic.ts
+++ b/src/lib/actions/playtomic.ts
@@ -94,3 +94,77 @@ export async function addMatchByUrlAction(url: string): Promise<AddMatchByUrlRes
   revalidatePath("/matches");
   return { success: true };
 }
+
+export type AttachInsightResult = { success: true } | { success: false; error: string };
+
+/**
+ * Attaches an insight card to a match (creates a match_goals row).
+ */
+export async function attachInsightToMatch(
+  matchId: string,
+  insightId: string
+): Promise<AttachInsightResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  const supabase = await createClient();
+
+  // Verify the match belongs to the current user
+  const { data: match, error: matchError } = await supabase
+    .from("matches")
+    .select("id")
+    .eq("id", matchId)
+    .eq("profile_id", session.id)
+    .single();
+
+  if (matchError || !match) {
+    return { success: false, error: "Match not found" };
+  }
+
+  const { error } = await supabase
+    .from("match_goals")
+    .upsert({ match_id: matchId, insight_id: insightId }, { onConflict: "match_id,insight_id" });
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/matches/${matchId}`);
+  return { success: true };
+}
+
+export type DetachInsightResult = { success: true } | { success: false; error: string };
+
+/**
+ * Detaches an insight card from a match (removes the match_goals row).
+ */
+export async function detachInsightFromMatch(
+  matchId: string,
+  insightId: string
+): Promise<DetachInsightResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  const supabase = await createClient();
+
+  // Verify the match belongs to the current user
+  const { data: match, error: matchError } = await supabase
+    .from("matches")
+    .select("id")
+    .eq("id", matchId)
+    .eq("profile_id", session.id)
+    .single();
+
+  if (matchError || !match) {
+    return { success: false, error: "Match not found" };
+  }
+
+  const { error } = await supabase
+    .from("match_goals")
+    .delete()
+    .eq("match_id", matchId)
+    .eq("insight_id", insightId);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/matches/${matchId}`);
+  return { success: true };
+}

--- a/src/lib/dashboard/data.ts
+++ b/src/lib/dashboard/data.ts
@@ -2,6 +2,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { calculateSkillLevel } from "@/lib/types";
 import { getMasterPlan } from "@/lib/actions/masterPlan";
+import { syncUserMatches } from "@/lib/playtomic/sync";
 import type { Locale } from "@/lib/i18n";
 import type { MasterPlan } from "@/lib/types";
 
@@ -47,6 +48,16 @@ export interface DashboardProfile {
   playtomic_user_id: string | null;
 }
 
+export interface DashboardMatch {
+  id: string;
+  start_date: string;
+  location: string | null;
+  resource_name: string | null;
+  status: string | null;
+  teams: unknown;
+  goalsCount: number;
+}
+
 export interface DashboardData {
   profile: DashboardProfile;
   goals: DashboardGoal[];
@@ -56,6 +67,7 @@ export interface DashboardData {
   masterPlan: MasterPlan | null;
   totalPendingCards: number;
   firstPendingSessionId: string | null;
+  upcomingMatches: DashboardMatch[];
 }
 
 export async function loadDashboardData(
@@ -198,6 +210,41 @@ export async function loadDashboardData(
 
   const masterPlan = await getMasterPlan(userId);
 
+  // Sync Playtomic matches (10-min cooldown) and fetch upcoming ones
+  await syncUserMatches(userId);
+
+  const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
+  const { data: matchesRaw } = await supabase
+    .from("matches")
+    .select(
+      `id, start_date, location, resource_name, status, teams, match_goals(count)`
+    )
+    .eq("profile_id", userId)
+    .in("status", UPCOMING_STATUSES)
+    .gte("start_date", new Date().toISOString())
+    .order("start_date", { ascending: true })
+    .limit(5);
+
+  const upcomingMatches: DashboardMatch[] = (matchesRaw ?? []).map(
+    (r: {
+      id: string;
+      start_date: string;
+      location: string | null;
+      resource_name: string | null;
+      status: string | null;
+      teams: unknown;
+      match_goals: Array<{ count: number }>;
+    }) => ({
+      id: r.id,
+      start_date: r.start_date,
+      location: r.location,
+      resource_name: r.resource_name,
+      status: r.status,
+      teams: r.teams,
+      goalsCount: r.match_goals?.[0]?.count ?? 0,
+    })
+  );
+
   return {
     profile: {
       id: profileRow.id as string,
@@ -213,5 +260,6 @@ export async function loadDashboardData(
     masterPlan,
     totalPendingCards,
     firstPendingSessionId,
+    upcomingMatches,
   };
 }

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -122,6 +122,22 @@ const ru = {
   "matches.goalsCount": "целей",
   "matches.setGoals": "Поставь цели",
   "matches.refreshing": "Обновление…",
+  "matches.detail.goals": "Цели на игру",
+  "matches.detail.attachInsight": "Прикрепить инсайт",
+  "matches.detail.noGoals": "Нет прикреплённых инсайтов",
+  "matches.detail.modalTitle": "Выберите инсайты",
+  "matches.detail.modalEmpty": "Нет инсайтов в коллекции",
+  "matches.detail.modalSave": "Сохранить",
+  "matches.detail.modalCancel": "Отмена",
+  "matches.detail.modalSaving": "Сохранение…",
+  "matches.detail.detach": "Открепить",
+  "matches.detail.notFound": "Матч не найден",
+  "matches.detail.court": "Корт",
+
+  // Dashboard — «Актуальное» block
+  "dashboard.upcoming": "Актуальное",
+  "dashboard.upcomingEmpty": "Нет предстоящих тренировок или матчей",
+  "dashboard.upcomingMatch": "Матч",
 
   // Language switcher
   "lang.label": "Язык",
@@ -229,6 +245,11 @@ const en: Record<keyof typeof ru, string> = {
   "lang.ru": "Русский",
   "lang.en": "English",
 
+  // Dashboard — «Актуальное» block
+  "dashboard.upcoming": "Upcoming",
+  "dashboard.upcomingEmpty": "No upcoming sessions or matches",
+  "dashboard.upcomingMatch": "Match",
+
   // Matches
   "matches.title": "Matches",
   "matches.tabUpcoming": "Upcoming",
@@ -245,6 +266,17 @@ const en: Record<keyof typeof ru, string> = {
   "matches.goalsCount": "goals",
   "matches.setGoals": "Set goals",
   "matches.refreshing": "Refreshing…",
+  "matches.detail.goals": "Match goals",
+  "matches.detail.attachInsight": "Attach insight",
+  "matches.detail.noGoals": "No insights attached yet",
+  "matches.detail.modalTitle": "Select insights",
+  "matches.detail.modalEmpty": "No insights in your vault",
+  "matches.detail.modalSave": "Save",
+  "matches.detail.modalCancel": "Cancel",
+  "matches.detail.modalSaving": "Saving…",
+  "matches.detail.detach": "Detach",
+  "matches.detail.notFound": "Match not found",
+  "matches.detail.court": "Court",
 };
 
 export type DictKey = keyof typeof ru;


### PR DESCRIPTION
Closes #65

## Что сделано

- Создан маршрут `src/app/matches/[id]/page.tsx` — Server Component, загружающий матч и прикреплённые инсайты через `match_goals`
- Шапка: дата, клуб, корт; статус-бейдж
- Блок команд: 4 игрока из `teams` JSONB, текущий пользователь выделяется по `playtomic_user_id`
- Блок «Цели на игру» (только для предстоящих): список прикреплённых инсайтов + кнопка «Прикрепить инсайт»
- Создан клиентский компонент `AttachInsightModal.tsx` — модалка с чекбоксами по коллекции инсайтов ученика (`taken` карточки), diff-логика attach/detach при сохранении
- Добавлены Server Actions `attachInsightToMatch` / `detachInsightFromMatch` в `src/lib/actions/playtomic.ts`
- Добавлены i18n ключи `matches.detail.*` в `dict.ts` (ru + en)

## Файлы

- `src/app/matches/[id]/page.tsx` — новая страница
- `src/components/matches/AttachInsightModal.tsx` — новый клиентский компонент
- `src/lib/actions/playtomic.ts` — два новых server action
- `src/lib/i18n/dict.ts` — 12 новых ключей

## Проверка

- `npx tsc --noEmit` — пройден без ошибок
- На предстоящем матче: прикрепить N инсайтов → сохранить → список обновляется при перезагрузке
- Открепление: снять галочку в модалке → сохранить → инсайт исчезает из списка
- Текущий пользователь выделяется в блоке команд