### PR TITLE
feat(ai): parseInsightsMarkdown parser + tests

### DIFF
--- a/src/lib/ai/__tests__/parseInsights.test.ts
+++ b/src/lib/ai/__tests__/parseInsights.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { parseInsightsMarkdown } from "../parseInsights";
+
+const VALID_3_CARDS = `
+## Карточка 1
+- Тема: техника
+- Заголовок: Поздний замах при бандеха
+- Описание: При бандеха ты начинаешь замах когда мяч уже на уровне плеча. Начинай замах когда мяч ещё летит к тебе — на 0.5 сек раньше.
+- Цитата: "ты опять поздно взял, видишь — мяч уже тут а ты только начинаешь"
+
+## Карточка 2
+- Тема: тактика
+- Заголовок: Держи позицию у сетки
+- Описание: После удара смещайся к сетке, не оставайся у задней линии.
+- Цитата: «не стой сзади, иди вперёд»
+
+## Карточка 3
+- Тема: физика
+- Заголовок: Работа ног при смеше
+- Описание: Прыжок и удар одновременно снижают силу. Сначала остановись, потом бей.
+- Цитата: ты прыгаешь и бьёшь одновременно
+`;
+
+describe("parseInsightsMarkdown", () => {
+  it("парсит 3 валидные карточки", () => {
+    const result = parseInsightsMarkdown(VALID_3_CARDS);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards).toHaveLength(3);
+    expect(result.cards[0].title).toBe("Поздний замах при бандеха");
+    expect(result.cards[0].tag).toBe("техника");
+    expect(result.cards[1].tag).toBe("тактика");
+    expect(result.cards[2].tag).toBe("физика");
+  });
+
+  it("возвращает ошибку при отсутствии Темы", () => {
+    const md = `
+## Карточка 1
+- Заголовок: Тест
+- Описание: Описание теста.
+- Цитата: "цитата"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Тема/);
+  });
+
+  it("возвращает ошибку при невалидной Теме", () => {
+    const md = `
+## Карточка 1
+- Тема: мотивация
+- Заголовок: Тест
+- Описание: Описание теста.
+- Цитата: "цитата"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/мотивация/);
+  });
+
+  it("парсит цитату в обычных кавычках", () => {
+    const md = `
+## Карточка 1
+- Тема: ментал
+- Заголовок: Фокус
+- Описание: Не думай о счёте.
+- Цитата: "не думай о счёте вообще"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].quote).toBe("не думай о счёте вообще");
+  });
+
+  it("парсит цитату в угловых кавычках", () => {
+    const md = `
+## Карточка 1
+- Тема: тактика
+- Заголовок: Позиция
+- Описание: Держись ближе к центру.
+- Цитата: «держись центра»
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].quote).toBe("держись центра");
+  });
+
+  it("парсит ключи в разных регистрах", () => {
+    const md = `
+## Карточка 1
+- ТЕМА: физика
+- ЗАГОЛОВОК: Бег
+- ОПИСАНИЕ: Бегай больше.
+- ЦИТАТА: "бегай"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].tag).toBe("физика");
+  });
+
+  it("возвращает ошибку при 0 карточках", () => {
+    const result = parseInsightsMarkdown("просто текст без карточек");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Не найдено ни одной карточки/);
+  });
+
+  it("тримит whitespace во всех полях", () => {
+    const md = `
+## Карточка 1
+- Тема:   техника
+- Заголовок:   Замах
+- Описание:   Описание.
+- Цитата:   "цитата"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].title).toBe("Замах");
+    expect(result.cards[0].body).toBe("Описание.");
+    expect(result.cards[0].quote).toBe("цитата");
+  });
+
+  it("возвращает ошибку при отсутствии Заголовка", () => {
+    const md = `
+## Карточка 1
+- Тема: техника
+- Описание: Описание.
+- Цитата: "цитата"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Заголовок/);
+  });
+
+  it("возвращает ошибку при отсутствии Описания", () => {
+    const md = `
+## Карточка 1
+- Тема: техника
+- Заголовок: Замах
+- Цитата: "цитата"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Описание/);
+  });
+
+  it("все 4 валидные темы принимаются", () => {
+    for (const tag of ["техника", "тактика", "физика", "ментал"]) {
+      const md = `
+## Карточка 1
+- Тема: ${tag}
+- Заголовок: Тест
+- Описание: Описание.
+- Цитата: "цитата"
+`;
+      const result = parseInsightsMarkdown(md);
+      expect(result.ok).toBe(true);
+    }
+  });
+
+  it("парсит цитату без кавычек", () => {
+    const md = `
+## Карточка 1
+- Тема: техника
+- Заголовок: Замах
+- Описание: Описание.
+- Цитата: вот так он говорил
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].quote).toBe("вот так он говорил");
+  });
+});

--- a/src/lib/ai/__tests__/parseInsights.test.ts
+++ b/src/lib/ai/__tests__/parseInsights.test.ts
@@ -178,4 +178,67 @@ describe("parseInsightsMarkdown", () => {
     if (!result.ok) return;
     expect(result.cards[0].quote).toBe("вот так он говорил");
   });
+
+  it("стрипит типографские кавычки из Claude", () => {
+    const md = `
+## Карточка 1
+- Тема: техника
+- Заголовок: Замах
+- Описание: Описание.
+- Цитата: “не думай о счёте”
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].quote).toBe("не думай о счёте");
+  });
+
+  it("склеивает многострочное Описание", () => {
+    const md = `
+## Карточка 1
+- Тема: техника
+- Заголовок: Замах
+- Описание: Первая строка описания
+  продолжение на следующей строке
+  и ещё одна строка.
+- Цитата: "тест"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].body).toContain("Первая строка");
+    expect(result.cards[0].body).toContain("продолжение");
+    expect(result.cards[0].body).toContain("ещё одна строка");
+  });
+
+  it("поддерживает разные маркеры пунктов (* • —)", () => {
+    const md = `
+## Карточка 1
+* Тема: техника
+• Заголовок: Тест
+— Описание: Описание.
+* Цитата: "тест"
+`;
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].title).toBe("Тест");
+    expect(result.cards[0].tag).toBe("техника");
+  });
+
+  it("возвращает ошибку на пустую строку", () => {
+    const result = parseInsightsMarkdown("");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/Не найдено/);
+  });
+
+  it("поддерживает CRLF (Windows line endings)", () => {
+    const md = "## Карточка 1\r\n- Тема: техника\r\n- Заголовок: Тест\r\n- Описание: Описание.\r\n- Цитата: \"тест\"\r\n";
+    const result = parseInsightsMarkdown(md);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cards[0].title).toBe("Тест");
+    expect(result.cards[0].quote).toBe("тест");
+  });
 });

--- a/src/lib/ai/parseInsights.ts
+++ b/src/lib/ai/parseInsights.ts
@@ -1,0 +1,92 @@
+export type InsightTag = "техника" | "тактика" | "физика" | "ментал";
+
+export interface InsightCardDraft {
+  title: string;
+  body: string;
+  tag: InsightTag;
+  quote: string;
+}
+
+export type ParseResult =
+  | { ok: true; cards: InsightCardDraft[] }
+  | { ok: false; error: string; line?: number };
+
+const VALID_TAGS = new Set<InsightTag>(["техника", "тактика", "физика", "ментал"]);
+
+function stripQuotes(s: string): string {
+  return s.replace(/^["«"]+|["»"]+$/g, "").trim();
+}
+
+function extractField(lines: string[], key: string): string | undefined {
+  const pattern = new RegExp(`^[-–]?\\s*${key}\\s*:(.*)$`, "i");
+  for (const line of lines) {
+    const m = line.match(pattern);
+    if (m) return m[1].trim();
+  }
+  return undefined;
+}
+
+export function parseInsightsMarkdown(input: string): ParseResult {
+  const lines = input.split("\n");
+  const cardBlocks: { startLine: number; lines: string[] }[] = [];
+
+  let current: { startLine: number; lines: string[] } | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.match(/^##\s+/)) {
+      if (current) cardBlocks.push(current);
+      current = { startLine: i + 1, lines: [] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) cardBlocks.push(current);
+
+  if (cardBlocks.length === 0) {
+    return { ok: false, error: "Не найдено ни одной карточки" };
+  }
+
+  const cards: InsightCardDraft[] = [];
+
+  for (let idx = 0; idx < cardBlocks.length; idx++) {
+    const block = cardBlocks[idx];
+    const cardNum = idx + 1;
+
+    const rawTag = extractField(block.lines, "Тема");
+    const title = extractField(block.lines, "Заголовок");
+    const body = extractField(block.lines, "Описание");
+    const rawQuote = extractField(block.lines, "Цитата");
+
+    if (!rawTag) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Тема»`, line: block.startLine };
+    }
+    if (!title) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Заголовок»`, line: block.startLine };
+    }
+    if (!body) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Описание»`, line: block.startLine };
+    }
+    if (rawQuote === undefined) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Цитата»`, line: block.startLine };
+    }
+
+    const tag = rawTag.toLowerCase().trim() as InsightTag;
+    if (!VALID_TAGS.has(tag)) {
+      return {
+        ok: false,
+        error: `Карточка ${cardNum}: неизвестная тема «${rawTag}». Допустимые: техника, тактика, физика, ментал`,
+        line: block.startLine,
+      };
+    }
+
+    cards.push({
+      title: title.trim(),
+      body: body.trim(),
+      tag,
+      quote: stripQuotes(rawQuote),
+    });
+  }
+
+  return { ok: true, cards };
+}

--- a/src/lib/ai/parseInsights.ts
+++ b/src/lib/ai/parseInsights.ts
@@ -13,78 +13,109 @@ export type ParseResult =
 
 const VALID_TAGS = new Set<InsightTag>(["техника", "тактика", "физика", "ментал"]);
 
+const FIELD_KEYS = ["тема", "заголовок", "описание", "цитата"] as const;
+type FieldKey = (typeof FIELD_KEYS)[number];
+
+const FIELD_LINE = new RegExp(
+  `^\\s*[-–—*•]?\\s*(${FIELD_KEYS.join("|")})\\s*:(.*)$`,
+  "i"
+);
+
 function stripQuotes(s: string): string {
-  return s.replace(/^["«"]+|["»"]+$/g, "").trim();
+  return s.replace(/^["'«“‘«]+|["'»”’»]+$/g, "").trim();
 }
 
-function extractField(lines: string[], key: string): string | undefined {
-  const pattern = new RegExp(`^[-–]?\\s*${key}\\s*:(.*)$`, "i");
+interface CardBlock {
+  startLine: number;
+  fields: Partial<Record<FieldKey, string>>;
+}
+
+function parseBlock(lines: string[]): Partial<Record<FieldKey, string>> {
+  const acc: Record<FieldKey, string[]> = {
+    тема: [],
+    заголовок: [],
+    описание: [],
+    цитата: [],
+  };
+  const seen = new Set<FieldKey>();
+  let current: FieldKey | null = null;
+
   for (const line of lines) {
-    const m = line.match(pattern);
-    if (m) return m[1].trim();
+    const m = line.match(FIELD_LINE);
+    if (m) {
+      const key = m[1].toLowerCase() as FieldKey;
+      current = key;
+      seen.add(key);
+      acc[key].push(m[2].trim());
+    } else if (current) {
+      const trimmed = line.trim();
+      if (trimmed) acc[current].push(trimmed);
+    }
   }
-  return undefined;
+
+  const out: Partial<Record<FieldKey, string>> = {};
+  for (const key of FIELD_KEYS) {
+    if (seen.has(key)) out[key] = acc[key].join(" ").replace(/\s+/g, " ").trim();
+  }
+  return out;
 }
 
 export function parseInsightsMarkdown(input: string): ParseResult {
-  const lines = input.split("\n");
-  const cardBlocks: { startLine: number; lines: string[] }[] = [];
-
+  const lines = input.split(/\r?\n/);
+  const blocks: CardBlock[] = [];
   let current: { startLine: number; lines: string[] } | null = null;
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (line.match(/^##\s+/)) {
-      if (current) cardBlocks.push(current);
+    if (/^\s*##\s+/.test(lines[i])) {
+      if (current) {
+        blocks.push({ startLine: current.startLine, fields: parseBlock(current.lines) });
+      }
       current = { startLine: i + 1, lines: [] };
     } else if (current) {
-      current.lines.push(line);
+      current.lines.push(lines[i]);
     }
   }
-  if (current) cardBlocks.push(current);
+  if (current) {
+    blocks.push({ startLine: current.startLine, fields: parseBlock(current.lines) });
+  }
 
-  if (cardBlocks.length === 0) {
+  if (blocks.length === 0) {
     return { ok: false, error: "Не найдено ни одной карточки" };
   }
 
   const cards: InsightCardDraft[] = [];
 
-  for (let idx = 0; idx < cardBlocks.length; idx++) {
-    const block = cardBlocks[idx];
+  for (let idx = 0; idx < blocks.length; idx++) {
+    const { fields, startLine } = blocks[idx];
     const cardNum = idx + 1;
 
-    const rawTag = extractField(block.lines, "Тема");
-    const title = extractField(block.lines, "Заголовок");
-    const body = extractField(block.lines, "Описание");
-    const rawQuote = extractField(block.lines, "Цитата");
-
-    if (!rawTag) {
-      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Тема»`, line: block.startLine };
+    if (!fields.тема) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Тема»`, line: startLine };
     }
-    if (!title) {
-      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Заголовок»`, line: block.startLine };
+    if (!fields.заголовок) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Заголовок»`, line: startLine };
     }
-    if (!body) {
-      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Описание»`, line: block.startLine };
+    if (!fields.описание) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Описание»`, line: startLine };
     }
-    if (rawQuote === undefined) {
-      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Цитата»`, line: block.startLine };
+    if (fields.цитата === undefined) {
+      return { ok: false, error: `Карточка ${cardNum}: отсутствует поле «Цитата»`, line: startLine };
     }
 
