### PR TITLE
refactor(auth): extract requireTrainerOwnsSession to ownership.ts

### DIFF
--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -1,38 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
+import { getSession } from "@/lib/auth/session";
 import { parseInsightsMarkdown } from "@/lib/ai/parseInsights";
-
-async function requireTrainerOwnsSession(sessionId: string) {
-  const user = await getSession();
-  if (!user || user.role !== "trainer") return null;
-
-  const supabase = await createClient();
-
-  const { data: session } = await supabase
-    .from("sessions")
-    .select("id, goals!inner(user_id)")
-    .eq("id", sessionId)
-    .single();
-
-  if (!session) return null;
-
-  const goal = (session as unknown as { goals: { user_id: string } }).goals;
-  const studentId = goal.user_id;
-
-  const { data: studentProfile } = await supabase
-    .from("profiles")
-    .select("id")
-    .eq("id", studentId)
-    .eq("created_by", user.id)
-    .maybeSingle();
-
-  if (!studentProfile) return null;
-
-  return { user, supabase, studentId, trainerId: user.id };
-}
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
 
 export async function pasteInsightsFromClaude(
   sessionId: string,

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -1,40 +1,10 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
-import { getSession } from "@/lib/auth/session";
 import { postprocessTranscript } from "@/lib/stt/postprocess";
 import { revalidatePath } from "next/cache";
 import { randomUUID } from "crypto";
 import { redirect } from "next/navigation";
-
-async function requireTrainerOwnsSession(sessionId: string) {
-  const user = await getSession();
-  if (!user || user.role !== "trainer") return null;
-
-  const supabase = await createClient();
-
-  const { data: session } = await supabase
-    .from("sessions")
-    .select("id, goals(user_id)")
-    .eq("id", sessionId)
-    .single();
-
-  if (!session) return null;
-
-  const goal = session.goals as unknown as { user_id: string } | null;
-  if (!goal) return null;
-
-  const { data: studentProfile } = await supabase
-    .from("profiles")
-    .select("id")
-    .eq("id", goal.user_id)
-    .eq("created_by", user.id)
-    .maybeSingle();
-
-  if (!studentProfile) return null;
-
-  return { user, supabase };
-}
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
 
 const ALLOWED_AUDIO_EXTENSIONS = new Set(["m4a", "mp3", "wav", "ogg", "webm", "mp4", "aac"]);
 

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -1,0 +1,53 @@
+import { createClient } from "@/lib/supabase/server";
+import { getSession } from "@/lib/auth/session";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SessionUser } from "@/lib/auth/session";
+
+export type OwnershipContext = {
+  user: SessionUser;
+  supabase: SupabaseClient;
+  studentId: string;
+  trainerId: string;
+};
+
+/**
+ * Verifies that the current session belongs to a trainer who owns the given
+ * training session (i.e. the session's goal belongs to a student created by
+ * this trainer).
+ *
+ * Returns an OwnershipContext on success, or null if the check fails (not
+ * authenticated, not a trainer, session not found, or not the trainer's student).
+ *
+ * NOTE: this is a plain module — no "use server" — so it can be imported from
+ * both Server Actions and Route Handlers without becoming an RPC endpoint.
+ */
+export async function requireTrainerOwnsSession(
+  sessionId: string
+): Promise<OwnershipContext | null> {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+
+  const supabase = await createClient();
+
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, goals!inner(user_id)")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session) return null;
+
+  const goal = (session as unknown as { goals: { user_id: string } }).goals;
+  const studentId = goal.user_id;
+
+  const { data: studentProfile } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", studentId)
+    .eq("created_by", user.id)
+    .maybeSingle();
+
+  if (!studentProfile) return null;
+
+  return { user, supabase, studentId, trainerId: user.id };
+}


### PR DESCRIPTION
## Summary

- Creates `src/lib/auth/ownership.ts` — a plain module (no `"use server"`) exporting `requireTrainerOwnsSession` and the `OwnershipContext` type
- Removes the duplicated local helper from `src/lib/actions/audio.ts` and `src/lib/actions/aiInsights.ts`
- Both files now import from `@/lib/auth/ownership`

Closes #123

## Отклонения от плана

The two inline implementations differed slightly:
- `audio.ts` used `goals(user_id)` (left join) and returned `{ user, supabase }` only
- `aiInsights.ts` used `goals!inner(user_id)` (inner join) and returned `{ user, supabase, studentId, trainerId }`

The unified helper uses `!inner` (stricter, matches the aiInsights behavior) and always returns all four fields. `audio.ts` callers only destructure `{ supabase }` so the extra fields are harmlessly ignored. The `!inner` join makes the goal-null check implicit in the SQL rather than an explicit `if (!goal) return null` guard.

## What to check

- [ ] Trainer flow: upload audio on `/sessions/[id]` — transcription still works
- [ ] Trainer flow: paste insights from Claude on `/sessions/[id]` — insight cards created correctly
- [ ] `src/lib/auth/ownership.ts` has no `"use server"` at the top
- [ ] No duplicate `requireTrainerOwnsSession` anywhere in `src/`

https://claude.ai/code/session_01XR8gSuRgNq7VHtBGht5Hcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XR8gSuRgNq7VHtBGht5Hcz)_