### PR TITLE
feat(#89): deleteTranscript action + /sessions/[id]/transcript stub (Epic 4 M9)

### DIFF
--- a/src/app/sessions/[id]/transcript/DeleteTranscriptButton.tsx
+++ b/src/app/sessions/[id]/transcript/DeleteTranscriptButton.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTransition } from "react";
+import { deleteTranscript } from "@/lib/actions/audio";
+
+export function DeleteTranscriptButton({ sessionId }: { sessionId: string }) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    if (!confirm("Удалить транскрипт? Это действие нельзя отменить.")) return;
+    startTransition(() => {
+      void deleteTranscript(sessionId);
+    });
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isPending}
+      className="text-xs text-red-400 font-bold uppercase tracking-wider disabled:opacity-50"
+    >
+      {isPending ? "Удаление…" : "Удалить транскрипт"}
+    </button>
+  );
+}

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -1,0 +1,74 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import Link from "next/link";
+import { DeleteTranscriptButton } from "./DeleteTranscriptButton";
+
+export default async function TranscriptPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = await getSession();
+  if (!user || user.role !== "trainer") redirect("/dashboard");
+
+  const supabase = await createClient();
+
+  const { data: transcript } = await supabase
+    .from("transcripts")
+    .select("status, error_message, created_at")
+    .eq("session_id", id)
+    .maybeSingle();
+
+  if (!transcript) redirect(`/sessions/${id}`);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
+        <Link href={`/sessions/${id}`} className="text-on-surface-variant">
+          <span className="material-symbols-outlined">arrow_back</span>
+        </Link>
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
+          Транскрипт
+        </span>
+        <div className="w-10" />
+      </header>
+
+      <main className="px-5 pt-6 pb-36 max-w-[430px] mx-auto space-y-6">
+        {transcript.status === "processing" && (
+          <div className="rounded-3xl bg-surface-card p-6 text-center space-y-2">
+            <span className="material-symbols-outlined text-4xl text-primary block">hourglass_top</span>
+            <p className="text-sm font-bold text-on-surface">Транскрипция в процессе…</p>
+            <p className="text-xs text-on-surface-variant">Обновите страницу через 15–30 секунд</p>
+          </div>
+        )}
+
+        {transcript.status === "failed" && (
+          <div className="rounded-3xl bg-surface-card p-6 space-y-2">
+            <p className="text-sm font-bold text-red-400">Ошибка транскрипции</p>
+            {transcript.error_message && (
+              <p className="text-xs text-on-surface-variant font-mono">{transcript.error_message}</p>
+            )}
+            <p className="text-xs text-on-surface-variant mt-3">
+              Удалите транскрипт и загрузите аудио заново.
+            </p>
+          </div>
+        )}
+
+        {transcript.status === "ready" && (
+          <div className="rounded-3xl bg-surface-card p-6 space-y-2">
+            <p className="text-sm font-bold text-primary">Транскрипт готов</p>
+            <p className="text-xs text-on-surface-variant">
+              Полный просмотр появится в следующем обновлении.
+            </p>
+          </div>
+        )}
+
+        <div className="pt-4 border-t border-border-dim flex justify-center">
+          <DeleteTranscriptButton sessionId={id} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -1,0 +1,125 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { getSession } from "@/lib/auth/session";
+import { revalidatePath } from "next/cache";
+import { randomUUID } from "crypto";
+import { redirect } from "next/navigation";
+
+async function requireTrainerOwnsSession(sessionId: string) {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+
+  const supabase = await createClient();
+
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, goals(user_id)")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session) return null;
+
+  const goal = session.goals as unknown as { user_id: string } | null;
+  if (!goal) return null;
+
+  const { data: studentProfile } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", goal.user_id)
+    .eq("created_by", user.id)
+    .maybeSingle();
+
+  if (!studentProfile) return null;
+
+  return { user, supabase };
+}
+
+export async function requestAudioUploadUrl(
+  sessionId: string,
+  ext = "m4a"
+): Promise<{ uploadUrl: string; storagePath: string } | { error: string }> {
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return { error: "Forbidden" };
+
+  const { supabase } = ctx;
+  const storagePath = `${sessionId}/${randomUUID()}.${ext}`;
+
+  const { data, error } = await supabase.storage
+    .from("session-audio")
+    .createSignedUploadUrl(storagePath);
+
+  if (error || !data) return { error: error?.message ?? "Failed to create upload URL" };
+
+  return { uploadUrl: data.signedUrl, storagePath };
+}
+
+export async function transcribeSession(
+  sessionId: string,
+  storagePath: string
+): Promise<{ success: boolean; error?: string }> {
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return { success: false, error: "Forbidden" };
+
+  const { supabase } = ctx;
+
+  // M4 will replace this stub with real Groq STT logic.
+  const { error } = await supabase.from("transcripts").upsert(
+    {
+      session_id: sessionId,
+      storage_path: storagePath,
+      raw_text: "",
+      segments_json: [],
+      stt_provider: "groq",
+      stt_model: "whisper-large-v3",
+      status: "processing",
+    },
+    { onConflict: "session_id" }
+  );
+
+  if (error) return { success: false, error: error.message };
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true };
+}
+
+export async function getTranscriptStatus(
+  sessionId: string
+): Promise<{ status: string; error_message: string | null } | null> {
+  const user = await getSession();
+  if (!user) return null;
+
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("transcripts")
+    .select("status, error_message")
+    .eq("session_id", sessionId)
+    .maybeSingle();
+
+  return data ? { status: data.status, error_message: data.error_message } : null;
+}
+
+export async function deleteTranscript(sessionId: string): Promise<void> {
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return;
+
+  const { supabase } = ctx;
+
+  // If there's a leftover storage file (upload failed mid-transcription), clean it up.
+  const { data: existing } = await supabase
+    .from("transcripts")
+    .select("storage_path")
+    .eq("session_id", sessionId)
+    .maybeSingle();
+
+  if (existing?.storage_path) {
+    await supabase.storage.from("session-audio").remove([existing.storage_path]);
+  }
+
+  await supabase.from("transcripts").delete().eq("session_id", sessionId);
+
+  revalidatePath(`/sessions/${sessionId}`);
+  revalidatePath(`/sessions/${sessionId}/transcript`);
+  redirect(`/sessions/${sessionId}`);
+}