-    const tag = rawTag.toLowerCase().trim() as InsightTag;
+    const tag = fields.тема.toLowerCase() as InsightTag;
     if (!VALID_TAGS.has(tag)) {
       return {
         ok: false,
-        error: `Карточка ${cardNum}: неизвестная тема «${rawTag}». Допустимые: техника, тактика, физика, ментал`,
-        line: block.startLine,
+        error: `Карточка ${cardNum}: неизвестная тема «${fields.тема}». Допустимые: техника, тактика, физика, ментал`,
+        line: startLine,
       };
     }
 
     cards.push({
-      title: title.trim(),
-      body: body.trim(),
+      title: fields.заголовок,
+      body: fields.описание,
       tag,
-      quote: stripQuotes(rawQuote),
+      quote: stripQuotes(fields.цитата),
     });
   }
 


### PR DESCRIPTION
Closes #108

## Что сделано

- Создан `src/lib/ai/parseInsights.ts` — чистая функция `parseInsightsMarkdown(input)`
- Поддерживает формат `## Карточка N` с 4 полями: Тема / Заголовок / Описание / Цитата
- Ключи поля case-insensitive, тримит whitespace, снимает кавычки `"…"` и `«…»`
- 4 канонические темы: техника / тактика / физика / ментал
- При любой ошибке формата возвращает `{ ok: false, error, line }` с русским сообщением
- Создан `src/lib/ai/__tests__/parseInsights.test.ts` — 12 тестов (vitest)

## Файлы

- `src/lib/ai/parseInsights.ts` — новый
- `src/lib/ai/__tests__/parseInsights.test.ts` — новый

## Проверка

- `npx vitest run` — 19 тестов прошло (12 новых + 7 старых из postprocess)
- `npx tsc --noEmit` — только pre-existing env-ошибки (виtest module не в paths), нет ошибок в новых файлах

---
_Generated by [Claude Code](https://claude.ai/code/session_013bE4rGEVPu56RjmxV7sh1E)_