### PR TITLE
feat(#86): Groq STT client + real transcribeSession

### DIFF
--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { getSession } from "@/lib/auth/session";
+import { postprocessTranscript } from "@/lib/stt/postprocess";
 import { revalidatePath } from "next/cache";
 import { randomUUID } from "crypto";
 import { redirect } from "next/navigation";
@@ -66,8 +67,7 @@ export async function transcribeSession(
 
   const { supabase } = ctx;
 
-  // M4 will replace this stub with real Groq STT logic.
-  const { error } = await supabase.from("transcripts").upsert(
+  const { error: upsertError } = await supabase.from("transcripts").upsert(
     {
       session_id: sessionId,
       storage_path: storagePath,
@@ -80,10 +80,55 @@ export async function transcribeSession(
     { onConflict: "session_id" }
   );
 
-  if (error) return { success: false, error: error.message };
+  if (upsertError) return { success: false, error: upsertError.message };
 
-  revalidatePath(`/sessions/${sessionId}`);
-  return { success: true };
+  try {
+    const filename = storagePath.split("/").pop() ?? "audio.m4a";
+
+    const { data: blob, error: downloadError } = await supabase.storage
+      .from("session-audio")
+      .download(storagePath);
+
+    if (downloadError || !blob) {
+      throw new Error(downloadError?.message ?? "Failed to download audio from Storage");
+    }
+
+    const audioBuffer = Buffer.from(await blob.arrayBuffer());
+
+    const { transcribeAudio } = await import("@/lib/stt/groq");
+    const verboseJson = await transcribeAudio(audioBuffer, filename);
+
+    const { raw_text, segments } = postprocessTranscript(verboseJson);
+
+    await supabase
+      .from("transcripts")
+      .update({
+        raw_text,
+        segments_json: segments,
+        duration_seconds: verboseJson.duration != null ? Math.round(verboseJson.duration) : null,
+        status: "ready",
+        error_message: null,
+      })
+      .eq("session_id", sessionId);
+
+    await supabase.storage.from("session-audio").remove([storagePath]);
+
+    await supabase
+      .from("transcripts")
+      .update({ storage_path: null })
+      .eq("session_id", sessionId);
+
+    revalidatePath(`/sessions/${sessionId}`);
+    revalidatePath(`/sessions/${sessionId}/transcript`);
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await supabase
+      .from("transcripts")
+      .update({ status: "failed", error_message: message })
+      .eq("session_id", sessionId);
+    return { success: false, error: message };
+  }
 }
 
 export async function getTranscriptStatus(

--- a/src/lib/stt/groq.ts
+++ b/src/lib/stt/groq.ts
@@ -1,0 +1,34 @@
+import type { WhisperVerboseJson } from './postprocess';
+
+function requireGroqKey(): string {
+  const key = process.env.GROQ_API_KEY;
+  if (!key) throw new Error('GROQ_API_KEY environment variable is required for Groq STT');
+  return key;
+}
+
+const GROQ_API_KEY = requireGroqKey();
+
+export async function transcribeAudio(
+  audioBuffer: Buffer,
+  filename: string
+): Promise<WhisperVerboseJson> {
+  const form = new FormData();
+  form.append('file', new Blob([new Uint8Array(audioBuffer)]), filename);
+  form.append('model', 'whisper-large-v3');
+  form.append('language', 'ru');
+  form.append('response_format', 'verbose_json');
+  form.append('temperature', '0');
+
+  const res = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${GROQ_API_KEY}` },
+    body: form,
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Groq API ${res.status}: ${errText}`);
+  }
+
+  return res.json() as Promise<WhisperVerboseJson>;
+}

--- a/src/lib/stt/groq.ts
+++ b/src/lib/stt/groq.ts
@@ -8,6 +8,8 @@ function requireGroqKey(): string {
 
 const GROQ_API_KEY = requireGroqKey();
 
+const GROQ_TIMEOUT_MS = 120_000;
+
 export async function transcribeAudio(
   audioBuffer: Buffer,
   filename: string
@@ -19,16 +21,29 @@ export async function transcribeAudio(
   form.append('response_format', 'verbose_json');
   form.append('temperature', '0');
 
-  const res = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${GROQ_API_KEY}` },
-    body: form,
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GROQ_TIMEOUT_MS);
 
-  if (!res.ok) {
-    const errText = await res.text();
-    throw new Error(`Groq API ${res.status}: ${errText}`);
+  try {
+    const res = await fetch('https://api.groq.com/openai/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${GROQ_API_KEY}` },
+      body: form,
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      throw new Error(`Groq API ${res.status}: ${errText}`);
+    }
+
+    return (await res.json()) as WhisperVerboseJson;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`Groq API timed out after ${GROQ_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
   }
-
-  return res.json() as Promise<WhisperVerboseJson>;
 }

--- a/src/lib/stt/postprocess.ts
+++ b/src/lib/stt/postprocess.ts
@@ -26,6 +26,7 @@ export interface ProcessedSegment {
   start: number;
   end: number;
   text: string;
+  avg_logprob?: number;
 }
 
 function applyGlossary(text: string): string {
@@ -60,6 +61,7 @@ export function postprocessTranscript(verboseJson: WhisperVerboseJson): {
     start: seg.start,
     end: seg.end,
     text: cleanText(seg.text),
+    ...(seg.avg_logprob != null ? { avg_logprob: seg.avg_logprob } : {}),
   }));
 
   const raw_text = cleanText(verboseJson.text);


### PR DESCRIPTION
Closes #86

## Что сделано

- **`src/lib/stt/groq.ts`** — новый Groq STT клиент:
  - `transcribeAudio(audioBuffer, filename)` → `WhisperVerboseJson`
  - Параметры: `whisper-large-v3`, `language=ru`, `response_format=verbose_json`, `temperature=0`, **без `prompt`** (per issue spec)
  - Проверка `GROQ_API_KEY` при загрузке модуля: `throw new Error(...)` если не задан

- **`src/lib/actions/audio.ts`** — `transcribeSession` заменён с заглушки на полный flow:
  1. Trainer ownership check (существующий `requireTrainerOwnsSession`)
  2. Upsert `transcripts` с `status='processing'`
  3. Скачать аудио из Supabase Storage (`session-audio` bucket)
  4. Конвертировать Blob → Buffer → передать в `transcribeAudio`
  5. Применить `postprocessTranscript` из `src/lib/stt/postprocess.ts`
  6. UPDATE `transcripts`: `raw_text`, `segments_json`, `duration_seconds`, `status='ready'`
  7. Удалить аудиофайл из Storage
  8. UPDATE `transcripts.storage_path = NULL`
  - При любой ошибке: UPDATE `status='failed'`, `error_message`; Storage-файл НЕ удаляется

## Файлы

- `src/lib/stt/groq.ts` (новый)
- `src/lib/actions/audio.ts` (изменён — `transcribeSession` + добавлен импорт `postprocessTranscript`)

## Проверка

- `npx tsc --noEmit` — 0 ошибок в наших файлах (pre-existing errors в codebase не затронуты)
- Логика соответствует acceptance: `status='ready'`, `storage_path=NULL`, файл удалён из Storage
- При GROQ error → `status='failed'` с `error_message`, файл в Storage остаётся для retry

## Отклонения от плана

| Пункт плана | Реальность | Решение |
|---|---|---|
| `getTranscriptStatus` — создать заново | Уже существует в `audio.ts` (добавлен в #95) | Оставил как есть, не дублировал |
| Static import `transcribeAudio` в `audio.ts` | Используем dynamic `import('@/lib/stt/groq')` внутри `transcribeSession` | Чтобы проверка `GROQ_API_KEY` в `groq.ts` не блокировала `requestAudioUploadUrl` и другие actions при старте |
| `duration_seconds` — хранить как есть | Тип в БД — `INTEGER`, Groq возвращает float | `Math.round()` при сохранении |
| Проверка Groq key "at module load" | При dynamic import — проверка срабатывает при первом вызове `transcribeSession` | Семантически то же самое (fail-fast при первой попытке транскрипции), зафиксировано в PR |

## Зависимость от env

`GROQ_API_KEY` должен быть задан в Vercel Environment Variables (Edgar добавил вручную). Если ключ отсутствует — `transcribeSession` вернёт `{ success: false, error: "GROQ_API_KEY environment variable is required..." }` и запись в `transcripts` получит `status='failed'`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9mYWhgwyFVD37JTxhUZx6)_