### PR TITLE
docs: Epic 4 — Audio → Insights research + план

### DIFF
--- a/docs/plans/2026-05-13-audio-insights-research.md
+++ b/docs/plans/2026-05-13-audio-insights-research.md
@@ -1,0 +1,252 @@
+# Epic 4 (research): Audio → Insights pipeline
+
+**Date:** 2026-05-13
+**Status:** research / pre-design
+
+## Идея эпика
+
+После каждой тренировки тренер получает часовое аудио. Цель: автоматически транскрибировать его на русский и сгенерировать черновики insight-карточек, которые тренер ревьюит/редактирует/аппрувит и отправляет ученику.
+
+Текущая боль: инсайты "теряются" внутри часовой записи, тренер не успевает их выписывать вручную.
+
+## Constraints
+
+- RU-язык, падел-терминология (бандеха, вибора, смэш, пала, аламбре, трахте...)
+- Серверлесс-стек: Next.js 16 на Vercel (300s function timeout), Supabase
+- Бюджет MVP: **$0.30–$1 за одну часовую тренировку**
+- Скорость не критична: можно ждать 10–30 минут
+- MVP: один спикер (тренер с петличкой). Диаризация — v2.
+- LLM-инсайты опциональны на старте — сначала важна качественная транскрипция.
+
+---
+
+## ✅ TL;DR — что закладываем в эпик
+
+- **STT**: Groq `whisper-large-v3` без промпта + постпроцессинг (фильтр галлюцинаций + fuzzy-glossary). **~$0.04/час, 12 сек обработки**.
+- **LLM**: `anthropic/claude-sonnet-4.6` через Vercel AI Gateway, `generateObject` + Zod схема. **~$0.08/тренировка**.
+- **Async**: Vercel Queues (beta) или Inngest для оркестрации STT → LLM пайплайна.
+- **БД**: новая таблица `transcripts` (1:1 с sessions) + reuse `insight_cards` (`source='ai'`, `trainer_status='draft'`).
+- **Бюджет на тренировку: ~$0.12** (STT $0.04 + LLM $0.08).
+- **Диаризация — v2** (Replicate + WhisperX).
+
+Подробности по выбору STT — в разделе 8 (Pilot-эксперимент 2026-05-13).
+
+---
+
+## 1. Транскрибация (STT): сравнение
+
+| Сервис                            | $/час  | RU WER         | Glossary           | Async        | Diarization | File limit |
+|-----------------------------------|--------|----------------|--------------------|--------------|-------------|------------|
+| **ElevenLabs Scribe v1**          | $0.22  | **3.1%** (FLEURS) | `keyterms` (+$0.05/ч) | sync        | ✅          | нет        |
+| **Yandex SpeechKit (async)**      | ~$0.18 | ~3–5% (нативный RU) | ❌                 | ✅ async     | ❌          | 4 часа     |
+| **Deepgram Nova-3**               | $0.31 (batch) | ~5–6%   | `keywords` + boost | ✅ webhook   | ✅ (+$0.06/ч)| нет        |
+| **AssemblyAI Universal-2**        | $0.27  | ~6%            | ❌                 | ✅ async     | ✅ (+$0.12/ч)| нет        |
+| **OpenAI gpt-4o-transcribe**      | $0.36  | ~7–8%          | `prompt` (224 tok) | sync         | ❌          | **25 MB**  |
+| **OpenAI whisper-1**              | $0.36  | ~10–12%        | `prompt`           | sync         | ❌          | **25 MB**  |
+| **Groq Whisper large-v3-turbo**   | **$0.04** | ~8%         | `prompt`           | sync, 216× RT| ❌          | 25 MB      |
+| **fal.ai Wizper**                 | $0.03  | ~8%            | `prompt`           | ✅ webhook   | ❌          | нет        |
+| **Google Chirp 2 (Dynamic Batch)**| $0.24  | ~7%            | ❌                 | ✅ BatchRecognize | платно | нет        |
+| **Azure Speech (batch)**          | $0.18  | ~7%            | custom endpoint    | ✅ async     | ✅ (free)   | нет        |
+| **Replicate/Modal Whisper-v3**    | $0.05–0.15 | ~8–10%     | `prompt`           | ✅ async     | через WhisperX | нет     |
+| **Локально Mac M-series**         | **$0** | ~8–10%         | `initial_prompt`   | оффлайн      | через WhisperX | —       |
+
+### Recommendation
+
+**MVP:** **ElevenLabs Scribe** — лучшее RU-качество из коммерческих API, glossary через `keyterms` для падел-сленга, нет лимита длины, $0.22/час.
+**Upgrade-path (диаризация, v2):** **Deepgram Nova-3** — нативный async webhook, diarization из коробки.
+**Zero-budget pilot:** локально `whisper.cpp` на Mac (large-v3) с `initial_prompt` падел-терминов.
+
+---
+
+## 2. Async-архитектура на Vercel
+
+Часовой файл нельзя обработать в одном route handler (300s). Варианты:
+
+1. **Vercel Queues** (beta, нативно) — лучший выбор для Next.js на Vercel.
+2. **Inngest** — durable workflows, step-based, отличный DX.
+3. **Trigger.dev / Upstash QStash** — альтернативы.
+4. **Supabase Edge Functions + pg_cron** — если хочется держать всё в Supabase.
+
+Для STT с webhook-режимом (Deepgram/AssemblyAI/fal.ai/Google Batch): сразу отдать задачу провайдеру и принять callback. Для ElevenLabs (sync): запустить через Vercel Queues, дождаться, записать результат.
+
+---
+
+## 3. LLM для генерации инсайтов
+
+| Модель                          | Input ($/MTok) | Output ($/MTok) | За тренировку (15k+2k) | RU      |
+|---------------------------------|----------------|------------------|------------------------|---------|
+| **anthropic/claude-sonnet-4.6** | $3             | $15              | **$0.075**             | 🏆       |
+| anthropic/claude-opus-4.7       | $5             | $25              | $0.125                 | 🏆       |
+| google/gemini-2.5-flash         | $0.30          | $2.50            | **$0.009**             | хорошо  |
+| openai/gpt-4.1                  | $2             | $8               | $0.046                 | хорошо  |
+| openai/gpt-4o                   | $2.50          | $10              | $0.057                 | хорошо  |
+
+**Recommendation:** `anthropic/claude-sonnet-4.6` через **Vercel AI Gateway** (единый ключ, failover, observability). Если нужно удешевить — `gemini-2.5-flash` в 8× дешевле.
+
+### Архитектура промпт-цепочки
+
+**Two-stage** (лучше single-pass для часа разговора):
+
+1. **Extract**: транскрипт → сырые наблюдения тренера (20–30 штук).
+2. **Structure**: наблюдения → дедупликация + структурирование в `insight_cards`.
+
+Map-reduce оправдан только при >4 часах записи.
+
+### Zod schema
+
+```ts
+import { z } from "zod";
+
+const InsightTagSchema = z.enum(["техника", "тактика", "физика", "ментал"]);
+
+export const InsightCardDraftSchema = z.object({
+  title: z.string().max(80),
+  body: z.string().max(400),
+  tags: z.array(InsightTagSchema).min(1).max(3),
+  quote: z.string().optional(),         // якорь против галлюцинаций
+  timestamp_ref: z.string().optional(), // "14:32"
+});
+
+export const InsightBatchSchema = z.object({
+  insights: z.array(InsightCardDraftSchema).min(3).max(15),
+});
+```
+
+Использовать `generateObject` из Vercel AI SDK (предпочтительнее tool use для чистого structured output).
+
+### Промпт-принципы
+
+- **Few-shot обязателен** (без примеров модель пишет пересказ, а не actionable советы).
+- **`quote` обязателен** — якорь против галлюцинаций; нет цитаты → инсайт невалиден.
+- **Actionable filter**: "только то, что ученик может применить на следующей тренировке".
+- **Теги**: техника / тактика / физика / ментал — с определениями в системном промпте.
+
+---
+
+## 4. Хранение в Supabase
+
+Существующая `insight_cards` уже имеет `source='ai'` и `trainer_status='draft'` — готова под AI-черновики.
+
+Добавить:
+
+```sql
+CREATE TABLE transcripts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid REFERENCES sessions(id) ON DELETE CASCADE,
+  raw_text text NOT NULL,
+  storage_path text,             -- путь в Supabase Storage (audio)
+  duration_seconds integer,
+  stt_provider text,             -- 'elevenlabs' | 'deepgram' | ...
+  created_at timestamptz DEFAULT now()
+);
+```
+
+Связь: `sessions` → `transcripts` (1:1) → `insight_cards` (1:N через `session_id`).
+Embeddings (pgvector) — не нужны для MVP, добавить позже для поиска по карточкам.
+
+---
+
+## 5. Предлагаемая архитектура MVP
+
+```
+[Тренер: upload MP3/M4A через UI Nivel]
+        │
+        ▼
+Supabase Storage (signed URL)
+        │
+        ▼
+POST /api/transcribe ──enqueue──►  Vercel Queues
+                                        │
+                                        ▼
+                                ElevenLabs Scribe API
+                                (keyterms: бандеха, вибора,
+                                 смэш, пала, аламбре, ...)
+                                        │
+                                        ▼
+                                INSERT transcripts
+                                        │
+                                        ▼
+                                AI Gateway:
+                                anthropic/claude-sonnet-4.6
+                                generateObject(InsightBatchSchema)
+                                two-stage prompt chain
+                                        │
+                                        ▼
+                                INSERT insight_cards
+                                  source='ai',
+                                  trainer_status='draft'
+                                        │
+                                        ▼
+                          Supabase Realtime → клиент
+                                        │
+                                        ▼
+[Тренер: review/edit/approve/reject]
+                                        │
+                                        ▼
+[Ученик видит approved карточки в /insights]
+```
+
+**Бюджет за тренировку:** ~$0.22 (STT) + ~$0.08 (LLM) = **~$0.30/тренировка**.
+
+---
+
+## 6. Аналоги в мире
+
+- **Fireflies AI / tl;dv** — action items + summary для митингов, нет домена паделя, нет review-flow тренер→ученик.
+- **Otter AI** — транскрипция + highlights, общий домен.
+- **Granola** — AI-нотс встреч, ближайший по UX.
+
+**Differentiator Nivel:** доменная модель (техника/тактика/физика/ментал), интеграция с sessions/goals/students, review-flow тренер→ученик.
+
+---
+
+## 7. Открытые развилки (перед началом эпика)
+
+- **STT-движок**: ElevenLabs Scribe vs Yandex SpeechKit (после pilot-эксперимента).
+- **Async-механика**: Vercel Queues (beta) vs Inngest vs Supabase Edge Functions.
+- **UX загрузки**: drag&drop в карточку session vs отдельная страница `/sessions/[id]/upload` vs запись прямо в PWA.
+- **Tracking прогресса**: polling vs Supabase Realtime vs SSE-стрим.
+- **Регенерация инсайтов**: хранить версии? разрешать тренеру перегенерить с другим промптом?
+- **Включать ли LLM-stage в MVP** или ограничиться только транскриптом + ручные инсайты?
+
+---
+
+## 8. Pilot-эксперимент (2026-05-13) — результаты
+
+Прогнали 58-минутную тренировку (Ваня Куд) через несколько движков. Скрипт: `scripts/transcribe-pilot.mjs`.
+
+### Прогоны
+
+| Версия | Движок | Промпт | Время | Низк.увер. | Заметки |
+|--------|--------|--------|-------|------------|---------|
+| v1     | Groq whisper-large-v3-turbo | старый («Термины: ...») | 28.8s | 97/360 | Фантом «Термины» вылезает в текст |
+| v2-turbo | Groq turbo | новый (без «Термины:») | 14.2s | 35/388 | Галлюцинация «Субтитры создавал DimaTorzok» |
+| v2-large | Groq whisper-large-v3 | новый | 17.6s | 2/260 | Промпт повторяется ×30 раз в тишине (катастрофа) |
+| **v3-noprompt** | **Groq whisper-large-v3** | **пустой** | **12.6s** | **4/630** | **Чисто, с пунктуацией, термины узнаются естественно** |
+| Yandex SpeechKit (для сравнения) | Yandex | — | — | — | Каждая фраза дублируется ×2, нет пунктуации, термины искажены |
+
+### Ключевые выводы
+
+1. **Whisper-prompt — это не glossary, а контекст.** Whisper заполняет тишину фразами из промпта. Использовать промпт **запрещено** или максимум 1-2 слова.
+2. **`whisper-large-v3` без промпта — лучшая конфигурация.** 12 секунд на час аудио, 4 низкоуверенных сегмента из 630.
+3. **Yandex SpeechKit проиграл по всем параметрам** (нет пунктуации, дубли фраз, искажения терминов). Не берём.
+4. **Известная Whisper-галлюцинация на тишине**: «Субтитры сделал DimaTorzok», «Продолжение следует...» — убирается простым regex-фильтром.
+5. **Падел-термины**: частые узнаются (бандеха, чикита, форхенд, бэкхенд, стекло), редкие пропускаются (вибора, глоба, аламбре). Решение — постпроцессинг с fuzzy-match по канонической glossary, а не промпт.
+
+### Финальный выбор для эпика
+
+- **STT**: **Groq `whisper-large-v3`** (без turbo, без промпта)
+- **Цена**: **$0.04/час** на платном Dev tier, **$0** на free tier (до 2 ч аудио/час). На 100 тренировок в месяц = **$4**.
+- **Скорость**: ~12-20 секунд на часовое аудио
+- **Постпроцессинг** (мини-step после STT):
+  - Regex-фильтр известных Whisper-галлюцинаций («Субтитры сделал...», «Продолжение следует», «Подписывайтесь...»)
+  - Fuzzy-match glossary: `бомбех|пандех|бандех` → `бандеха`, `чек-гилл|чикит` → `чикита`, и т.д.
+- **Диаризация — v2** через Replicate (WhisperX + pyannote) когда понадобятся групповые тренировки.
+
+### Артефакты пилота
+
+- `scripts/transcribe-pilot.mjs` — скрипт CLI (Node 25, без зависимостей)
+- `scripts/transcript-to-html.mjs` — рендер verbose_json в HTML с подсветкой неуверенных сегментов
+- Транскрипты в `~/Downloads/29 апр. в 11-05 Ваня Куд.*.{txt,json,html}` (вне репо)
+
+Если качество ElevenLabs устраивает — закладываем в эпик. Иначе пробуем Yandex SpeechKit.

