### PR TITLE
feat(#88): Re-transcribe button with confirmation

### DIFF
--- a/src/app/sessions/[id]/transcript/ReTranscribeButton.tsx
+++ b/src/app/sessions/[id]/transcript/ReTranscribeButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { resetTranscript } from "@/lib/actions/audio";
+
+export function ReTranscribeButton({ sessionId }: { sessionId: string }) {
+  const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  function handleConfirm() {
+    startTransition(async () => {
+      await resetTranscript(sessionId);
+    });
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold text-on-surface-variant border border-border-dim active:scale-95 transition-transform min-h-[44px]"
+      >
+        <span className="material-symbols-outlined text-base">refresh</span>
+        Перетранскрибировать
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center p-4"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-surface-card rounded-3xl p-6 w-full max-w-[430px] space-y-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-base font-black tracking-tight">Перетранскрибировать?</h3>
+            <p className="text-sm text-on-surface-variant leading-relaxed">
+              Аудиофайл не хранится — нужно загрузить его заново. Текущий транскрипт будет удалён.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={handleConfirm}
+                disabled={isPending}
+                className="flex-1 py-3 rounded-xl font-bold text-sm bg-primary text-on-primary disabled:opacity-40 min-h-[44px]"
+              >
+                {isPending ? "Удаляем…" : "Загрузить заново"}
+              </button>
+              <button
+                onClick={() => setOpen(false)}
+                className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface min-h-[44px]"
+              >
+                Отмена
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -4,6 +4,7 @@ import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import { DeleteTranscriptButton } from "./DeleteTranscriptButton";
 import { TranscriptView } from "./TranscriptView";
+import { ReTranscribeButton } from "./ReTranscribeButton";
 
 export default async function TranscriptPage({
   params,
@@ -73,7 +74,8 @@ export default async function TranscriptPage({
           segments={segments}
         />
 
-        <div className="pt-4 border-t border-border-dim flex justify-center">
+        <div className="pt-4 border-t border-border-dim flex items-center justify-center gap-3 flex-wrap">
+          <ReTranscribeButton sessionId={id} />
           <DeleteTranscriptButton sessionId={id} />
         </div>
       </main>

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -146,6 +146,29 @@ export async function getTranscriptStatus(
   return data ? { status: data.status, error_message: data.error_message } : null;
 }
 
+export async function resetTranscript(sessionId: string): Promise<void> {
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return;
+
+  const { supabase } = ctx;
+
+  const { data: existing } = await supabase
+    .from("transcripts")
+    .select("storage_path")
+    .eq("session_id", sessionId)
+    .maybeSingle();
+
+  if (existing?.storage_path) {
+    await supabase.storage.from("session-audio").remove([existing.storage_path]);
+  }
+
+  await supabase.from("transcripts").delete().eq("session_id", sessionId);
+
+  revalidatePath(`/sessions/${sessionId}`);
+  revalidatePath(`/sessions/${sessionId}/transcript`);
+  redirect(`/sessions/${sessionId}`);
+}
+
 export async function deleteTranscript(sessionId: string): Promise<void> {
   const ctx = await requireTrainerOwnsSession(sessionId);
   if (!ctx) return;


### PR DESCRIPTION
Closes #88

**Assumes #86 (PR #101) and #87 (PR #102) merged first** — needs `transcripts` table and transcript page to exist.

> **Note on merge order:** этот PR изменяет `page.tsx` на основе `main` (без изменений из #87). После мержа #87, в этой ветке нужно rebase или merge. Можно смержить #86 → #87 → #88 последовательно.

## Что сделано

- **`src/app/sessions/[id]/transcript/ReTranscribeButton.tsx`** (новый):
  - Кнопка «Перетранскрибировать» с иконкой
  - Bottom-sheet модалка с предупреждением: «Аудиофайл не хранится — нужно загрузить его заново»
  - Кнопки: «Загрузить заново» (вызывает `resetTranscript`) и «Отмена»
  - После подтверждения → `resetTranscript` → редирект на `/sessions/[id]` где показывается `AudioUploader`

- **`src/lib/actions/audio.ts`** — добавлен `resetTranscript(sessionId)`:
  - Проверяет trainer ownership (`requireTrainerOwnsSession`)
  - Удаляет Storage-файл если `storage_path` != NULL (обработка failed-транскрипций где файл мог остаться)
  - Удаляет запись из `transcripts`
  - `revalidatePath` + `redirect` на `/sessions/${sessionId}`

- **`page.tsx`** (обновлён): импорт и рендер `ReTranscribeButton` рядом с `DeleteTranscriptButton`

## Файлы

- `src/app/sessions/[id]/transcript/ReTranscribeButton.tsx` (новый)
- `src/app/sessions/[id]/transcript/page.tsx` (изменён)
- `src/lib/actions/audio.ts` (изменён — добавлен `resetTranscript`)

## Проверка

- `npx tsc --noEmit` — 0 ошибок
- Acceptance: кнопка «Перетранскрибировать» → подтверждение → попадаешь на upload UI `/sessions/[id]` → можно загрузить файл заново

## Отклонения от плана

| Пункт плана | Реальность | Решение |
|---|---|---|
| `resetTranscript` по сути = `deleteTranscript` | Одинаковая логика — удалить запись + Storage-файл + redirect | Создан отдельный `resetTranscript` для ясности семантики; `deleteTranscript` оставлен для "удалить без возврата к загрузке" |
| Inline drag&drop на странице транскрипта (альтернатива) | Не реализована (план: "если время позволяет") | Реализован минималистичный вариант: подтверждение → редирект на `/sessions/[id]` с AudioUploader |

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9mYWhgwyFVD37JTxhUZx6)_