### PR TITLE
feat(ui): переименовать «История сессий» → «Тренировки», «Сессия N» → «Индивидуальная N»

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -372,7 +372,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="font-semibold text-sm">
-                          {t(locale, "dashboard.session")} {session.session_number}
+                          {t(locale, "dashboard.trainingType.individual")} {session.session_number}
                         </p>
                         <p className="text-[11px] text-on-surface-variant">
                           {new Date(session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long" })}

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -51,8 +51,9 @@ const ru = {
   "dashboard.activeGoals": "Активные цели",
   "dashboard.sessions": "сессий",
   "dashboard.skillProgression": "Прогресс навыков",
-  "dashboard.sessionHistory": "История сессий",
+  "dashboard.sessionHistory": "Тренировки",
   "dashboard.session": "Сессия",
+  "dashboard.trainingType.individual": "Индивидуальная",
   "dashboard.nextSession": "Следующая сессия",
   "dashboard.exercises": "Упражнения",
 
@@ -208,8 +209,9 @@ const en: Record<keyof typeof ru, string> = {
   "dashboard.activeGoals": "Active goals",
   "dashboard.sessions": "sessions",
   "dashboard.skillProgression": "Skill progression",
-  "dashboard.sessionHistory": "Session history",
+  "dashboard.sessionHistory": "Trainings",
   "dashboard.session": "Session",
+  "dashboard.trainingType.individual": "Individual",
   "dashboard.nextSession": "Next session",
   "dashboard.exercises": "Exercises",
 


### PR DESCRIPTION
## Что сделано

В секции «История сессий» на экране ученика (`DashboardView`):

- Заголовок секции **«История сессий»** → **«Тренировки»** (`Session history` → `Trainings` в EN).
- Подпись внутри карточек **«Сессия N»** → **«Индивидуальная N»** (`Session N` → `Individual N`).
- Кнопка `+ SESSION` в правом верхнем углу секции — не тронута.
- Блок «Следующая сессия» ниже — не тронут (использует тот же `dashboard.session`, но переименование там пользователь не просил).

## Изменённые файлы

- `src/lib/i18n/dict.ts` — обновлены значения `dashboard.sessionHistory` (RU/EN), добавлен ключ `dashboard.trainingType.individual`.
- `src/components/dashboard/DashboardView.tsx` — карточка списка использует `dashboard.trainingType.individual` вместо `dashboard.session`.

## Отклонения от плана

В плане предлагалось менять литералы по grep `«Сессия »`. По факту слово в карточке формируется через i18n (`t(locale, "dashboard.session")`), а ключ `dashboard.session` шарится с блоком «Следующая сессия». Чтобы не задеть соседнюю секцию, добавил новый ключ `dashboard.trainingType.individual` и подменил вызов точечно в нужном месте.

## Проверка

- `npx tsc --noEmit` — без ошибок.
- `npx eslint` на тронутых файлах — без ошибок по моим правкам (есть пред-существующий warning `Date.now` на строке 111, не относится к PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)