### PR TITLE
feat(transcript): download .txt button

### DIFF
--- a/src/app/sessions/[id]/transcript/DownloadTranscriptButton.tsx
+++ b/src/app/sessions/[id]/transcript/DownloadTranscriptButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+export function DownloadTranscriptButton({
+  sessionId,
+  rawText,
+}: {
+  sessionId: string;
+  rawText: string | null;
+}) {
+  function handleClick() {
+    const text = rawText ?? "";
+    const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `transcript-${sessionId}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      className="flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-bold text-on-surface-variant border border-border-dim active:scale-95 transition-transform min-h-[44px]"
+    >
+      <span className="material-symbols-outlined text-base">download</span>
+      Скачать транскрипт
+    </button>
+  );
+}

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import { DeleteTranscriptButton } from "./DeleteTranscriptButton";
+import { DownloadTranscriptButton } from "./DownloadTranscriptButton";
 import { TranscriptView } from "./TranscriptView";
 import { ReTranscribeButton } from "./ReTranscribeButton";
 
@@ -76,6 +77,7 @@ export default async function TranscriptPage({
 
         <div className="pt-4 border-t border-border-dim flex items-center justify-center gap-3 flex-wrap">
           <ReTranscribeButton sessionId={id} />
+          <DownloadTranscriptButton sessionId={id} rawText={transcript.raw_text} />
           <DeleteTranscriptButton sessionId={id} />
         </div>
       </main>


### PR DESCRIPTION
Closes #107

## Что сделано

- Новый компонент `DownloadTranscriptButton.tsx` — клиентский blob-download транскрипта в `.txt`
- Кнопка размещена в `flex-wrap` контейнере на `/sessions/[id]/transcript` между «Перетранскрибировать» и «Удалить транскрипт»
- Touch target `min-h-[44px]`, стиль совпадает с `ReTranscribeButton`
- Имя файла: `transcript-{sessionId}.txt`

## Отклонения от плана

Нет — реализация точно соответствует плану из issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sP6GqKPyF1B2dRDw3qXKD)_