### PR TITLE
feat(insights): editor modal for draft AI cards

### DIFF
--- a/src/components/insights/EditAiCardModal.tsx
+++ b/src/components/insights/EditAiCardModal.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateAiInsightCard } from "@/lib/actions/aiInsights";
+import type { InsightCard } from "@/lib/types";
+
+const TAGS = ["техника", "тактика", "физика", "ментал"] as const;
+
+interface Props {
+  card: InsightCard;
+  onClose: () => void;
+}
+
+export function EditAiCardModal({ card, onClose }: Props) {
+  const router = useRouter();
+  const [title, setTitle] = useState(card.title || card.front_text);
+  const [body, setBody] = useState(card.body || card.context_text || "");
+  const [tag, setTag] = useState<string>(card.tags?.[0] ?? "техника");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const isValid = title.trim().length > 0 && title.trim().length <= 80 &&
+    body.trim().length > 0 && body.trim().length <= 400 &&
+    TAGS.includes(tag as typeof TAGS[number]);
+
+  function handleSave() {
+    if (!isValid) return;
+    setError(null);
+    startTransition(async () => {
+      const result = await updateAiInsightCard(card.id, {
+        title: title.trim(),
+        body: body.trim(),
+        tag,
+      });
+      if ("error" in result) {
+        setError(result.error);
+      } else {
+        router.refresh();
+        onClose();
+      }
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-card rounded-t-3xl w-full max-w-[430px] mx-auto p-6 space-y-4 pb-10"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-black tracking-tight">Редактировать карточку</h3>
+          <button
+            onClick={onClose}
+            className="w-9 h-9 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
+          >
+            <span className="material-symbols-outlined text-base">close</span>
+          </button>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+            Заголовок <span className="text-on-surface-variant/50">({title.trim().length}/80)</span>
+          </label>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={80}
+            autoFocus
+            className="w-full bg-surface-elevated rounded-xl px-3 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+            Описание <span className="text-on-surface-variant/50">({body.trim().length}/400)</span>
+          </label>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            maxLength={400}
+            rows={4}
+            className="w-full bg-surface-elevated rounded-xl p-3 text-sm text-on-surface resize-none border border-border-dim focus:border-primary focus:outline-none"
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+            Тема
+          </label>
+          <select
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+            className="w-full bg-surface-elevated rounded-xl px-3 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+          >
+            {TAGS.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        {card.quote && (
+          <div className="space-y-1">
+            <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+              Цитата (не редактируется)
+            </p>
+            <p className="rounded-xl bg-surface-elevated p-3 text-xs text-on-surface-variant italic border-l-2 border-primary/40">
+              «{card.quote}»
+            </p>
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-400 bg-red-500/10 rounded-xl p-3">{error}</p>
+        )}
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleSave}
+            disabled={isPending || !isValid}
+            className="flex-1 py-3 rounded-xl font-bold text-sm kinetic-gradient text-on-primary disabled:opacity-40 min-h-[44px]"
+          >
+            {isPending ? "Сохраняем…" : "Сохранить"}
+          </button>
+          <button
+            onClick={onClose}
+            disabled={isPending}
+            className="flex-1 py-3 rounded-xl font-bold text-sm border border-border-dim text-on-surface min-h-[44px] disabled:opacity-40"
+          >
+            Закрыть
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/insights/EditAiCardModal.tsx
+++ b/src/components/insights/EditAiCardModal.tsx
@@ -55,7 +55,8 @@ export function EditAiCardModal({ card, onClose }: Props) {
           <h3 className="text-lg font-black tracking-tight">Редактировать карточку</h3>
           <button
             onClick={onClose}
-            className="w-9 h-9 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
+            aria-label="Закрыть"
+            className="w-11 h-11 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
           >
             <span className="material-symbols-outlined text-base">close</span>
           </button>

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -137,3 +137,35 @@ export async function rejectInsightCard(
   revalidatePath(`/sessions/${sessionId}`);
   return { success: true };
 }
+
+const VALID_TAGS = new Set(["техника", "тактика", "физика", "ментал"]);
+
+export async function updateAiInsightCard(
+  cardId: string,
+  patch: { title: string; body: string; tag: string }
+): Promise<{ success: true } | { error: string }> {
+  if (!patch.title.trim()) return { error: "Заголовок обязателен" };
+  if (patch.title.trim().length > 80) return { error: "Заголовок не более 80 знаков" };
+  if (!patch.body.trim()) return { error: "Описание обязательно" };
+  if (patch.body.trim().length > 400) return { error: "Описание не более 400 знаков" };
+  if (!VALID_TAGS.has(patch.tag)) return { error: `Недопустимая тема: ${patch.tag}` };
+
+  const ctx = await requireTrainerOwnsCard(cardId);
+  if (!ctx) return { error: "Forbidden" };
+
+  const { supabase, sessionId } = ctx;
+  const { error } = await supabase
+    .from("insight_cards")
+    .update({
+      title: patch.title.trim(),
+      body: patch.body.trim(),
+      tags: [patch.tag],
+      front_text: patch.title.trim(),
+    })
+    .eq("id", cardId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true };
+}

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -161,6 +161,7 @@ export async function updateAiInsightCard(
       body: patch.body.trim(),
       tags: [patch.tag],
       front_text: patch.title.trim(),
+      context_text: patch.body.trim(),
     })
     .eq("id", cardId);
 


### PR DESCRIPTION
Closes #112

## Что сделано

- `src/lib/actions/aiInsights.ts` — добавлен `updateAiInsightCard(cardId, { title, body, tag })`
  - Валидация: title ≤80 знаков, body ≤400 знаков, tag ∈ {техника/тактика/физика/ментал}
  - Ownership check через `requireTrainerOwnsCard`
  - UPDATE `title`, `body`, `tags`, `front_text` (синхронизируем с title) — карточка остаётся `draft`
- `src/components/insights/EditAiCardModal.tsx` — bottom-sheet модалка
  - Поля: Заголовок (input, счётчик), Описание (textarea, счётчик), Тема (select 4 вариантов)
  - Цитата — read-only блок (нельзя редактировать)
  - «Сохранить» disabled при невалидных значениях
  - Ошибка сервера отображается в модалке
- `src/components/insights/AiInsightCard.tsx` — кнопка ✎ Edit теперь открывает `EditAiCardModal`

## Файлы

- `src/lib/actions/aiInsights.ts`
- `src/components/insights/EditAiCardModal.tsx` — новый
- `src/components/insights/AiInsightCard.tsx`

## Проверка

- ✅ ✎ Edit открывает модалку с заполненными полями
- ✅ Цитата отображается, не редактируется
- ✅ Сохранение обновляет карточку, карточка остаётся draft
- ✅ Валидация: пустые поля / тема не из списка → кнопка disabled + серверная ошибка
- ✅ `npx tsc --noEmit` — только pre-existing env-ошибки

---
_Generated by [Claude Code](https://claude.ai/code/session_013bE4rGEVPu56RjmxV7sh1E)_