### PR TITLE
fix(ui): mobile-first polish — 5 UX fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,13 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+# Mobile-first
+
+Nivel — **mobile-first** сервис. Любая страница, компонент, модалка, форма проектируется под мобильный viewport (∼390px) в первую очередь. Десктоп — производное.
+
+- Контейнеры ограничивай `max-w-[430px]`, центрируй.
+- Тач-зоны ≥ 44px, не полагайся на `:hover`.
+- Модалки/sheet'ы используй bottom-sheet pattern (через portal, чтобы не застревать в `transform`-контексте родителя). Не открывай обычные центрированные диалоги.
+- Длинные горизонтальные списки (карусели) делай с `overflow-x-auto` + `snap-x snap-mandatory`, не вертикальный stack.
+- Шрифты, отступы, иконки выбирай под палец, не курсор. Проверяй на узком экране до того как зафиксировать дизайн.

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -161,7 +161,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
                     {t(locale, "dashboard.upcomingEmpty")}
                   </p>
                 ) : (
-                  <div className="space-y-2">
+                  <div className="-mx-4 px-4 flex gap-3 overflow-x-auto snap-x snap-mandatory scroll-px-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                     {allItems.map((item) => {
                       if (item.kind === "session") {
                         const dateStr = item.scheduled_at
@@ -171,20 +171,19 @@ export default function DashboardView({ data, locale, editable }: Props) {
                           <Link
                             key={`session-${item.id}`}
                             href={`/sessions/${item.id}`}
-                            className="flex items-center gap-4 bg-surface-low rounded-2xl px-4 py-3.5 active:bg-surface-card transition-colors"
+                            className="snap-start shrink-0 w-[78%] flex flex-col gap-3 bg-surface-low rounded-2xl px-4 py-4 active:bg-surface-card transition-colors"
                           >
-                            <div className="w-10 h-10 rounded-xl bg-surface-card text-primary flex items-center justify-center font-black text-sm flex-shrink-0">
+                            <div className="w-10 h-10 rounded-xl bg-surface-card text-primary flex items-center justify-center font-black text-sm">
                               {item.session_number}
                             </div>
-                            <div className="flex-1 min-w-0">
+                            <div className="min-w-0">
                               <p className="font-semibold text-sm">
                                 {t(locale, "dashboard.session")} {item.session_number}
                               </p>
                               {dateStr && (
-                                <p className="text-[11px] text-on-surface-variant">{dateStr}</p>
+                                <p className="text-[11px] text-on-surface-variant mt-0.5">{dateStr}</p>
                               )}
                             </div>
-                            <span className="material-symbols-outlined text-on-surface-variant opacity-40 text-base">chevron_right</span>
                           </Link>
                         );
                       }
@@ -199,31 +198,30 @@ export default function DashboardView({ data, locale, editable }: Props) {
                         <Link
                           key={`match-${item.id}`}
                           href={`/matches/${item.id}`}
-                          className="flex items-center gap-4 bg-surface-low rounded-2xl px-4 py-3.5 active:bg-surface-card transition-colors"
+                          className="snap-start shrink-0 w-[78%] flex flex-col gap-3 bg-surface-low rounded-2xl px-4 py-4 active:bg-surface-card transition-colors"
                         >
-                          <div className="w-10 h-10 rounded-xl bg-primary/15 text-primary flex items-center justify-center flex-shrink-0">
+                          <div className="w-10 h-10 rounded-xl bg-primary/15 text-primary flex items-center justify-center">
                             <span className="material-symbols-outlined text-[20px]">sports_tennis</span>
                           </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="font-semibold text-sm">
+                          <div className="min-w-0">
+                            <p className="font-semibold text-sm truncate">
                               {t(locale, "dashboard.upcomingMatch")}
                               {item.location ? ` · ${item.location}` : ""}
                             </p>
-                            <p className="text-[11px] text-on-surface-variant">
+                            <p className="text-[11px] text-on-surface-variant mt-0.5">
                               {dateStr}
                               {item.resource_name ? ` · ${item.resource_name}` : ""}
                             </p>
                             {item.goalsCount > 0 ? (
-                              <p className="text-[10px] text-primary font-bold mt-0.5">
+                              <p className="text-[10px] text-primary font-bold mt-1">
                                 {item.goalsCount} {t(locale, "matches.goalsCount")}
                               </p>
                             ) : (
-                              <p className="text-[10px] text-on-surface-variant mt-0.5">
+                              <p className="text-[10px] text-on-surface-variant mt-1">
                                 {t(locale, "matches.setGoals")}
                               </p>
                             )}
                           </div>
-                          <span className="material-symbols-outlined text-on-surface-variant opacity-40 text-base">chevron_right</span>
                         </Link>
                       );
                     })}

--- a/src/components/insights/UseAtMatchModal.tsx
+++ b/src/components/insights/UseAtMatchModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
 import { attachInsightToMatch } from "@/lib/actions/playtomic";
 import { t } from "@/lib/i18n/dict";
 import type { Locale } from "@/lib/i18n/dict";
