### PR TITLE
feat(audio): Upload UI + auth fixes (supersedes #94)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -279,28 +280,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -521,6 +500,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
       "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
@@ -587,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
       "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
@@ -603,6 +584,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
       "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.0"
       }
@@ -1056,6 +1038,7 @@
       "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2331,6 +2314,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.101.1.tgz",
       "integrity": "sha512-Jnhm3LfuACwjIzvk2pfUbGQn7pa7hi6MFzfSyPrRYWVCCu69RPLCFyHSBl7HSBwadbQ3UZOznnD3gPca3ePrRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.101.1",
         "@supabase/functions-js": "2.101.1",
@@ -2687,6 +2671,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2755,6 +2740,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3393,6 +3379,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3754,6 +3741,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4363,6 +4351,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4548,6 +4537,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6906,6 +6896,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6915,6 +6906,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7739,6 +7731,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7911,6 +7904,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8499,6 +8493,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import { getLocale } from "@/lib/i18n";
 import Link from "next/link";
 import type { InsightCard } from "@/lib/types";
+import { AudioUploader } from "@/components/sessions/AudioUploader";
 
 export default async function SessionDetailPage({
   params,
@@ -58,6 +59,12 @@ export default async function SessionDetailPage({
       exercises.flatMap((e) => e.skills).map((s) => [s.id, s])
     ).values(),
   ];
+
+  const { data: transcript } = await supabase
+    .from("transcripts")
+    .select("status")
+    .eq("session_id", id)
+    .maybeSingle();
 
   const { data: cards } = await supabase
     .from("insight_cards")
@@ -152,6 +159,43 @@ export default async function SessionDetailPage({
                 </span>
               ))}
             </div>
+          </section>
+        )}
+
+        {isTrainer && (
+          <section>
+            {transcript ? (
+              <div className="space-y-3">
+                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+                  {isRu ? "Аудио тренировки" : "Session audio"}
+                </p>
+                <Link
+                  href={`/sessions/${id}/transcript`}
+                  className="flex items-center gap-3 rounded-2xl bg-surface-card p-4 border border-border-dim"
+                >
+                  <span className="material-symbols-outlined text-primary">description</span>
+                  <div>
+                    <p className="text-sm font-bold text-on-surface">
+                      {transcript.status === "ready"
+                        ? isRu ? "Открыть транскрипт" : "Open transcript"
+                        : transcript.status === "processing"
+                        ? isRu ? "Транскрипция…" : "Transcribing…"
+                        : isRu ? "Ошибка транскрипции" : "Transcription failed"}
+                    </p>
+                    <p className="text-xs text-on-surface-variant mt-0.5">
+                      {transcript.status === "processing"
+                        ? isRu ? "Обычно занимает 15–30 сек" : "Usually takes 15–30 sec"
+                        : ""}
+                    </p>
+                  </div>
+                  <span className="material-symbols-outlined text-on-surface-variant ml-auto">
+                    chevron_right
+                  </span>
+                </Link>
+              </div>
+            ) : (
+              <AudioUploader sessionId={id} />
+            )}
           </section>
         )}
 

