### PR TITLE
feat(insights): student-side rendering for AI cards (title/body/quote/tags)

### DIFF
--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -159,13 +159,14 @@ export default async function MatchDetailPage({ params }: PageProps) {
   let attachedInsights: Array<{
     id: string;
     front_text: string;
+    title: string | null;
     problem: { name: string } | null;
   }> = [];
 
   if (attachedIds.length > 0) {
     const { data: insightRows } = await supabase
       .from("insight_cards")
-      .select("id, front_text, problem:problems(id, name)")
+      .select("id, front_text, title, problem:problems(id, name)")
       .in("id", attachedIds);
 
     attachedInsights = (insightRows ?? []).map((r) => {
@@ -178,6 +179,7 @@ export default async function MatchDetailPage({ params }: PageProps) {
       return {
         id: r.id,
         front_text: r.front_text,
+        title: (r.title as string | null) ?? null,
         problem: problemObj,
       };
     });
@@ -308,7 +310,7 @@ export default async function MatchDetailPage({ params }: PageProps) {
                     </span>
                     <div className="min-w-0">
                       <p className="text-sm font-semibold text-on-surface leading-snug">
-                        {insight.front_text}
+                        {insight.title || insight.front_text}
                       </p>
                       {insight.problem?.name && (
                         <p className="text-xs text-on-surface-variant mt-0.5">
@@ -355,7 +357,7 @@ export default async function MatchDetailPage({ params }: PageProps) {
                       </span>
                       <div className="min-w-0">
                         <p className="text-sm font-semibold text-on-surface leading-snug">
-                          {insight.front_text}
+                          {insight.title || insight.front_text}
                         </p>
                         {insight.problem?.name && (
                           <p className="text-xs text-on-surface-variant mt-0.5">

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -275,7 +275,7 @@ export default async function SessionDetailPage({
                   className="rounded-2xl bg-surface-card p-3 border-l-2 border-primary"
                 >
                   <p className="text-sm text-on-surface">
-                    {c.student_edited_text || c.front_text}
+                    {c.student_edited_text || c.title || c.front_text}
                   </p>
                 </div>
               ))}

--- a/src/components/insights/InsightTinder.tsx
+++ b/src/components/insights/InsightTinder.tsx
@@ -160,20 +160,34 @@ function CardFace({
         </>
       )}
       <div className="flex flex-col gap-3 mt-12">
-        {card.category && (
-          <span className="text-xs uppercase tracking-widest text-secondary font-bold">
-            {card.category.name}
-          </span>
-        )}
+        <div className="flex flex-wrap items-center gap-2">
+          {card.category && (
+            <span className="text-xs uppercase tracking-widest text-secondary font-bold">
+              {card.category.name}
+            </span>
+          )}
+          {card.tags && card.tags.length > 0 && (
+            <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">
+              {card.tags[0]}
+            </span>
+          )}
+        </div>
         <p className="text-2xl font-black text-on-surface leading-tight">
-          {card.front_text}
+          {card.title || card.front_text}
         </p>
       </div>
-      {card.context_text && (
-        <p className="text-sm text-on-surface-variant leading-relaxed">
-          {card.context_text}
-        </p>
-      )}
+      <div className="flex flex-col gap-2">
+        {(card.body || card.context_text) && (
+          <p className="text-sm text-on-surface-variant leading-relaxed">
+            {card.body || card.context_text}
+          </p>
+        )}
+        {card.quote && (
+          <p className="text-xs text-on-surface-variant italic border-l-2 border-primary/40 pl-2">
+            «{card.quote}»
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/insights/VaultGrid.tsx
+++ b/src/components/insights/VaultGrid.tsx
@@ -43,7 +43,8 @@ export default function VaultGrid({ cards, upcomingMatches, locale = "ru" }: Pro
     <div className="grid grid-cols-2 gap-3">
       {cards.map((card) => {
         const isFlipped = flipped.has(card.id);
-        const front = card.student_edited_text || card.front_text;
+        const front = card.student_edited_text || card.title || card.front_text;
+        const back = card.body || card.context_text;
         return (
           <div
             key={card.id}
@@ -57,6 +58,11 @@ export default function VaultGrid({ cards, upcomingMatches, locale = "ru" }: Pro
                     {card.category.name}
                   </span>
                 )}
+                {card.tags && card.tags.length > 0 && (
+                  <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant mb-1">
+                    {card.tags[0]}
+                  </span>
+                )}
                 <p className="text-sm font-bold text-on-surface leading-tight flex-1 line-clamp-3">
                   {front}
                 </p>
@@ -65,13 +71,18 @@ export default function VaultGrid({ cards, upcomingMatches, locale = "ru" }: Pro
                 </span>
               </div>
               <div className="vault-card-face vault-card-back">
-                {card.context_text ? (
+                {back ? (
                   <p className="text-xs text-on-surface leading-snug flex-1 line-clamp-4">
-                    {card.context_text}
+                    {back}
                   </p>
                 ) : (
                   <p className="text-xs text-on-surface-variant italic flex-1">
                     Дополнительного контекста нет.
+                  </p>
+                )}
+                {card.quote && (
+                  <p className="text-[10px] text-on-surface-variant italic border-l-2 border-primary/40 pl-2 mt-1 line-clamp-2">
+                    «{card.quote}»
                   </p>
                 )}
                 {card.session && (

--- a/src/components/insights/VaultPreview.tsx
+++ b/src/components/insights/VaultPreview.tsx
@@ -43,8 +43,13 @@ export default function VaultPreview({ cards, totalCount }: Props) {
                   {card.category.name}
                 </span>
               )}
+              {card.tags && card.tags.length > 0 && (
+                <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">
+                  {card.tags[0]}
+                </span>
+              )}
               <p className="text-xs font-bold text-on-surface leading-snug line-clamp-4">
-                {card.student_edited_text || card.front_text}
+                {card.student_edited_text || card.title || card.front_text}
               </p>
             </Link>
           ))}


### PR DESCRIPTION
Closes #121

## Что сделано

Updated all student-facing insight card rendering sites to prefer new AI fields (`title`, `body`, `quote`, `tags`) with fallback to legacy `front_text`/`context_text`:

- **VaultPreview.tsx**: front text now `student_edited_text || title || front_text`; shows `tags[0]` badge if present
- **VaultGrid.tsx**: same front fallback; back face uses `body || context_text`; shows `tags[0]` on front face and `quote` (italic with left border) on back face
- **InsightTinder.tsx** (`CardFace`): title uses `title || front_text`; body uses `body || context_text`; shows `tags[0]` badge and `quote` (italic) when present
- **sessions/[id]/page.tsx** (takenCards list): `student_edited_text || title || front_text`
- **matches/[id]/page.tsx** (`attachedInsights`): extended Supabase query to fetch `title`; interface updated; rendering uses `title || front_text`

## Паттерн

Consistent with `AiInsightCard.tsx` (trainer-side reference component):
```ts
const displayText = card.title || card.front_text;
const displayBody = card.body || card.context_text;
// + card.quote and card.tags[0] shown when present
```

https://claude.ai/code/session_01HJwMNc9TdQNAfdtNRfGaAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJwMNc9TdQNAfdtNRfGaAv)_