### PR TITLE
feat(#82): transcripts table + session-audio bucket (Epic 4 M1)

### DIFF
--- a/supabase/migrations/010_session_transcripts.sql
+++ b/supabase/migrations/010_session_transcripts.sql
@@ -1,0 +1,21 @@
+CREATE TABLE public.transcripts (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id      UUID NOT NULL REFERENCES public.sessions(id) ON DELETE CASCADE,
+  storage_path    TEXT,                          -- путь в bucket; NULL после удаления аудио
+  audio_size_bytes BIGINT,
+  duration_seconds INTEGER,
+  raw_text        TEXT NOT NULL,
+  segments_json   JSONB NOT NULL,
+  stt_provider    TEXT NOT NULL,
+  stt_model       TEXT NOT NULL,
+  language        TEXT DEFAULT 'ru',
+  status          TEXT NOT NULL DEFAULT 'processing',
+  error_message   TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_transcripts_session ON public.transcripts(session_id);
+
+COMMENT ON TABLE public.transcripts IS 'Транскрипт тренировки — 1:1 с sessions.';
+COMMENT ON COLUMN public.transcripts.storage_path IS 'Путь к аудио в Storage; NULL после успешной транскрипции и удаления файла.';
+COMMENT ON COLUMN public.transcripts.status IS 'processing | ready | failed';


### PR DESCRIPTION
Closes #82

## Что сделано

- Создан `supabase/migrations/010_session_transcripts.sql` с таблицей `transcripts` (1:1 с sessions, CASCADE delete, unique index на session_id, статусы processing/ready/failed)
- Миграция применена через Supabase Management API
- Создан private Storage bucket `session-audio` через Supabase Storage REST API

## Файлы

- `supabase/migrations/010_session_transcripts.sql` — новая миграция

## Проверка

- `SELECT 1 FROM transcripts LIMIT 0` — ОК (пустой результат)
- `GET /v1/projects/gqcyaxxhvyvpzuhoysis/storage/buckets` — возвращает `session-audio` с `public: false`

---
_Generated by [Claude Code](https://claude.ai/code/session_011vxh5oFhozvkbMjx7vqtK7)_