### PR TITLE
feat(insights): пилюли над карточкой AI-черновика, плотнее spacing внутри

### DIFF
--- a/src/components/insights/DraftCardsList.tsx
+++ b/src/components/insights/DraftCardsList.tsx
@@ -88,11 +88,23 @@ export function DraftCardsList({ cards, isTrainer }: Props) {
   const dx = drag?.x ?? 0;
   const rot = dx / 18;
   const opacity = exiting ? 0 : 1 - Math.min(Math.abs(dx) / 400, 0.4);
+  const topTag = top.tags?.[0] ?? null;
 
   return (
     <>
       <div className="space-y-5">
-        <div className="tinder-stack">
+        <div>
+          <div className="flex items-center gap-2 px-1 mb-2">
+            <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-300">
+              AI черновик
+            </span>
+            {topTag && (
+              <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+                {topTag}
+              </span>
+            )}
+          </div>
+          <div className="tinder-stack">
           {next && <DraftCardFace card={next} stacked />}
           <div
             className={`tinder-card ${drag ? "dragging" : ""} ${
@@ -111,6 +123,7 @@ export function DraftCardsList({ cards, isTrainer }: Props) {
           >
             <DraftCardFace card={top} dx={dx} />
           </div>
+        </div>
         </div>
 
         {isTrainer && (
@@ -164,53 +177,38 @@ function DraftCardFace({
 }) {
   const title = card.title || card.front_text || "";
   const body = card.body || card.context_text || "";
-  const tag = card.tags?.[0] ?? null;
 
   return (
     <div
-      className={`absolute inset-0 rounded-3xl p-6 flex flex-col justify-between bg-white border border-gray-200 shadow-lg ${
+      className={`absolute inset-0 rounded-3xl p-6 flex flex-col gap-3 bg-white border border-gray-200 shadow-lg overflow-hidden ${
         stacked ? "scale-[0.94] -translate-y-3 opacity-60" : ""
       }`}
     >
       {!stacked && (
         <>
           <div
-            className="absolute top-6 left-6 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-green-500 text-white"
+            className="absolute top-4 left-4 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-green-500 text-white pointer-events-none"
             style={{ opacity: Math.max(0, Math.min(1, dx / 80)) }}
           >
             Принять
           </div>
           <div
-            className="absolute top-6 right-6 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-red-500 text-white"
+            className="absolute top-4 right-4 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-red-500 text-white pointer-events-none"
             style={{ opacity: Math.max(0, Math.min(1, -dx / 80)) }}
           >
             Отклонить
           </div>
         </>
       )}
-      <div className="flex flex-col gap-3 mt-10">
-        <div className="flex items-center gap-2">
-          <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">
-            AI черновик
-          </span>
-          {tag && (
-            <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500">
-              {tag}
-            </span>
-          )}
-        </div>
-        <p className="text-2xl font-black text-gray-900 leading-tight">{title}</p>
-      </div>
-      <div className="flex flex-col gap-3 mt-4">
-        {body && (
-          <p className="text-sm text-gray-700 leading-relaxed">{body}</p>
-        )}
-        {card.quote && (
-          <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
-            «{card.quote}»
-          </p>
-        )}
-      </div>
+      <p className="text-2xl font-black text-gray-900 leading-tight">{title}</p>
+      {body && (
+        <p className="text-sm text-gray-700 leading-relaxed">{body}</p>
+      )}
+      {card.quote && (
+        <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
+          «{card.quote}»
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Что изменилось

**До:** пилюли «AI ЧЕРНОВИК» + тег категории находились внутри белой карточки сверху, плюс layout использовал `flex justify-between` на высоте 460px — это создавало большие пустоты сверху, между заголовком и body, и между body и цитатой. Карточка выглядела пустой и текст оторванным друг от друга.

**После:**
- Пилюли вынесены НАД белой карточкой, на тёмный фон страницы. Расстояние пилюли → карточка = `mb-2`.
- Внутри карточки убрал `justify-between` и `mt-10` — теперь заголовок, body и цитата идут единым flex-потоком с `gap-3`. Текст читается как один связный блок.
- Indicator-пилюли «Принять/Отклонить» (которые появляются при свайпе) подвинуты в углы карточки (top-4) и получили `pointer-events-none`, чтобы не мешать жесту.
- Добавил `overflow-hidden` к карточке, чтобы свайп-индикаторы не вылезали за её радиусы.

## Затронутые файлы

- \`src/components/insights/DraftCardsList.tsx\` — компонент \`DraftCardFace\` и обёртка \`DraftCardsList\`.

## Mobile

Проверено визуально под ~390px. Пилюли в светлых тонах (\`bg-amber-500/20 text-amber-300\`) на тёмном фоне страницы читаемы. Никаких overflow по горизонтали.

## Acceptance check

- [x] Пилюли над белой карточкой, не внутри.
- [x] Spacing внутри карточки плотный (gap-3), без оторванности.
- [x] Action-кнопки (×, ✎, ✓), секции APPROVED и paste — не тронуты.
- [x] typecheck OK; lint в DraftCardsList.tsx чистый (предсуществующие ошибки в других файлах остались как есть).