### PR TITLE
feat(#87): transcript page — segments, confidence highlights, insight creation

### DIFF
--- a/src/app/sessions/[id]/transcript/TranscriptView.tsx
+++ b/src/app/sessions/[id]/transcript/TranscriptView.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useEffect, useRef, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { getTranscriptStatus } from "@/lib/actions/audio";
+import { createInsightCard, setTrainerCardStatus } from "@/lib/actions/insightCards";
+
+interface Segment {
+  id: number;
+  start: number;
+  end: number;
+  text: string;
+  avg_logprob?: number;
+}
+
+interface Props {
+  sessionId: string;
+  status: string;
+  errorMessage: string | null;
+  rawText: string | null;
+  segments: Segment[];
+}
+
+function fmtTime(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60).toString().padStart(2, "0");
+  return `${m}:${sec}`;
+}
+
+function segClass(avg?: number): string {
+  if (avg === undefined || avg === null) return "";
+  if (avg < -1.0) return " border-l-2 border-red-400 bg-red-500/10 pl-2";
+  if (avg < -0.6) return " border-l-2 border-yellow-400 bg-yellow-400/10 pl-2";
+  return "";
+}
+
+export function TranscriptView({ sessionId, status, errorMessage, rawText, segments }: Props) {
+  const router = useRouter();
+  const [tab, setTab] = useState<"segments" | "fulltext">("segments");
+  const [selection, setSelection] = useState("");
+  const [showModal, setShowModal] = useState(false);
+  const [insightText, setInsightText] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (status !== "processing") return;
+    const intervalId = setInterval(async () => {
+      const result = await getTranscriptStatus(sessionId);
+      if (result?.status === "ready" || result?.status === "failed") {
+        clearInterval(intervalId);
+        router.refresh();
+      }
+    }, 3000);
+    return () => clearInterval(intervalId);
+  }, [sessionId, status, router]);
+
+  useEffect(() => {
+    function onSelectionChange() {
+      const sel = window.getSelection();
+      const text = sel?.toString().trim() ?? "";
+      if (!text || !containerRef.current) {
+        setSelection("");
+        return;
+      }
+      const anchor = sel?.anchorNode;
+      if (anchor && containerRef.current.contains(anchor)) {
+        setSelection(text);
+      } else {
+        setSelection("");
+      }
+    }
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => document.removeEventListener("selectionchange", onSelectionChange);
+  }, []);
+
+  function openModal() {
+    setInsightText("");
+    setShowModal(true);
+  }
+
+  function handleCreate() {
+    if (!insightText.trim()) return;
+    startTransition(async () => {
+      const res = await createInsightCard(sessionId, {
+        frontText: insightText,
+        contextText: selection || null,
+      });
+      if (res.success) {
+        await setTrainerCardStatus(res.id, "approved");
+        setShowModal(false);
+        setSelection("");
+        window.getSelection()?.removeAllRanges();
+        router.refresh();
+      }
+    });
+  }
+
+  if (status === "processing") {
+    return (
+      <div className="rounded-3xl bg-surface-card p-6 text-center space-y-3">
+        <span
+          className="material-symbols-outlined text-4xl text-primary block"
+          style={{ animation: "spin 2s linear infinite" }}
+        >
+          autorenew
+        </span>
+        <p className="text-sm font-bold text-on-surface">Транскрипция в процессе…</p>
+        <p className="text-xs text-on-surface-variant">Обновляется автоматически каждые 3 секунды</p>
+      </div>
+    );
+  }
+
+  if (status === "failed") {
+    return (
+      <div className="rounded-3xl bg-surface-card p-6 space-y-2">
+        <p className="text-sm font-bold text-red-400">Ошибка транскрипции</p>
+        {errorMessage && (
+          <p className="text-xs text-on-surface-variant font-mono break-words">{errorMessage}</p>
+        )}
+        <p className="text-xs text-on-surface-variant mt-2">
+          Удалите транскрипт и загрузите аудио заново.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div ref={containerRef}>
+        <div className="flex gap-2 mb-4">
+          {(["segments", "fulltext"] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-4 py-2 rounded-xl text-xs font-bold uppercase tracking-wide transition-colors min-h-[44px] ${
+                tab === t
+                  ? "bg-primary text-on-primary"
+                  : "bg-surface-card text-on-surface-variant"
+              }`}
+            >
+              {t === "segments" ? "По сегментам" : "Сплошной текст"}
+            </button>
+          ))}
+        </div>
+
+        {tab === "segments" && (
+          <div className="space-y-1">
+            {segments.length === 0 && (
+              <p className="text-sm text-on-surface-variant">Сегменты недоступны.</p>
+            )}
+            {segments.map((seg) => (
+              <div
+                key={seg.id}
+                className={`rounded-xl p-3 bg-surface-card${segClass(seg.avg_logprob)}`}
+              >
+                <span className="text-[10px] font-black text-on-surface-variant uppercase tracking-wider mr-2 font-mono select-none">
+                  {fmtTime(seg.start)}
+                </span>
+                <span className="text-sm text-on-surface">{seg.text}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {tab === "fulltext" && (
+          <div className="rounded-2xl bg-surface-card p-4 text-sm text-on-surface leading-relaxed whitespace-pre-wrap break-words">
+            {rawText || "Текст недоступен."}
+          </div>
+        )}
+      </div>
+
+      {selection && !showModal && (
+        <div className="fixed bottom-24 left-0 right-0 z-40 flex justify-center px-5 pointer-events-none">
+          <button
+            onClick={openModal}
+            className="pointer-events-auto flex items-center gap-2 bg-primary text-on-primary px-5 py-3 rounded-2xl text-sm font-bold shadow-lg active:scale-95 transition-transform min-h-[44px]"
+          >
+            <span className="material-symbols-outlined text-base">add_circle</span>
+            Создать инсайт из фрагмента
+          </button>
+        </div>
+      )}
+
+      {showModal && (
+        <div
+          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center p-4"
+          onClick={() => setShowModal(false)}
+        >
+          <div
+            className="bg-surface-card rounded-3xl p-6 w-full max-w-[430px] space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-black tracking-tight">Новая инсайт-карточка</h3>
+            {selection && (
+              <div className="rounded-xl bg-surface-elevated p-3 border-l-2 border-primary">
+                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1">
+                  Цитата
+                </p>
+                <p className="text-xs text-on-surface leading-relaxed">«{selection}»</p>
+              </div>
+            )}
+            <textarea
+              value={insightText}
+              onChange={(e) => setInsightText(e.target.value)}
+              placeholder="Главная мысль — одним предложением"
+              rows={3}
+              autoFocus
+              className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none border border-border-dim focus:border-primary focus:outline-none"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={handleCreate}
+                disabled={isPending || !insightText.trim()}
+                className="flex-1 py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary disabled:opacity-40 min-h-[44px]"
+              >
+                {isPending ? "Сохраняем…" : "Добавить"}
+              </button>
+              <button
+                onClick={() => setShowModal(false)}
+                className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface min-h-[44px]"
+              >
+                Отмена
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sessions/[id]/transcript/TranscriptView.tsx
+++ b/src/app/sessions/[id]/transcript/TranscriptView.tsx
@@ -40,6 +40,7 @@ export function TranscriptView({ sessionId, status, errorMessage, rawText, segme
   const [selection, setSelection] = useState("");
   const [showModal, setShowModal] = useState(false);
   const [insightText, setInsightText] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -56,6 +57,7 @@ export function TranscriptView({ sessionId, status, errorMessage, rawText, segme
   }, [sessionId, status, router]);
 
   useEffect(() => {
+    if (status !== "ready") return;
     function onSelectionChange() {
       const sel = window.getSelection();
       const text = sel?.toString().trim() ?? "";
@@ -72,15 +74,17 @@ export function TranscriptView({ sessionId, status, errorMessage, rawText, segme
     }
     document.addEventListener("selectionchange", onSelectionChange);
     return () => document.removeEventListener("selectionchange", onSelectionChange);
-  }, []);
+  }, [status]);
 
   function openModal() {
     setInsightText("");
+    setCreateError(null);
     setShowModal(true);
   }
 
   function handleCreate() {
     if (!insightText.trim()) return;
+    setCreateError(null);
     startTransition(async () => {
       const res = await createInsightCard(sessionId, {
         frontText: insightText,
@@ -92,6 +96,8 @@ export function TranscriptView({ sessionId, status, errorMessage, rawText, segme
         setSelection("");
         window.getSelection()?.removeAllRanges();
         router.refresh();
+      } else {
+        setCreateError(res.error || "Не удалось создать карточку");
       }
     });
   }
@@ -208,6 +214,9 @@ export function TranscriptView({ sessionId, status, errorMessage, rawText, segme
               autoFocus
               className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface placeholder-on-surface-variant/50 resize-none border border-border-dim focus:border-primary focus:outline-none"
             />
+            {createError && (
+              <p className="text-xs text-red-400 break-words">{createError}</p>
+            )}
             <div className="flex gap-2">
               <button
                 onClick={handleCreate}

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -16,6 +16,24 @@ export default async function TranscriptPage({
 
   const supabase = await createClient();
 
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, goals(user_id)")
+    .eq("id", id)
+    .single();
+
+  const studentId = (session?.goals as unknown as { user_id: string } | null)?.user_id;
+  if (!studentId) redirect("/dashboard");
+
+  const { data: studentProfile } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", studentId)
+    .eq("created_by", user.id)
+    .maybeSingle();
+
+  if (!studentProfile) redirect("/dashboard");
+
   const { data: transcript } = await supabase
     .from("transcripts")
     .select("status, error_message, raw_text, segments_json, duration_seconds, created_at")

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import { DeleteTranscriptButton } from "./DeleteTranscriptButton";
+import { TranscriptView } from "./TranscriptView";
 
 export default async function TranscriptPage({
   params,
@@ -17,11 +18,21 @@ export default async function TranscriptPage({
 
   const { data: transcript } = await supabase
     .from("transcripts")
-    .select("status, error_message, created_at")
+    .select("status, error_message, raw_text, segments_json, duration_seconds, created_at")
     .eq("session_id", id)
     .maybeSingle();
 
   if (!transcript) redirect(`/sessions/${id}`);
+
+  const segments = Array.isArray(transcript.segments_json)
+    ? (transcript.segments_json as Array<{
+        id: number;
+        start: number;
+        end: number;
+        text: string;
+        avg_logprob?: number;
+      }>)
+    : [];
 
   return (
     <div className="min-h-screen bg-background">
@@ -36,34 +47,13 @@ export default async function TranscriptPage({
       </header>
 
       <main className="px-5 pt-6 pb-36 max-w-[430px] mx-auto space-y-6">
-        {transcript.status === "processing" && (
-          <div className="rounded-3xl bg-surface-card p-6 text-center space-y-2">
-            <span className="material-symbols-outlined text-4xl text-primary block">hourglass_top</span>
-            <p className="text-sm font-bold text-on-surface">Транскрипция в процессе…</p>
-            <p className="text-xs text-on-surface-variant">Обновите страницу через 15–30 секунд</p>
-          </div>
-        )}
-
-        {transcript.status === "failed" && (
-          <div className="rounded-3xl bg-surface-card p-6 space-y-2">
-            <p className="text-sm font-bold text-red-400">Ошибка транскрипции</p>
-            {transcript.error_message && (
-              <p className="text-xs text-on-surface-variant font-mono">{transcript.error_message}</p>
-            )}
-            <p className="text-xs text-on-surface-variant mt-3">
-              Удалите транскрипт и загрузите аудио заново.
-            </p>
-          </div>
-        )}
-
-        {transcript.status === "ready" && (
-          <div className="rounded-3xl bg-surface-card p-6 space-y-2">
-            <p className="text-sm font-bold text-primary">Транскрипт готов</p>
-            <p className="text-xs text-on-surface-variant">
-              Полный просмотр появится в следующем обновлении.
-            </p>
-          </div>
-        )}
+        <TranscriptView
+          sessionId={id}
+          status={transcript.status}
+          errorMessage={transcript.error_message}
+          rawText={transcript.raw_text}
+          segments={segments}
+        />
 
         <div className="pt-4 border-t border-border-dim flex justify-center">
           <DeleteTranscriptButton sessionId={id} />


### PR DESCRIPTION
Closes #87

**Assumes #86 (PR #101) merged** — depends on the `transcripts` table having `raw_text` and `segments_json` populated by the real Groq flow.

## Что сделано

- **`TranscriptView.tsx`** (новый client component):
  - `processing`: спиннер + `setInterval`-поллинг `getTranscriptStatus` каждые 3 сек → `router.refresh()` когда `ready`/`failed`
  - `failed`: текст ошибки из `error_message`
  - `ready`: две вкладки («По сегментам» / «Сплошной текст»)
    - Сегменты с таймкодами в формате `м:сс`
    - Подсветка уверенности: `avg_logprob < -0.6` → жёлтый, `< -1.0` → красный (graceful degradation — текущие сегменты из #93 не хранят `avg_logprob`, код готов когда поле появится)
    - `selectionchange` → fixed bottom bar «Создать инсайт из фрагмента»
    - Клик → bottom-sheet модалка с показом цитаты (read-only) + поле инсайта → `createInsightCard` + `setTrainerCardStatus('approved')`

- **`page.tsx`** (обновлён):
  - SELECT расширен: `raw_text, segments_json, duration_seconds`
  - Inline состояния удалены, заменены на `<TranscriptView>`
  - `segments_json` приводится к типизированному массиву с `avg_logprob?: number`

## Файлы

- `src/app/sessions/[id]/transcript/TranscriptView.tsx` (новый)
- `src/app/sessions/[id]/transcript/page.tsx` (изменён)

## Проверка

- `npx tsc --noEmit` — 0 ошибок в изменённых файлах
- Acceptance: тренер открывает `/sessions/[id]/transcript` → видит сегменты → выделяет → кнопка → модалка → инсайт

## Отклонения от плана

| Пункт плана | Реальность | Решение |
|---|---|---|
| `avg_logprob` highlighting | `ProcessedSegment` из #93 не сохраняет `avg_logprob` — только `{id, start, end, text}` | Код подсветки написан, graceful degradation: если поля нет — класс не добавляется. Заработает автоматически если #93 будет дополнен |
| «Аудио-плеер» вкладка (план упоминал 3 вкладки) | M7 исключён из MVP (аудио не хранится) | Только 2 вкладки: сегменты + сплошной текст |
| `InlineSessionCardAdder` с pre-fill | Компонент не поддерживает начальные значения | Новая встроенная модалка в `TranscriptView` с той же логикой (createInsightCard → setTrainerCardStatus approved) |

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9mYWhgwyFVD37JTxhUZx6)_