--- a/docs/plans/2026-05-13-epic4-audio-insights.md
+++ b/docs/plans/2026-05-13-epic4-audio-insights.md
@@ -1,0 +1,251 @@
+# Epic 4 — Audio → Insights
+
+**Дата:** 2026-05-13
+**Статус:** план эпика (готов к декомпозиции в GitHub issues)
+**Базовый research:** [`2026-05-13-audio-insights-research.md`](./2026-05-13-audio-insights-research.md)
+
+---
+
+## Цель
+
+После каждой тренировки тренер загружает часовую аудиозапись в Nivel и получает:
+- **MVP:** машинный транскрипт на русском, размеченный по сегментам с таймкодами. Тренер читает транскрипт и **руками** создаёт insight-карточки через существующий inline-adder.
+- **v2:** AI-черновики insight-карточек, которые тренер ревьюит/редактирует/аппрувит.
+- **v3:** диаризация для групповых тренировок.
+
+---
+
+## Решённые архитектурные вопросы
+
+| Вопрос | Решение | Источник |
+|--------|---------|----------|
+| STT-движок | **Groq `whisper-large-v3`** без промпта | Pilot 2026-05-13 (research §8) |
+| Цена/тренировку | ~$0.04 (STT only); ~$0.12 с LLM v2 | research §3 |
+| Скорость | 12–20 сек на 1 ч аудио | Pilot |
+| Vercel 300s timeout | помещается в один route handler (STT < 60s) — **очередь НЕ нужна для MVP** | Pilot |
+| LLM (v2) | `anthropic/claude-sonnet-4.6` через Vercel AI Gateway, `generateObject` + Zod | research §3 |
+| Хранилище аудио | Supabase Storage bucket `session-audio` | research §4 |
+| Постпроцессинг | regex-фильтр Whisper-галлюцинаций + fuzzy-glossary падел-терминов | Pilot |
+
+---
+
+## Архитектура MVP
+
+```
+[Тренер: drag&drop m4a/mp3 на /sessions/[id]]
+        │
+        ▼
+Direct upload → Supabase Storage (session-audio/{session_id}/{uuid}.m4a)
+        │
+        ▼
+Server Action: transcribeSession(sessionId, storagePath)
+   1. Скачать аудио из Storage в memory
+   2. POST → Groq Whisper-large-v3 (~15s)
+   3. Постпроцессинг: фильтр галлюцинаций, glossary
+   4. INSERT transcripts (session_id, raw_text, segments_json, ...)
+        │
+        ▼
+Клиент опрашивает или Realtime → редирект на /sessions/[id]/transcript
+        │
+        ▼
+UI: транскрипт по сегментам с таймкодами,
+   подсветка низкоуверенных, кнопка «создать инсайт из этого фрагмента»
+        │
+        ▼
+[Тренер: выделяет фразу → создаёт insight_card вручную]
+   (используем существующий inline-adder + автозаполнение quote из выделения)
+```
+
+---
+
+## БД-изменения
+
+### Миграция `010_session_transcripts.sql`
+
+```sql
+CREATE TABLE public.transcripts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id      UUID NOT NULL REFERENCES public.sessions(id) ON DELETE CASCADE,
+  storage_path    TEXT NOT NULL,             -- path в bucket session-audio
+  audio_size_bytes BIGINT,
+  duration_seconds INTEGER,
+  raw_text        TEXT NOT NULL,             -- сплошной текст
+  segments_json   JSONB NOT NULL,            -- массив {start, end, text, avg_logprob}
+  stt_provider    TEXT NOT NULL,             -- 'groq-whisper-large-v3'
+  stt_model       TEXT NOT NULL,
+  language        TEXT DEFAULT 'ru',
+  status          TEXT NOT NULL DEFAULT 'ready',  -- 'processing' | 'ready' | 'failed'
+  error_message   TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_transcripts_session ON public.transcripts(session_id);
+
+COMMENT ON TABLE public.transcripts IS 'Транскрипт тренировки — 1:1 с sessions.';
+```
+
+### Storage bucket `session-audio`
+
+- Private (доступ только через signed URLs)
+- Policy: только владелец сессии (тренер) может upload/read
+- TTL подписи: 1 час для upload
+
+---
+
+## Issue breakdown (MVP)
+
+Зависимости показаны стрелками `→`. Issues помеченные `[P]` можно делать параллельно.
+
+### Phase 1 — Foundation
+
+**Issue #M1 [P] — DB: миграция `010_session_transcripts.sql` + Supabase Storage bucket**
+- Создать миграцию (см. выше)
+- Через Management API применить
+- Создать bucket `session-audio` (private)
+- Прописать RLS-эквиваленты или storage policies (наш паттерн — через service role + проверки в app)
+- **Файлы:** `supabase/migrations/010_session_transcripts.sql`
+- **Acceptance:** `SELECT * FROM transcripts LIMIT 0;` работает; bucket виден в dashboard
+
+**Issue #M2 [P] — env: добавить `GROQ_API_KEY`**
+- Добавить переменную в Vercel (preview + prod) и `.env.local.example`
+- Документировать в CLAUDE.md под секцией "ENV переменные"
+- **Файлы:** `.env.local.example`, `CLAUDE.md`
+- **Acceptance:** `process.env.GROQ_API_KEY` доступен в dev
+
+### Phase 2 — Upload UI
+
+**Issue #M3 — Upload-блок на `/sessions/[id]`** → требует #M1
+- Drag&drop зона + кнопка «Загрузить аудио»
+- Валидация: MIME `audio/*`, размер ≤ 100MB
+- Direct upload в Supabase Storage через signed URL (получаем через Server Action `requestAudioUploadUrl`)
+- Progress bar (XHR upload событие)
+- После успеха — тригерим Server Action `transcribeSession`
+- **Файлы:** `src/app/sessions/[id]/page.tsx`, `src/app/sessions/[id]/AudioUploader.tsx` (новый), `src/lib/actions/audio.ts` (новый)
+- **Acceptance:** загрузил файл → видно в Storage → Server Action вызван
+
+### Phase 3 — STT pipeline
+
+**Issue #M4 — Groq STT client + Server Action `transcribeSession`** → требует #M1, #M2, #M3
+- `src/lib/stt/groq.ts` — обёртка над Groq API (модель `whisper-large-v3`, response_format `verbose_json`)
+- Server Action: качает аудио из Storage, шлёт в Groq, инсертит в `transcripts`
+- Перевод `status` через стадии: `processing` → `ready`/`failed`
+- **После успешной транскрипции — удалить файл из Storage** (см. решение #3)
+- Catch и логгирование ошибок Groq (rate limit, file size, etc.)
+- **Файлы:** `src/lib/stt/groq.ts`, `src/lib/actions/audio.ts`
+- **Acceptance:** загрузка часового файла → через ~20 сек в `transcripts` лежит запись со статусом `ready`, файл в Storage удалён
+
+**Issue #M5 [P] — Постпроцессинг транскрипта**
+- `src/lib/stt/postprocess.ts`:
+  - Фильтр известных Whisper-галлюцинаций (regex по списку: «Субтитры сделал.*», «Продолжение следует», «Подписывайтесь...», «DimaTorzok» и т.п.)
+  - Fuzzy-glossary падел-терминов: словарь `{ canonical: [misheard_patterns] }` — `бандеха ← бомбех|пандех|бамдех|...`
+  - Применяется к `raw_text` И к `segments_json[].text` перед сохранением
+- Unit-тесты на фикстурах из пилота (артефакты в `~/Downloads/...v3-noprompt.json`)
+- **Файлы:** `src/lib/stt/postprocess.ts`, `src/lib/stt/glossary.ts`, `src/lib/stt/__tests__/postprocess.test.ts`
+- **Acceptance:** на v3-noprompt.json — нет «Субтитры сделал DimaTorzok», «бомбеху» → «бандеху»
+
+### Phase 4 — Transcript UI
+
+**Issue #M6 — Страница `/sessions/[id]/transcript`** → требует #M4
+- Server Component, читает transcript по `session_id`
+- Три вкладки: «По сегментам» / «Сплошной текст» / «Аудио-плеер»
+- Сегменты с таймкодами, подсветка низкой уверенности (`avg_logprob < -0.6`)
+- Кнопка «Создать инсайт из фрагмента» (выделил текст → открывается inline-adder с pre-filled `quote`)
+- Состояние `processing`: skeleton + опрос статуса каждые 3 секунды (или Supabase Realtime подписка)
+- Состояние `failed`: показать ошибку + кнопку «Попробовать снова»
+- **Файлы:** `src/app/sessions/[id]/transcript/page.tsx`, `src/app/sessions/[id]/transcript/TranscriptView.tsx`
+- **Acceptance:** открыл `/sessions/[id]/transcript` → видишь сегменты → выделил → создал insight-карточку с цитатой
+
+~~**Issue #M7 — Аудио-плеер с синхронизацией сегментов**~~ — **исключено из MVP** (аудио не хранится, см. решение #3).
+
+### Phase 5 — Polish
+
+**Issue #M8 — Кнопка «Re-transcribe»** → требует #M4
+- На странице транскрипта — кнопка «Перетранскрибировать» (если результат не устраивает)
+- Удаляет старый transcript, запускает заново
+- **Файлы:** `src/app/sessions/[id]/transcript/page.tsx`
+
+**Issue #M9 — Удаление транскрипта** → требует #M1
+- Server Action `deleteTranscript(sessionId)`: удаляет запись + файл из Storage
+- Кнопка в UI с подтверждением
+- **Файлы:** `src/lib/actions/audio.ts`
+
+---
+
+## Issue breakdown (v2 — LLM auto-insights)
+
+После MVP, когда транскрипт стабильно работает.
+
+**Issue #V1 — Vercel AI Gateway setup + `@ai-sdk/anthropic` / `ai`**
+- `vercel ai gateway add anthropic`
+- `npm i ai @ai-sdk/anthropic zod`
+- `env`: `AI_GATEWAY_API_KEY`
+- Smoke-test через `generateText`
+
+**Issue #V2 — Zod-схема + промпт `extractInsights(transcript)`**
+- `src/lib/ai/schemas.ts` — `InsightBatchSchema` (см. research §3)
+- `src/lib/ai/prompts.ts` — system prompt с few-shot, теги, обязательная цитата
+- `src/lib/ai/extractInsights.ts` — two-stage prompt chain
+- Unit-тест на одном транскрипте из пилота: ожидаем 5–15 карточек с цитатами
+
+**Issue #V3 — Server Action `generateInsightDrafts(sessionId)`**
+- Дергается после `transcribeSession` (или вручную кнопкой)
+- Пишет insight_cards с `source='ai'`, `trainer_status='draft'`
+- Streaming через `streamObject` для лучшего UX
+
+**Issue #V4 — UI ревью AI-черновиков**
+- На странице сессии — секция «AI-черновики» с карточками `trainer_status='draft'`
+- Кнопки: Approve / Edit / Reject
+- Approve → `trainer_status='approved'`, видно ученику
+- Reject → удаление или `trainer_status='rejected'`
+
+**Issue #V5 — Async-pipeline через Vercel Queues**
+- Если LLM-этап начнёт превышать 60 сек или захотим автоматический trigger after upload — переезд в Queues
+- Step 1: STT, Step 2: postprocess, Step 3: LLM
+
+---
+
+## v3 — Диаризация (отдельный эпик позже)
+
+- Replicate WhisperX / pyannote
+- Speaker labels в `segments_json`
+- UI: фильтр сегментов по спикеру
+- Привязка AI-инсайтов к конкретному ученику (для группы)
+
+---
+
+## Утверждённые решения (2026-05-13)
+
+1. **Один файл на сессию.** Если тренер записал в 2 устройства — мержит руками в аудиоредакторе перед загрузкой.
+2. **Tracking прогресса: polling каждые 3 секунды.** Проще, без настройки Realtime-канала.
+3. **Аудио не хранится.** Удаляется сразу после успешной транскрипции.
+   - Storage используется только как **временный буфер** для передачи файла от клиента к серверу.
+   - Транскрипт (текст в БД) хранится **бессрочно**.
+   - **Последствия:**
+     - На странице транскрипта **нет аудио-плеера** (issue #M7 убирается из MVP).
+     - Re-transcribe (#M8) = перезалить файл заново.
+     - Нулевые затраты на Storage, free план Supabase без давления.
+4. **Лимит размера: 100MB.** Час m4a ≈ 22MB, запас в 5× хватит и на 4 часа.
+5. **Доступ к транскрипту:** только тренер сессии. Ученику — только approved insight_cards.
+
+---
+
+## Roadmap
+
+| Phase | Issues | Оценка | Готов |
+|-------|--------|--------|--------|
+| MVP Foundation | #M1, #M2 | 0.5 дня | — |
+| MVP Upload | #M3 | 1 день | — |
+| MVP STT | #M4, #M5 | 1.5 дня | — |
+| MVP UI | #M6 | 1 день | — |
+| MVP Polish | #M8, #M9 | 0.5 дня | — |
+| **Итого MVP** | **8 issues** | **~4.5 дня** | — |
+| v2 LLM | #V1–#V5 | ~5 дней | после MVP |
+| v3 Diarization | отдельный эпик | — | после первых матчей с группой |
+
+---
+
+## Next step
+
+1. Утвердить план → создать GitHub epic-issue с этим текстом
+2. Декомпозировать на 9 child issues (#M1–#M9), проставить `ready-for-agent` на parallel-friendly (#M1, #M2)
+3. Закоммитить research-doc + pilot scripts в новую ветку, мерджить в main как `docs(plans)`

--- a/scripts/transcribe-pilot.mjs
+++ b/scripts/transcribe-pilot.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Pilot транскрипции одного аудиофайла через Groq Whisper.
+//
+// Запуск:
+//   GROQ_API_KEY=... node scripts/transcribe-pilot.mjs <путь-к-аудио>
+//
+// Опции через env:
+//   MODEL=whisper-large-v3-turbo   (по умолчанию; альтернативы: whisper-large-v3)
+//   LANGUAGE=ru                    (по умолчанию)
+//   FORMAT=verbose_json            (verbose_json | text | srt | vtt)
+//
+// Результат: <basename>.transcript.txt и <basename>.transcript.json рядом с исходником.
+
+import { readFile, writeFile, stat } from "node:fs/promises";
+import { basename, dirname, extname, join } from "node:path";
+
+const apiKey = process.env.GROQ_API_KEY;
+const inputPath = process.argv[2];
+
+if (!apiKey) {
+  console.error("❌ GROQ_API_KEY не задан. Получи ключ на https://console.groq.com и запусти:");
+  console.error("   GROQ_API_KEY=gsk_... node scripts/transcribe-pilot.mjs <файл>");
+  process.exit(1);
+}
+
+if (!inputPath) {
+  console.error("❌ Передай путь к аудиофайлу: node scripts/transcribe-pilot.mjs <файл>");
+  process.exit(1);
+}
+
+const model = process.env.MODEL || "whisper-large-v3-turbo";
+const language = process.env.LANGUAGE || "ru";
+const format = process.env.FORMAT || "verbose_json";
+
+// Промпт-словарь для Whisper. Важно: НЕ начинать с метки типа "Термины:" —
+// Whisper склонен «протекать» начало промпта в транскрипт. Лучше дать естественную
+// фразу с упоминанием слов в разных формах и склонениях.
+const PADEL_PROMPT =
+  "Тренер объясняет ученику технику игры в падел. На корте используются удары " +
+  "бандеха, бандехой, вибора, виборой, смэш, ремате, чикита, чикитой, глоба, " +
+  "лоб, форхенд, бэкхенд, волей, дроп. Игроки бьют ракеткой по мячу через сетку, " +
+  "используют отскок от стекла, играют пала по аламбре, делают контра-парет и " +
+  "дос-парет, выходят к сетке, защищают заднюю линию, ставят байт.";
+
+const overridePrompt = process.env.PROMPT;
+const promptToUse = overridePrompt ?? PADEL_PROMPT;
+
+const stats = await stat(inputPath);
+const sizeMB = (stats.size / 1024 / 1024).toFixed(1);
+console.log(`📁 Файл: ${basename(inputPath)} (${sizeMB} MB)`);
+console.log(`🤖 Модель: ${model}, язык: ${language}`);
+
+if (stats.size > 25 * 1024 * 1024) {
+  console.warn(`⚠️  Файл >25MB — может не пройти на free tier Groq. Dev tier держит до 100MB.`);
+}
+
+const fileBuffer = await readFile(inputPath);
+const fileBlob = new Blob([fileBuffer], { type: "audio/mp4" });
+
+const form = new FormData();
+form.append("file", fileBlob, basename(inputPath));
+form.append("model", model);
+form.append("language", language);
+form.append("response_format", format);
+form.append("prompt", promptToUse);
+form.append("temperature", "0");
+
+console.log("⏳ Отправляю в Groq...");
+const startedAt = Date.now();
+
+const res = await fetch("https://api.groq.com/openai/v1/audio/transcriptions", {
+  method: "POST",
+  headers: { Authorization: `Bearer ${apiKey}` },
+  body: form,
+});
+
+if (!res.ok) {
+  const errText = await res.text();
+  console.error(`❌ Groq API ${res.status}: ${errText}`);
+  process.exit(1);
+}
+
+const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+const suffix = process.env.OUTPUT_SUFFIX || "transcript";
+const dir = dirname(inputPath);
+const stem = basename(inputPath, extname(inputPath));
+const txtPath = join(dir, `${stem}.${suffix}.txt`);
+const jsonPath = join(dir, `${stem}.${suffix}.json`);
+
+if (format === "verbose_json") {
+  const data = await res.json();
+  await writeFile(jsonPath, JSON.stringify(data, null, 2), "utf8");
+  await writeFile(txtPath, data.text ?? "", "utf8");
+  const segments = Array.isArray(data.segments) ? data.segments.length : 0;
+  const duration = typeof data.duration === "number" ? data.duration.toFixed(1) : "?";
+  console.log(`✅ Готово за ${elapsed}s`);
+  console.log(`   Длительность аудио: ${duration}s, сегментов: ${segments}`);
+  console.log(`   Текст:  ${txtPath}`);
+  console.log(`   JSON:   ${jsonPath}`);
+} else {
+  const text = await res.text();
+  await writeFile(txtPath, text, "utf8");
+  console.log(`✅ Готово за ${elapsed}s`);
+  console.log(`   Текст: ${txtPath}`);
+}

--- a/scripts/transcript-to-html.mjs
+++ b/scripts/transcript-to-html.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Конвертирует verbose_json транскрипт Groq/Whisper в одностраничный HTML
+// с таймкодами, цветовой подсветкой неуверенных сегментов и пояснениями.
+//
+// Запуск:
+//   node scripts/transcript-to-html.mjs <path>.transcript.json [output.html]
+
+import { readFile, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join } from "node:path";
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error("Использование: node scripts/transcript-to-html.mjs <file>.transcript.json [out.html]");
+  process.exit(1);
+}
+
+const raw = await readFile(inputPath, "utf8");
+const data = JSON.parse(raw);
+const segments = Array.isArray(data.segments) ? data.segments : [];
+
+const fmtTime = (s) => {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60).toString().padStart(2, "0");
+  return `${m}:${sec}`;
+};
+
+const escapeHtml = (str) =>
+  str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const totalDuration = typeof data.duration === "number" ? data.duration : 0;
+
+const lowConfidence = segments.filter((s) => s.avg_logprob < -0.6).length;
+const veryLow = segments.filter((s) => s.avg_logprob < -1.0).length;
+
+const segmentsHtml = segments
+  .map((s) => {
+    const text = escapeHtml((s.text ?? "").trim());
+    const cls = s.avg_logprob < -1.0 ? "seg low" : s.avg_logprob < -0.6 ? "seg mid" : "seg";
+    const conf = (s.avg_logprob ?? 0).toFixed(2);
+    return `<div class="${cls}" data-conf="${conf}"><span class="ts">${fmtTime(s.start)}</span><span class="txt">${text}</span></div>`;
+  })
+  .join("\n");
+
+const fullText = segments.map((s) => (s.text ?? "").trim()).join(" ");
+
+const html = `<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<title>Транскрипт — ${escapeHtml(basename(inputPath, ".json"))}</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+         max-width: 860px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; color: #1a1a1a; background: #fafafa; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0f0f10; color: #e6e6e6; }
+    header { border-color: #2a2a2a !important; }
+    .meta { color: #888 !important; }
+    .seg .ts { color: #888 !important; }
+    .seg.mid { background: rgba(255, 200, 0, 0.10) !important; }
+    .seg.low { background: rgba(255, 80, 80, 0.15) !important; }
+    .tab { background: #1a1a1a; color: #e6e6e6; border-color: #333; }
+    .tab.active { background: #2a2a2a; }
+    .toolbar { border-color: #2a2a2a; }
+    pre { background: #1a1a1a; color: #e6e6e6; }
+  }
+  header { border-bottom: 1px solid #e0e0e0; padding-bottom: 1rem; margin-bottom: 1.5rem; }
+  h1 { margin: 0 0 0.5rem; font-size: 1.4rem; }
+  .meta { color: #666; font-size: 0.9rem; }
+  .meta b { color: inherit; }
+  .toolbar { display: flex; gap: 0.5rem; padding: 0.75rem 0; border-bottom: 1px solid #e0e0e0; margin-bottom: 1rem; position: sticky; top: 0; background: inherit; z-index: 10; }
+  .tab { padding: 0.4rem 0.9rem; border: 1px solid #ddd; border-radius: 6px; background: #fff; cursor: pointer; font-size: 0.9rem; }
+  .tab.active { background: #1a1a1a; color: #fff; border-color: #1a1a1a; }
+  .tab:hover { opacity: 0.85; }
+  .view { display: none; }
+  .view.active { display: block; }
+  .seg { display: flex; gap: 0.75rem; padding: 0.3rem 0.5rem; border-radius: 4px; margin-bottom: 0.15rem; }
+  .seg .ts { color: #999; font-variant-numeric: tabular-nums; flex-shrink: 0; width: 3.5rem; font-size: 0.85rem; padding-top: 0.15rem; }
+  .seg .txt { flex: 1; }
+  .seg.mid { background: rgba(255, 180, 0, 0.10); }
+  .seg.low { background: rgba(255, 80, 80, 0.10); }
+  .seg.mid::after, .seg.low::after { content: attr(data-conf); color: #aaa; font-size: 0.75rem; align-self: flex-start; padding-top: 0.2rem; }
+  pre { white-space: pre-wrap; word-wrap: break-word; background: #fff; padding: 1rem; border-radius: 6px; border: 1px solid #e0e0e0; }
+  .legend { font-size: 0.85rem; color: #777; margin-bottom: 1rem; }
+  .legend span { padding: 1px 6px; border-radius: 3px; margin: 0 4px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>${escapeHtml(basename(inputPath, ".transcript.json"))}</h1>
+  <div class="meta">
+    Длительность: <b>${fmtTime(totalDuration)}</b> ·
+    Сегментов: <b>${segments.length}</b> ·
+    Модель: <b>${escapeHtml(data.model ?? "—")}</b> ·
+    Язык: <b>${escapeHtml(data.language ?? "ru")}</b> ·
+    Низкая уверенность: <b>${lowConfidence}</b> · Очень низкая: <b>${veryLow}</b>
+  </div>
+</header>
+
+<div class="toolbar">
+  <button class="tab active" data-view="segments">По сегментам</button>
+  <button class="tab" data-view="plain">Сплошной текст</button>
+  <button class="tab" data-view="raw">JSON</button>
+</div>
+
+<div class="legend">
+  <span style="background: rgba(255,180,0,0.10)">желтое</span> — средняя уверенность (avg_logprob &lt; -0.6) ·
+  <span style="background: rgba(255,80,80,0.10)">красное</span> — низкая уверенность (&lt; -1.0)
+</div>
+
+<div class="view active" id="view-segments">
+  ${segmentsHtml}
+</div>
+
+<div class="view" id="view-plain">
+  <pre>${escapeHtml(fullText)}</pre>
+</div>
+
+<div class="view" id="view-raw">
+  <pre>${escapeHtml(JSON.stringify(data, null, 2))}</pre>
+</div>
+
+<script>
+  document.querySelectorAll(".tab").forEach((tab) => {
+    tab.addEventListener("click", () => {
+      document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"));
+      document.querySelectorAll(".view").forEach((v) => v.classList.remove("active"));
+      tab.classList.add("active");
+      document.getElementById("view-" + tab.dataset.view).classList.add("active");
+    });
+  });
+</script>
+</body>
+</html>
+`;
+
+const outArg = process.argv[3];
+const dir = dirname(inputPath);
+const stem = basename(inputPath, extname(inputPath)).replace(/\.transcript$/, "");
+const outPath = outArg || join(dir, `${stem}.transcript.html`);
+
+await writeFile(outPath, html, "utf8");
+console.log(`✅ HTML: ${outPath}`);
+console.log(`   ${segments.length} сегментов, ${lowConfidence} среднеуверенных, ${veryLow} низкоуверенных`);


### PR DESCRIPTION
## Что внутри

Research + план для **Epic 4: Audio → Insights** — тренер загружает часовое аудио тренировки, получает транскрипт и (в v2) AI-черновики insight-карточек.

### Pilot 2026-05-13 — выбор STT

Прогнал реальную 58-минутную тренировку через несколько движков:

| Движок | Время | Цена/час | Качество |
|--------|-------|----------|----------|
| **Groq whisper-large-v3** (без промпта) | 12s | $0 (free) / $0.04 | 🏆 |
| Groq whisper-large-v3-turbo | 14s | $0.02 | хорошо |
| Yandex SpeechKit | — | $0.18 | ❌ нет пунктуации, дубли фраз ×2 |

**Вывод**: Groq `whisper-large-v3` — лучший выбор. Дёшево, быстро, читаемо.

### Утверждённые решения

1. STT: Groq whisper-large-v3 без промпта + постпроцессинг (glossary + фильтр галлюцинаций)
2. Аудио **не хранится** — удаляется после транскрипции (Supabase Free план)
3. Polling для tracking прогресса
4. Один файл на сессию, лимит 100MB

### MVP-скоуп

8 issues на ~4.5 дня. Тренер загружает аудио → видит транскрипт → **вручную** создаёт insight-карточки из выделенных фрагментов через существующий inline-adder.

LLM-генерация инсайтов — v2 после MVP.

## Что мерджится

- `docs/plans/2026-05-13-audio-insights-research.md` — research-doc
- `docs/plans/2026-05-13-epic4-audio-insights.md` — план эпика с issue breakdown
- `scripts/transcribe-pilot.mjs` — pilot CLI для Groq STT
- `scripts/transcript-to-html.mjs` — рендер verbose_json в HTML

Кода продакта не трогает — только docs + dev-скрипты.

## Test plan

- [ ] Прочитать research, проверить что цена/качество корректные
- [ ] Прочитать epic-план, проверить что MVP scope понятен
- [ ] (Опционально) запустить pilot: `GROQ_API_KEY=... node scripts/transcribe-pilot.mjs <file.m4a>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)