### PR TITLE
fix(playtomic): accept /profile/user/ singular path

### DIFF
--- a/src/lib/actions/playtomic.ts
+++ b/src/lib/actions/playtomic.ts
@@ -27,7 +27,7 @@ export async function connectPlaytomicProfile(
     return {
       success: false,
       error:
-        "Не удалось распознать ссылку. Ожидается: https://app.playtomic.io/profile/users/…",
+        "Не удалось распознать ссылку. Ожидается: https://app.playtomic.io/profile/user/…",
     };
   }
 

--- a/src/lib/playtomic/client.ts
+++ b/src/lib/playtomic/client.ts
@@ -14,13 +14,13 @@ export interface PlaytomicMatch {
 
 /**
  * Extracts user_id from Playtomic profile URL.
- * Supports both numeric IDs (e.g. "5536921") and UUIDs.
- * Example: https://app.playtomic.io/profile/users/5536921
+ * Supports both numeric IDs and UUIDs.
+ * Both /profile/users/{id} (web) and /profile/user/{id} (Android share) are accepted.
  */
 export function parseProfileUrl(url: string): string | null {
   try {
     const parsed = new URL(url);
-    const match = parsed.pathname.match(/\/profile\/users\/([^/?#]+)/);
+    const match = parsed.pathname.match(/\/profile\/users?\/([^/?#]+)/);
     return match ? match[1] : null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
Android share links отдают `https://app.playtomic.io/profile/user/{id}?...` (без `s`), а наш парсер ожидал только `users`. Регекс `\/profile\/users?\/` теперь допускает оба варианта; user-facing error и placeholder обновлены.

Проверено вручную: `parseProfileUrl` корректно вытаскивает id из обеих форм.

🤖 Generated with [Claude Code](https://claude.com/claude-code)