--- a/src/components/sessions/AudioUploader.tsx
+++ b/src/components/sessions/AudioUploader.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { requestAudioUploadUrl, transcribeSession } from "@/lib/actions/audio";
+
+type UploadState = "idle" | "uploading" | "processing" | "done" | "error";
+
+export function AudioUploader({ sessionId }: { sessionId: string }) {
+  const [state, setState] = useState<UploadState>("idle");
+  const [progress, setProgress] = useState(0);
+  const [errorMsg, setErrorMsg] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFile(file: File) {
+    if (!file.type.startsWith("audio/")) {
+      setErrorMsg("Только аудио-файлы (m4a, mp3, wav…)");
+      setState("error");
+      return;
+    }
+    if (file.size > 100 * 1024 * 1024) {
+      setErrorMsg("Файл слишком большой — максимум 100 MB");
+      setState("error");
+      return;
+    }
+
+    setState("uploading");
+    setProgress(0);
+    setErrorMsg("");
+
+    const ext = file.name.split(".").pop()?.toLowerCase() ?? "m4a";
+    const urlResult = await requestAudioUploadUrl(sessionId, ext);
+    if ("error" in urlResult) {
+      setState("error");
+      setErrorMsg(urlResult.error);
+      return;
+    }
+
+    const { uploadUrl, storagePath } = urlResult;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("PUT", uploadUrl);
+        xhr.setRequestHeader("Content-Type", file.type);
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) setProgress(Math.round((e.loaded / e.total) * 100));
+        };
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) resolve();
+          else reject(new Error(`Upload failed (${xhr.status})`));
+        };
+        xhr.onerror = () => reject(new Error("Сетевая ошибка при загрузке"));
+        xhr.send(file);
+      });
+    } catch (err: unknown) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : "Ошибка загрузки");
+      return;
+    }
+
+    setState("processing");
+    const transcribeResult = await transcribeSession(sessionId, storagePath);
+    if (!transcribeResult.success) {
+      setState("error");
+      setErrorMsg(transcribeResult.error ?? "Ошибка запуска транскрипции");
+      return;
+    }
+    setState("done");
+  }
+
+  function onDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) void handleFile(file);
+  }
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) void handleFile(file);
+  }
+
+  if (state === "done") {
+    return (
+      <div className="rounded-3xl bg-surface-card p-5 text-center space-y-1">
+        <p className="text-sm font-bold text-primary">Аудио загружено — транскрипция запущена</p>
+        <p className="text-xs text-on-surface-variant">Обычно занимает 15–30 секунд.</p>
+      </div>
+    );
+  }
+
+  const isActive = state === "uploading" || state === "processing";
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+        Аудио тренировки
+      </p>
+      <div
+        onDrop={onDrop}
+        onDragOver={(e) => e.preventDefault()}
+        onClick={() => !isActive && state !== "error" && inputRef.current?.click()}
+        className={[
+          "rounded-3xl border-2 border-dashed p-8 text-center transition-colors",
+          state === "idle" ? "border-border-dim hover:border-primary/50 cursor-pointer" : "",
+          state === "error" ? "border-red-500/40" : "",
+          isActive ? "border-border-dim cursor-default" : "",
+        ].join(" ")}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept="audio/*"
+          className="hidden"
+          onChange={onFileChange}
+        />
+
+        {state === "idle" && (
+          <>
+            <span className="material-symbols-outlined text-4xl text-on-surface-variant mb-2 block">
+              audio_file
+            </span>
+            <p className="text-sm font-bold text-on-surface">Загрузить аудио</p>
+            <p className="text-xs text-on-surface-variant mt-1">
+              Перетащите файл или нажмите · m4a, mp3, wav · до 100 MB
+            </p>
+          </>
+        )}
+
+        {state === "uploading" && (
+          <div className="space-y-3">
+            <p className="text-sm font-bold text-on-surface">Загрузка… {progress}%</p>
+            <div className="w-full bg-surface-high rounded-full h-2">
+              <div
+                className="bg-primary h-2 rounded-full transition-all duration-300"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {state === "processing" && (
+          <div className="space-y-2">
+            <p className="text-sm font-bold text-on-surface">Запускаем транскрипцию…</p>
+            <p className="text-xs text-on-surface-variant">Это займёт 15–30 секунд</p>
+          </div>
+        )}
+
+        {state === "error" && (
+          <div className="space-y-3">
+            <span className="material-symbols-outlined text-3xl text-red-400 block">error</span>
+            <p className="text-sm text-red-400">{errorMsg}</p>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setState("idle");
+                setErrorMsg("");
+                setProgress(0);
+              }}
+              className="text-xs text-secondary font-bold uppercase tracking-wider"
+            >
+              Попробовать снова
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -35,6 +35,8 @@ async function requireTrainerOwnsSession(sessionId: string) {
   return { user, supabase };
 }
 
+const ALLOWED_AUDIO_EXTENSIONS = new Set(["m4a", "mp3", "wav", "ogg", "webm", "mp4", "aac"]);
+
 export async function requestAudioUploadUrl(
   sessionId: string,
   ext = "m4a"
@@ -42,8 +44,9 @@ export async function requestAudioUploadUrl(
   const ctx = await requireTrainerOwnsSession(sessionId);
   if (!ctx) return { error: "Forbidden" };
 
+  const safeExt = ALLOWED_AUDIO_EXTENSIONS.has(ext.toLowerCase()) ? ext.toLowerCase() : "m4a";
   const { supabase } = ctx;
-  const storagePath = `${sessionId}/${randomUUID()}.${ext}`;
+  const storagePath = `${sessionId}/${randomUUID()}.${safeExt}`;
 
   const { data, error } = await supabase.storage
     .from("session-audio")
@@ -86,12 +89,10 @@ export async function transcribeSession(
 export async function getTranscriptStatus(
   sessionId: string
 ): Promise<{ status: string; error_message: string | null } | null> {
-  const user = await getSession();
-  if (!user) return null;
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return null;
 
-  const supabase = await createClient();
-
-  const { data } = await supabase
+  const { data } = await ctx.supabase
     .from("transcripts")
     .select("status, error_message")
     .eq("session_id", sessionId)


### PR DESCRIPTION
Replaces stale **#94** (его audio.ts конфликтовал с уже мерджнутым #95).

## Что сделано

- ✅ Применяю M3 UI (`AudioUploader.tsx` + `page.tsx` секция) поверх свежего main
- ✅ Фиксы из [Opus-ревью на #94](https://github.com/profeshionalx-lang/NIVEL/pull/94#issuecomment-3551027149):
  - **Критично:** `getTranscriptStatus` теперь под `requireTrainerOwnsSession` (auth-дыра закрыта)
  - **Минор:** `requestAudioUploadUrl` — whitelist расширений
- ✅ `npm install` подтянул vitest (артефакт #93 — был в devDeps без установки)

## Файлы

- `src/components/sessions/AudioUploader.tsx` (new, 168 строк)
- `src/app/sessions/[id]/page.tsx` (+44, добавлена секция transcript для тренера)
- `src/lib/actions/audio.ts` (+8, -6 — auth + whitelist)
- `package-lock.json` (npm install)

## Отклонения от плана

- `AudioUploader.tsx` лежит в `src/components/sessions/`, не в `src/app/sessions/[id]/` — соответствует структуре остальных компонентов проекта (см. `src/components/sessions/`, `src/components/dashboard/`, и т.д.)

## Проверка

- [x] `npx tsc --noEmit` — чисто
- [x] `npm test` — 7/7 passed (теперь postprocess-тесты от #93 реально работают)
- [x] Все trainer-only actions защищены ownership-check
- [ ] Manual: тренер на `/sessions/[id]` видит uploader, кидает m4a → upload → "Транскрипция…"

Closes #85