### PR DESCRIPTION
Closes #89

## Что сделано

- **`src/lib/actions/audio.ts`** — новый файл с Server Actions:
  - `deleteTranscript(sessionId)` — trainer-only, удаляет Storage-файл если `storage_path != NULL`, удаляет запись из `transcripts`, редиректит на `/sessions/[id]`
  - Общий хелпер `requireTrainerOwnsSession` (через `profiles.created_by`)
  - Также включает стабы из M3 (#85): `requestAudioUploadUrl`, `transcribeSession`, `getTranscriptStatus` — _коллизия с PR #94 при мерже, нужно будет разрешить_
- **`src/app/sessions/[id]/transcript/DeleteTranscriptButton.tsx`** — client component с `confirm()` + `useTransition`
- **`src/app/sessions/[id]/transcript/page.tsx`** — минимальная страница транскрипта: статус (processing/failed/ready) + кнопка «Удалить транскрипт». M6 (#87) добавит полный вид по сегментам.

## Файлы

- `src/lib/actions/audio.ts` — новый
- `src/app/sessions/[id]/transcript/DeleteTranscriptButton.tsx` — новый
- `src/app/sessions/[id]/transcript/page.tsx` — новый

## ⚠️ Конфликт с PR #94 (M3)

Оба PR создают `src/lib/actions/audio.ts`. При мерже нужно объединить:
- из #94: `requestAudioUploadUrl`, `transcribeSession`, `getTranscriptStatus`  
- из этого PR: `deleteTranscript`, `requireTrainerOwnsSession`

Рекомендую смержить #94 первым.

## Проверка

- `npx tsc --noEmit` — ✅ чисто
- Открыть `/sessions/[id]/transcript` — страница рендерится
- Нажать «Удалить транскрипт» → подтверждение → запись в `transcripts` исчезает → редирект на `/sessions/[id]` → снова виден uploader

---
_Generated by [Claude Code](https://claude.ai/code/session_011vxh5oFhozvkbMjx7vqtK7)_