@@ -34,6 +35,11 @@ export default function UseAtMatchModal({ insightId, locale, upcomingMatches }: 
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [attached, setAttached] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   function handleOpen() {
     setSelectedMatchId(null);
@@ -82,13 +88,14 @@ export default function UseAtMatchModal({ insightId, locale, upcomingMatches }: 
           : t(locale, "insights.useAtMatch")}
       </button>
 
-      {open && (
+      {open && mounted && createPortal(
         <div
-          className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm px-4 pb-8"
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm"
           onClick={handleClose}
         >
           <div
-            className="w-full max-w-[430px] bg-surface-card rounded-3xl p-6 space-y-4 max-h-[80vh] flex flex-col"
+            className="w-full max-w-[430px] bg-surface-card rounded-t-3xl p-6 space-y-4 max-h-[85vh] flex flex-col"
+            style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1.5rem)" }}
             onClick={(e) => e.stopPropagation()}
           >
             <p className="text-sm font-black uppercase tracking-widest text-on-surface shrink-0">
@@ -160,7 +167,8 @@ export default function UseAtMatchModal({ insightId, locale, upcomingMatches }: 
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -38,7 +38,7 @@ const tabs: Tab[] = [
     icon: "sports_tennis",
     href: "/matches",
     match: (p) => p.startsWith("/matches"),
-    roles: ["student"],
+    roles: ["student", "trainer"],
   },
 ];
 

--- a/src/components/playtomic/PlaytomicConnectBlock.tsx
+++ b/src/components/playtomic/PlaytomicConnectBlock.tsx
@@ -19,27 +19,8 @@ export default function PlaytomicConnectBlock({ currentUserId }: Props) {
   const [url, setUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  // Already connected — show masked id
-  if (currentUserId) {
-    const masked =
-      currentUserId.length > 6
-        ? currentUserId.slice(0, 3) + "•••" + currentUserId.slice(-3)
-        : currentUserId;
-
-    return (
-      <div className="bg-surface-card rounded-2xl p-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-primary mb-0.5">
-              Playtomic подключён
-            </p>
-            <p className="text-sm text-on-surface-variant font-mono">{masked}</p>
-          </div>
-          <span className="material-symbols-outlined text-primary text-2xl">check_circle</span>
-        </div>
-      </div>
-    );
-  }
+  // Already connected — hide the block entirely (status moved to /matches & profile settings)
+  if (currentUserId) return null;
 
   function handleConnect() {
     setError(null);
@@ -67,7 +48,7 @@ export default function PlaytomicConnectBlock({ currentUserId }: Props) {
         type="url"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
-        placeholder="https://app.playtomic.io/profile/users/…"
+        placeholder="https://app.playtomic.io/profile/user/…"
         className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
         disabled={isPending}
       />

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -41,8 +41,8 @@ const ru = {
   "dashboard.emptyHint":
     "Начните с создания первой цели — выберите проблемы, над которыми хотите работать.",
   "dashboard.createGoal": "Создать цель",
-  "dashboard.insightsToReview": "новых карточек на разбор",
-  "dashboard.insightsToReview.one": "новая карточка на разбор",
+  "dashboard.insightsToReview": "карточек на разбор",
+  "dashboard.insightsToReview.one": "карточка на разбор",
   "dashboard.fromSession": "По сессии",
   "dashboard.andMore": "и ещё",
   "dashboard.masterPlan": "Мастер-план",
@@ -198,8 +198,8 @@ const en: Record<keyof typeof ru, string> = {
   "dashboard.emptyHint":
     "Start by creating your first goal — pick the problems you want to work on.",
   "dashboard.createGoal": "Create goal",
-  "dashboard.insightsToReview": "new insights to review",
-  "dashboard.insightsToReview.one": "new insight to review",
+  "dashboard.insightsToReview": "insights to review",
+  "dashboard.insightsToReview.one": "insight to review",
   "dashboard.fromSession": "From session",
   "dashboard.andMore": "and",
   "dashboard.masterPlan": "Master Plan",


### PR DESCRIPTION
## Summary
Серия мелких UI-фиксов после ручного теста на мобиле + фиксация **mobile-first** как rule в AGENTS.md.

1. **AGENTS.md:** добавлен раздел Mobile-first — все компоненты проектируем под ~390px, модалки = bottom-sheet через portal, горизонтальные наборы = scroll-snap карусель, не вертикальный stack.
2. **PlaytomicConnectBlock:** после подключения блок просто исчезает с главной (вместо «PLAYTOMIC ПОДКЛЮЧЁН 107•••968»). Плюс placeholder теперь `/profile/user/…` (соответствует Android share-формату, который мы фиксили в #90).
3. **i18n:** убрано «новых» / «new» из `dashboard.insightsToReview` (RU + EN).
4. **BottomNav:** таб «Матчи» теперь видим и для student, и для trainer (раньше был student-only — у тестового тренерского аккаунта пропадал).
5. **Dashboard → блок «Актуальное»:** превращён в горизонтальную свайп-карусель (`overflow-x-auto` + `snap-x snap-mandatory`). Карточки шире (`w-[78%]`), показывают типовую инфо без horizontal cramming.
6. **UseAtMatchModal:** рендер через `createPortal(…, document.body)`. Корень `<VaultGrid>` использует 3D-flip с `transform: rotateY(…)`, и `position: fixed` без портала «застревал» в этом контексте — модалка прилипала к карточке, а не к viewport. Это и есть кривая картинка из репорта.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Открыть `/insights`, перевернуть карточку, нажать «Использовать на игре» — модалка теперь покрывает весь экран снизу.
- [ ] На `/dashboard` блок «Актуальное» свайпается влево-вправо.
- [ ] Подключить Playtomic → редирект на `/matches` → вернуться на `/dashboard`, блока подключения нет.
- [ ] BottomNav: 3 таба (Главная / Карточки / Матчи).

🤖 Generated with [Claude Code](https://claude.com/claude-code)