### PR TITLE
feat(#62): «Использовать на игре» из карточки инсайта

### DIFF
--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -6,6 +6,7 @@ import VaultFilters from "@/components/insights/VaultFilters";
 import { getVaultCards } from "@/lib/actions/insightCards";
 import { getLocale, t } from "@/lib/i18n";
 import type { ProblemCategory } from "@/lib/types";
+import type { UpcomingMatchOption } from "@/components/insights/UseAtMatchModal";
 
 export default async function InsightsPage({
   searchParams,
@@ -21,13 +22,30 @@ export default async function InsightsPage({
 
   const categoryId = category ? Number(category) : undefined;
 
-  const [cards, { data: categoriesRaw }] = await Promise.all([
+  const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
+
+  const [cards, { data: categoriesRaw }, { data: matchesRaw }] = await Promise.all([
     getVaultCards({ categoryId }),
     supabase
       .from("problem_categories")
       .select("id, sort_order, name_ru, name_en")
       .order("sort_order"),
+    supabase
+      .from("matches")
+      .select("id, start_date, location, resource_name, status")
+      .eq("profile_id", user.id)
+      .in("status", UPCOMING_STATUSES)
+      .gte("start_date", new Date().toISOString())
+      .order("start_date", { ascending: true })
+      .limit(20),
   ]);
+
+  const upcomingMatches: UpcomingMatchOption[] = (matchesRaw ?? []).map((m) => ({
+    id: m.id as string,
+    start_date: m.start_date as string,
+    location: (m.location as string | null) ?? null,
+    resource_name: (m.resource_name as string | null) ?? null,
+  }));
 
   const nameCol = locale === "en" ? "name_en" : "name_ru";
   const categories = (categoriesRaw ?? []).map((c) => ({
@@ -53,7 +71,7 @@ export default async function InsightsPage({
           activeCategoryId={categoryId}
           allLabel={t(locale, "insights.filterAll")}
         />
-        <VaultGrid cards={cards} />
+        <VaultGrid cards={cards} upcomingMatches={upcomingMatches} locale={locale} />
       </main>
     </div>
   );

--- a/src/components/insights/UseAtMatchModal.tsx
+++ b/src/components/insights/UseAtMatchModal.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { attachInsightToMatch } from "@/lib/actions/playtomic";
+import { t } from "@/lib/i18n/dict";
+import type { Locale } from "@/lib/i18n/dict";
+
+export interface UpcomingMatchOption {
+  id: string;
+  start_date: string;
+  location: string | null;
+  resource_name: string | null;
+}
+
+interface Props {
+  insightId: string;
+  locale: Locale;
+  upcomingMatches: UpcomingMatchOption[];
+}
+
+function formatMatchDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("ru-RU", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function UseAtMatchModal({ insightId, locale, upcomingMatches }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [attached, setAttached] = useState(false);
+
+  function handleOpen() {
+    setSelectedMatchId(null);
+    setError(null);
+    setAttached(false);
+    setOpen(true);
+  }
+
+  function handleClose() {
+    if (isPending) return;
+    setOpen(false);
+  }
+
+  function handleSave() {
+    if (!selectedMatchId) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await attachInsightToMatch(selectedMatchId, insightId);
+      if (!result.success) {
+        setError(result.error);
+      } else {
+        setAttached(true);
+        setOpen(false);
+      }
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          handleOpen();
+        }}
+        className={`mt-2 flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest transition-colors ${
+          attached
+            ? "text-primary"
+            : "text-on-surface-variant hover:text-primary"
+        }`}
+      >
+        <span className="material-symbols-outlined text-[14px]">
+          {attached ? "check_circle" : "sports_tennis"}
+        </span>
+        {attached
+          ? t(locale, "insights.useAtMatch.success")
+          : t(locale, "insights.useAtMatch")}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm px-4 pb-8"
+          onClick={handleClose}
+        >
+          <div
+            className="w-full max-w-[430px] bg-surface-card rounded-3xl p-6 space-y-4 max-h-[80vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-sm font-black uppercase tracking-widest text-on-surface shrink-0">
+              {t(locale, "insights.useAtMatch.modalTitle")}
+            </p>
+
+            <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+              {upcomingMatches.length === 0 ? (
+                <p className="text-sm text-on-surface-variant text-center py-4">
+                  {t(locale, "insights.useAtMatch.modalEmpty")}
+                </p>
+              ) : (
+                upcomingMatches.map((match) => {
+                  const isSelected = selectedMatchId === match.id;
+                  return (
+                    <button
+                      key={match.id}
+                      type="button"
+                      onClick={() => setSelectedMatchId(match.id)}
+                      className={`w-full text-left flex items-start gap-3 px-3 py-3 rounded-xl transition-colors ${
+                        isSelected
+                          ? "bg-primary/15 border border-primary/40"
+                          : "bg-surface-elevated border border-transparent hover:bg-border-dim"
+                      }`}
+                    >
+                      <span
+                        className={`material-symbols-outlined text-[20px] mt-0.5 shrink-0 ${
+                          isSelected ? "text-primary" : "text-on-surface-variant"
+                        }`}
+                      >
+                        {isSelected ? "check_circle" : "radio_button_unchecked"}
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-on-surface leading-snug">
+                          {formatMatchDate(match.start_date)}
+                        </p>
+                        {(match.location || match.resource_name) && (
+                          <p className="text-xs text-on-surface-variant mt-0.5 truncate">
+                            {[match.location, match.resource_name]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </p>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+
+            {error && <p className="text-xs text-error shrink-0">{error}</p>}
+
+            <div className="flex gap-3 shrink-0">
+              <button
+                onClick={handleClose}
+                disabled={isPending}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest text-on-surface-variant bg-surface-elevated hover:bg-border-dim disabled:opacity-40 transition-colors"
+              >
+                {t(locale, "insights.useAtMatch.modalCancel")}
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={isPending || !selectedMatchId}
+                className="flex-1 py-2.5 rounded-xl text-sm font-black uppercase tracking-widest kinetic-gradient text-on-primary disabled:opacity-40"
+              >
+                {isPending
+                  ? t(locale, "insights.useAtMatch.modalSaving")
+                  : t(locale, "insights.useAtMatch.modalSave")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/insights/VaultGrid.tsx
+++ b/src/components/insights/VaultGrid.tsx
@@ -2,12 +2,18 @@
 
 import { useState } from "react";
 import type { InsightCardWithRelations } from "@/lib/types";
+import UseAtMatchModal, {
+  type UpcomingMatchOption,
+} from "@/components/insights/UseAtMatchModal";
+import type { Locale } from "@/lib/i18n/dict";
 
 interface Props {
   cards: InsightCardWithRelations[];
+  upcomingMatches?: UpcomingMatchOption[];
+  locale?: Locale;
 }
 
-export default function VaultGrid({ cards }: Props) {
+export default function VaultGrid({ cards, upcomingMatches, locale = "ru" }: Props) {
   const [flipped, setFlipped] = useState<Set<string>>(new Set());
 
   if (cards.length === 0) {
@@ -72,6 +78,13 @@ export default function VaultGrid({ cards }: Props) {
                   <p className="text-[10px] text-on-surface-variant mt-1 truncate">
                     Сессия №{card.session.session_number}
                   </p>
+                )}
+                {upcomingMatches !== undefined && (
+                  <UseAtMatchModal
+                    insightId={card.id}
+                    locale={locale}
+                    upcomingMatches={upcomingMatches}
+                  />
                 )}
               </div>
             </div>

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -143,6 +143,16 @@ const ru = {
   "lang.label": "Язык",
   "lang.ru": "Русский",
   "lang.en": "English",
+
+  // Insights — «Use at match» feature
+  "insights.useAtMatch": "Использовать на игре",
+  "insights.useAtMatch.modalTitle": "Выберите матч",
+  "insights.useAtMatch.modalEmpty": "Нет предстоящих матчей. Добавьте матч на странице Матчи.",
+  "insights.useAtMatch.modalSave": "Прикрепить",
+  "insights.useAtMatch.modalCancel": "Отмена",
+  "insights.useAtMatch.modalSaving": "Сохранение…",
+  "insights.useAtMatch.success": "Прикреплено",
+  "insights.useAtMatch.noPlaytomic": "Подключи Playtomic, чтобы использовать матчи",
 } as const;
 
 const en: Record<keyof typeof ru, string> = {
@@ -277,6 +287,16 @@ const en: Record<keyof typeof ru, string> = {
   "matches.detail.detach": "Detach",
   "matches.detail.notFound": "Match not found",
   "matches.detail.court": "Court",
+
+  // Insights — «Use at match» feature
+  "insights.useAtMatch": "Use at match",
+  "insights.useAtMatch.modalTitle": "Select a match",
+  "insights.useAtMatch.modalEmpty": "No upcoming matches. Add a match on the Matches page.",
+  "insights.useAtMatch.modalSave": "Attach",
+  "insights.useAtMatch.modalCancel": "Cancel",
+  "insights.useAtMatch.modalSaving": "Saving…",
+  "insights.useAtMatch.success": "Attached",
+  "insights.useAtMatch.noPlaytomic": "Connect Playtomic to use matches",
 };
 
 export type DictKey = keyof typeof ru;


### PR DESCRIPTION
Closes #62

## Что сделано

- Новый компонент `UseAtMatchModal` — модалка выбора предстоящего матча из карточки инсайта
- `VaultGrid` расширен опциональными пропами `upcomingMatches` и `locale`
- На обратной стороне каждой карточки появляется кнопка «Использовать на игре»
- Клик открывает модалку со списком предстоящих матчей (статус PENDING/CONFIRMED, дата > now)
- Выбор матча → запись в `match_goals` через существующий `attachInsightToMatch`
- Если матчей нет — пустое состояние с подсказкой
- `InsightsPage` параллельно запрашивает карточки, категории и предстоящие матчи
- i18n ключи добавлены для RU и EN

## Файлы

- `src/components/insights/UseAtMatchModal.tsx` — новый компонент
- `src/components/insights/VaultGrid.tsx` — расширены пропы + рендер кнопки
- `src/app/insights/page.tsx` — добавлен запрос матчей
- `src/lib/i18n/dict.ts` — новые ключи `insights.useAtMatch.*`

## Проверка

- [ ] На странице `/insights` на обратной стороне карточки видна кнопка «Использовать на игре»
- [ ] Клик открывает модалку со списком предстоящих матчей
- [ ] Если матчей нет — отображается пустое состояние
- [ ] Выбор матча и нажатие «Прикрепить» → инсайт виден на странице `/matches/[id]` в блоке «Цели на игру»
- [ ] TypeScript компилируется без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)