### PR TITLE
feat(#64): счёт и рефлексия для прошедших матчей

### DIFF
--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getLocale } from "@/lib/i18n";
 import { t } from "@/lib/i18n/dict";
 import AttachInsightModal from "@/components/matches/AttachInsightModal";
+import ReflectionTextarea from "@/components/matches/ReflectionTextarea";
 import { getVaultCards } from "@/lib/actions/insightCards";
 
 const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
@@ -41,6 +42,49 @@ function extractTeams(raw: unknown): Team[] {
   return raw as Team[];
 }
 
+/**
+ * Parses the Playtomic `results` jsonb into a human-readable score string.
+ * Playtomic results can be an array of game objects like:
+ *   [{ sets: [{local_score: 6, visitor_score: 3}, ...] }]
+ * or a flat array of score objects.
+ * Returns a formatted string like "6-3, 4-6, 6-4", or null if not parseable.
+ */
+function formatScore(results: unknown): string | null {
+  if (results == null || typeof results !== "object") return null;
+  if (!Array.isArray(results)) return null;
+
+  const sets: string[] = [];
+
+  for (const item of results) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+
+    // Shape: { sets: [{local_score, visitor_score}] }
+    if (Array.isArray(obj["sets"])) {
+      for (const s of obj["sets"] as unknown[]) {
+        if (!s || typeof s !== "object") continue;
+        const setObj = s as Record<string, unknown>;
+        const local =
+          setObj["local_score"] ?? setObj["team1"] ?? setObj["home"];
+        const visitor =
+          setObj["visitor_score"] ?? setObj["team2"] ?? setObj["away"];
+        if (local != null && visitor != null) {
+          sets.push(`${local}-${visitor}`);
+        }
+      }
+    } else {
+      // Flat shape: [{local_score, visitor_score}]
+      const local = obj["local_score"] ?? obj["team1"] ?? obj["home"];
+      const visitor = obj["visitor_score"] ?? obj["team2"] ?? obj["away"];
+      if (local != null && visitor != null) {
+        sets.push(`${local}-${visitor}`);
+      }
+    }
+  }
+
+  return sets.length > 0 ? sets.join(", ") : null;
+}
+
 export default async function MatchDetailPage({ params }: PageProps) {
   const user = await getSession();
   if (!user) redirect("/login");
@@ -49,7 +93,7 @@ export default async function MatchDetailPage({ params }: PageProps) {
   const locale = await getLocale();
   const supabase = await createClient();
 
-  // Fetch match with attached insight ids
+  // Fetch match with attached insight ids and reflection
   const { data: matchRaw, error } = await supabase
     .from("matches")
     .select(
@@ -62,6 +106,7 @@ export default async function MatchDetailPage({ params }: PageProps) {
       status,
       teams,
       results,
+      reflection,
       match_goals(insight_id)
     `
     )
@@ -80,11 +125,14 @@ export default async function MatchDetailPage({ params }: PageProps) {
     status: string | null;
     teams: unknown;
     results: unknown;
+    reflection: string | null;
     match_goals: Array<{ insight_id: string }>;
   };
 
   const attachedIds = match.match_goals.map((g) => g.insight_id);
   const isUpcoming = UPCOMING_STATUSES.includes(match.status ?? "");
+  const isPlayed = match.status === "PLAYED";
+  const scoreText = isPlayed ? formatScore(match.results) : null;
 
   // Fetch profile for playtomic_user_id to highlight "me"
   const { data: profile } = await supabase
@@ -273,6 +321,61 @@ export default async function MatchDetailPage({ params }: PageProps) {
               </div>
             )}
           </section>
+        )}
+
+        {/* Post-match block — only for PLAYED matches */}
+        {isPlayed && (
+          <>
+            {/* Score */}
+            {scoreText && (
+              <section className="bg-surface-card rounded-2xl p-4 space-y-1">
+                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+                  {t(locale, "matches.detail.score")}
+                </p>
+                <p className="text-2xl font-black text-on-surface tracking-tight">
+                  {scoreText}
+                </p>
+              </section>
+            )}
+
+            {/* Read-only goals (result view) */}
+            {attachedInsights.length > 0 && (
+              <section className="space-y-3">
+                <p className="text-sm font-black uppercase tracking-widest text-on-surface">
+                  {t(locale, "matches.detail.goalsReadOnly")}
+                </p>
+                <div className="space-y-2">
+                  {attachedInsights.map((insight) => (
+                    <div
+                      key={insight.id}
+                      className="bg-surface-card rounded-2xl p-4 flex items-start gap-3"
+                    >
+                      <span className="material-symbols-outlined text-[20px] text-on-surface-variant mt-0.5 shrink-0">
+                        flag
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-on-surface leading-snug">
+                          {insight.front_text}
+                        </p>
+                        {insight.problem?.name && (
+                          <p className="text-xs text-on-surface-variant mt-0.5">
+                            {insight.problem.name}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Reflection textarea with auto-save */}
+            <ReflectionTextarea
+              matchId={match.id}
+              initialValue={match.reflection ?? ""}
+              locale={locale}
+            />
+          </>
         )}
       </main>
     </div>

--- a/src/components/matches/ReflectionTextarea.tsx
+++ b/src/components/matches/ReflectionTextarea.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { saveReflection } from "@/lib/actions/playtomic";
+import type { Locale } from "@/lib/i18n/dict";
+import { t } from "@/lib/i18n/dict";
+
+interface Props {
+  matchId: string;
+  initialValue: string;
+  locale: Locale;
+}
+
+export default function ReflectionTextarea({
+  matchId,
+  initialValue,
+  locale,
+}: Props) {
+  const [value, setValue] = useState(initialValue);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved">("idle");
+  const [isPending, startTransition] = useTransition();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = e.target.value;
+    setValue(next);
+    setStatus("saving");
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      startTransition(async () => {
+        await saveReflection(matchId, next);
+        setStatus("saved");
+      });
+    }, 800);
+  }
+
+  const statusLabel =
+    status === "saving" || isPending
+      ? t(locale, "matches.detail.reflectionSaving")
+      : status === "saved"
+        ? t(locale, "matches.detail.reflectionSaved")
+        : null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-black uppercase tracking-widest text-on-surface">
+          {t(locale, "matches.detail.reflection")}
+        </p>
+        {statusLabel && (
+          <span className="text-[10px] text-on-surface-variant">{statusLabel}</span>
+        )}
+      </div>
+      <textarea
+        value={value}
+        onChange={handleChange}
+        placeholder={t(locale, "matches.detail.reflectionPlaceholder")}
+        rows={4}
+        className="w-full bg-surface-card rounded-2xl p-4 text-sm text-on-surface placeholder:text-on-surface-variant resize-none border border-border-dim focus:outline-none focus:border-primary/60 transition-colors"
+      />
+    </div>
+  );
+}

--- a/src/lib/actions/playtomic.ts
+++ b/src/lib/actions/playtomic.ts
@@ -131,6 +131,34 @@ export async function attachInsightToMatch(
   return { success: true };
 }
 
+export type SaveReflectionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+/**
+ * Saves the reflection text for a played match.
+ */
+export async function saveReflection(
+  matchId: string,
+  reflection: string
+): Promise<SaveReflectionResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "unauthorized" };
+
+  const supabase = await createClient();
+
+  const { error } = await supabase
+    .from("matches")
+    .update({ reflection })
+    .eq("id", matchId)
+    .eq("profile_id", session.id);
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/matches/${matchId}`);
+  return { success: true };
+}
+
 export type DetachInsightResult = { success: true } | { success: false; error: string };
 
 /**

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -133,6 +133,12 @@ const ru = {
   "matches.detail.detach": "Открепить",
   "matches.detail.notFound": "Матч не найден",
   "matches.detail.court": "Корт",
+  "matches.detail.score": "Счёт",
+  "matches.detail.goalsReadOnly": "Цели на игру (итог)",
+  "matches.detail.reflection": "Как прошло?",
+  "matches.detail.reflectionPlaceholder": "Запиши свои мысли после матча…",
+  "matches.detail.reflectionSaving": "Сохранение…",
+  "matches.detail.reflectionSaved": "Сохранено",
 
   // Dashboard — «Актуальное» block
   "dashboard.upcoming": "Актуальное",
@@ -277,6 +283,12 @@ const en: Record<keyof typeof ru, string> = {
   "matches.detail.detach": "Detach",
   "matches.detail.notFound": "Match not found",
   "matches.detail.court": "Court",
+  "matches.detail.score": "Score",
+  "matches.detail.goalsReadOnly": "Match goals (result)",
+  "matches.detail.reflection": "How did it go?",
+  "matches.detail.reflectionPlaceholder": "Write your thoughts after the match…",
+  "matches.detail.reflectionSaving": "Saving…",
+  "matches.detail.reflectionSaved": "Saved",
 };
 
 export type DictKey = keyof typeof ru;

--- a/src/lib/playtomic/sync.ts
+++ b/src/lib/playtomic/sync.ts
@@ -56,41 +56,36 @@ export async function syncUserMatches(
 
   // 4. Fetch from Playtomic
   const remoteMatches = await fetchUserMatches(playtomic_user_id);
-  if (remoteMatches.length === 0) {
-    // Still update sync timestamp so we don't spam the API
-    await supabase
-      .from("profiles")
-      .update({ playtomic_synced_at: new Date().toISOString() })
-      .eq("id", profileId);
-    return;
+
+  if (remoteMatches.length > 0) {
+    const now = new Date();
+
+    // 5. Load existing match IDs from our DB for this profile
+    const { data: existingRows } = await supabase
+      .from("matches")
+      .select("playtomic_match_id")
+      .eq("profile_id", profileId);
+
+    const existingIds = new Set(
+      (existingRows ?? []).map(
+        (r: { playtomic_match_id: string }) => r.playtomic_match_id
+      )
+    );
+
+    // Filter: upcoming OR already in DB (to refresh status/score)
+    const toSync = remoteMatches.filter((m) => {
+      if (existingIds.has(m.match_id)) return true;
+      if (!m.start_date) return false;
+      return new Date(m.start_date) >= now;
+    });
+
+    if (toSync.length > 0) {
+      await upsertMatches(supabase, profileId, toSync);
+    }
   }
 
-  const now = new Date();
-
-  // 5. Load existing match IDs from our DB for this profile
-  const { data: existingRows } = await supabase
-    .from("matches")
-    .select("playtomic_match_id")
-    .eq("profile_id", profileId);
-
-  const existingIds = new Set(
-    (existingRows ?? []).map(
-      (r: { playtomic_match_id: string }) => r.playtomic_match_id
-    )
-  );
-
-  // Filter: upcoming OR already in DB
-  const toSync = remoteMatches.filter((m) => {
-    if (existingIds.has(m.match_id)) return true;
-    if (!m.start_date) return false;
-    return new Date(m.start_date) >= now;
-  });
-
-  if (toSync.length > 0) {
-    await upsertMatches(supabase, profileId, toSync);
-  }
-
-  // 6 & 7. Mark past matches with results as PLAYED
+  // Always mark past matches with results as PLAYED, even when Playtomic returns
+  // no matches (guarantees correct status for already-synced records).
   await markPlayedMatches(supabase, profileId);
 
   // 8. Update sync timestamp


### PR DESCRIPTION
Closes #64

## Что сделано

- Добавлена функция `formatScore()` — парсит `results` jsonb из Playtomic в читаемый формат «6-3, 4-6, 6-4»
- `/matches/[id]` теперь запрашивает поле `reflection` из БД
- Для матчей со статусом `PLAYED` показывается блок: счёт → инсайты-цели (read-only) → textarea «Как прошло?»
- Новый клиентский компонент `ReflectionTextarea` — debounce 800ms, автосохранение через server action
- Новый server action `saveReflection` в `playtomic.ts`
- Исправлен `syncUserMatches`: `markPlayedMatches` теперь вызывается всегда, даже если Playtomic вернул 0 матчей
- Добавлены i18n-ключи (ru + en): `matches.detail.score`, `goalsReadOnly`, `reflection*`

## Файлы

- `src/app/matches/[id]/page.tsx` — post-match UI, `reflection` в запросе, `formatScore`
- `src/components/matches/ReflectionTextarea.tsx` — новый клиентский компонент
- `src/lib/actions/playtomic.ts` — `saveReflection` action
- `src/lib/playtomic/sync.ts` — fix early-return для `markPlayedMatches`
- `src/lib/i18n/dict.ts` — новые i18n-ключи

## Проверка

1. Открыть матч со статусом PLAYED → должен показываться счёт (если есть `results`), список целей (read-only), textarea рефлексии
2. Написать текст в textarea → через ~800ms должно сохраниться (появится «Сохранено»), перезагрузить страницу → текст остался
3. Открыть предстоящий матч → блок рефлексии не показывается, только «Цели на игру» с кнопкой прикрепления
4. Запустить синк при 0 матчах от Playtomic → статус PLAYED должен корректно выставляться для уже существующих матчей в БД