### PR TITLE
feat(ai): pasteInsightsFromClaude server action

### DIFF
--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import { parseInsightsMarkdown } from "@/lib/ai/parseInsights";
+
+async function requireTrainerOwnsSession(sessionId: string) {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+
+  const supabase = await createClient();
+
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, goals!inner(user_id)")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session) return null;
+
+  const goal = (session as unknown as { goals: { user_id: string } }).goals;
+  const studentId = goal.user_id;
+
+  const { data: studentProfile } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", studentId)
+    .eq("created_by", user.id)
+    .maybeSingle();
+
+  if (!studentProfile) return null;
+
+  return { user, supabase, studentId, trainerId: user.id };
+}
+
+export async function pasteInsightsFromClaude(
+  sessionId: string,
+  markdown: string
+): Promise<{ success: true; count: number } | { error: string; line?: number }> {
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return { error: "Сессия не найдена или нет доступа" };
+
+  const parsed = parseInsightsMarkdown(markdown);
+  if (!parsed.ok) {
+    return { error: parsed.error, line: parsed.line };
+  }
+
+  const { supabase, studentId, trainerId } = ctx;
+
+  const { error: deleteError } = await supabase
+    .from("insight_cards")
+    .delete()
+    .eq("session_id", sessionId)
+    .eq("trainer_status", "draft")
+    .eq("source", "ai-paste");
+
+  if (deleteError) {
+    return { error: deleteError.message };
+  }
+
+  const rows = parsed.cards.map((card) => ({
+    session_id: sessionId,
+    student_id: studentId,
+    trainer_id: trainerId,
+    source: "ai-paste" as const,
+    trainer_status: "draft" as const,
+    front_text: card.title,
+    title: card.title,
+    body: card.body,
+    quote: card.quote,
+    tags: [card.tag],
+  }));
+
+  const { error: insertError } = await supabase
+    .from("insight_cards")
+    .insert(rows);
+
+  if (insertError) {
+    return { error: insertError.message };
+  }
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true, count: parsed.cards.length };
+}

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -66,6 +66,7 @@ export async function pasteInsightsFromClaude(
     source: "ai-paste" as const,
     trainer_status: "draft" as const,
     front_text: card.title,
+    context_text: card.body,
     title: card.title,
     body: card.body,
     quote: card.quote,

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -68,7 +68,7 @@ export interface Session {
   created_at: string;
 }
 
-export type InsightCardSource = "manual" | "ai";
+export type InsightCardSource = "manual" | "ai" | "ai-paste";
 export type InsightTrainerStatus = "draft" | "approved" | "rejected";
 export type InsightStudentDecision = "taken" | "skipped";
 
@@ -81,6 +81,10 @@ export interface InsightCard {
   category_id: number | null;
   front_text: string;
   context_text: string | null;
+  title: string | null;
+  body: string | null;
+  quote: string | null;
+  tags: string[] | null;
   source: InsightCardSource;
   trainer_status: InsightTrainerStatus;
   student_decision: InsightStudentDecision | null;

--- a/supabase/migrations/011_ai_insight_cards.sql
+++ b/supabase/migrations/011_ai_insight_cards.sql
@@ -1,0 +1,15 @@
+-- Epic 5: add columns for AI paste-from-Claude cards
+
+ALTER TABLE public.insight_cards
+  ADD COLUMN IF NOT EXISTS title TEXT,
+  ADD COLUMN IF NOT EXISTS body TEXT,
+  ADD COLUMN IF NOT EXISTS quote TEXT,
+  ADD COLUMN IF NOT EXISTS tags TEXT[];
+
+-- Expand source CHECK to include 'ai-paste'
+ALTER TABLE public.insight_cards
+  DROP CONSTRAINT IF EXISTS insight_cards_source_check;
+
+ALTER TABLE public.insight_cards
+  ADD CONSTRAINT insight_cards_source_check
+    CHECK (source IN ('manual', 'ai', 'ai-paste'));


### PR DESCRIPTION
Closes #109

## Что сделано

- `src/lib/actions/aiInsights.ts` — Server Action `pasteInsightsFromClaude(sessionId, markdown)`
  - `requireTrainerOwnsSession` — проверяет, что пользователь trainer и сессия принадлежит его ученику
  - Вызывает `parseInsightsMarkdown` из #108; при ошибке — возвращает `{ error, line }` без изменения БД
  - DELETE старых `source='ai-paste'` + `trainer_status='draft'` карточек сессии
  - INSERT новых карточек: `source='ai-paste'`, `trainer_status='draft'`, `title/body/quote/tags`
  - `revalidatePath('/sessions/' + sessionId)`
- `supabase/migrations/011_ai_insight_cards.sql` — добавляет колонки `title`, `body`, `quote`, `tags TEXT[]` и расширяет source CHECK до `'ai-paste'`; миграция применена через Management API
- `src/lib/types/index.ts` — `InsightCardSource` расширен до `"ai-paste"`, в `InsightCard` добавлены поля `title/body/quote/tags`

## Отклонения от плана

План утверждал «изменения схемы не нужны», но текущая миграция `003_insight_cards.sql` не имеет колонок `title/body/quote/tags` и не допускает `source='ai-paste'`. Добавлена миграция 011.

## Файлы

- `src/lib/actions/aiInsights.ts` — новый
- `src/lib/types/index.ts` — обновлён
- `supabase/migrations/011_ai_insight_cards.sql` — новый, применён

## Проверка

- `npx tsc --noEmit` — только pre-existing env-ошибки
- Миграция подтверждена через `information_schema`: колонки `title/body/quote/tags` присутствуют

---
_Generated by [Claude Code](https://claude.ai/code/session_013bE4rGEVPu56RjmxV7sh1E)_