### PR TITLE
feat(insights): тап по approved-карточке открывает модалку с edit/delete

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -6,8 +6,8 @@ import Link from "next/link";
 import type { InsightCard } from "@/lib/types";
 import { AudioUploader } from "@/components/sessions/AudioUploader";
 import { PasteInsightsButton } from "@/components/sessions/PasteInsightsButton";
-import { AiInsightCard } from "@/components/insights/AiInsightCard";
 import { DraftCardsList } from "@/components/insights/DraftCardsList";
+import { ApprovedInsightCard } from "@/components/insights/ApprovedInsightCard";
 
 export default async function SessionDetailPage({
   params,
@@ -227,7 +227,7 @@ export default async function SessionDetailPage({
                 {isRu ? `Approved (${approvedCards.length})` : `Approved (${approvedCards.length})`}
               </p>
               {approvedCards.map((c) => (
-                <AiInsightCard key={c.id} card={c} isTrainer={isTrainer} />
+                <ApprovedInsightCard key={c.id} card={c} />
               ))}
             </div>
           )}

--- a/src/components/insights/ApprovedInsightCard.tsx
+++ b/src/components/insights/ApprovedInsightCard.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { deleteAiInsightCard } from "@/lib/actions/aiInsights";
+import { EditAiCardModal } from "./EditAiCardModal";
+import type { InsightCard } from "@/lib/types";
+
+interface Props {
+  card: InsightCard;
+}
+
+export function ApprovedInsightCard({ card }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const displayText = card.title || card.front_text;
+  const displayBody = card.body || card.context_text;
+  const tag = card.tags?.[0] ?? null;
+
+  function handleDelete() {
+    startTransition(async () => {
+      const res = await deleteAiInsightCard(card.id);
+      if ("error" in res) {
+        setConfirmDelete(false);
+        return;
+      }
+      setOpen(false);
+      setConfirmDelete(false);
+      router.refresh();
+    });
+  }
+
+  function handleEdit() {
+    setOpen(false);
+    setEditing(true);
+  }
+
+  const sheet =
+    open && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
+            onClick={() => setOpen(false)}
+          >
+            <div
+              className="w-full max-w-[430px] mx-auto p-5 pb-8 space-y-5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="relative rounded-3xl p-6 bg-white border border-gray-200 shadow-lg space-y-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-green-100 text-green-700">
+                    Approved
+                  </span>
+                  {tag && (
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500">
+                      {tag}
+                    </span>
+                  )}
+                </div>
+                <p className="text-2xl font-black text-gray-900 leading-tight">
+                  {displayText}
+                </p>
+                {displayBody && (
+                  <p className="text-sm text-gray-700 leading-relaxed">
+                    {displayBody}
+                  </p>
+                )}
+                {card.quote && (
+                  <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
+                    «{card.quote}»
+                  </p>
+                )}
+              </div>
+
+              <div className="flex items-center justify-center gap-4">
+                <button
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={isPending}
+                  aria-label="Удалить"
+                  className="w-16 h-16 rounded-full bg-white/95 border border-red-200 flex items-center justify-center active:scale-95 transition-transform shadow disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined text-red-500 text-3xl">
+                    close
+                  </span>
+                </button>
+                <button
+                  onClick={handleEdit}
+                  disabled={isPending}
+                  aria-label="Редактировать"
+                  className="w-16 h-16 rounded-full bg-white/95 border border-gray-200 flex items-center justify-center active:scale-95 transition-transform shadow disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined text-gray-700 text-2xl">
+                    edit
+                  </span>
+                </button>
+                <button
+                  onClick={() => setOpen(false)}
+                  disabled={isPending}
+                  aria-label="Готово"
+                  className="w-20 h-20 rounded-full kinetic-gradient glow-primary flex items-center justify-center active:scale-95 transition-transform disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined fill-icon text-on-primary text-4xl">
+                    check
+                  </span>
+                </button>
+              </div>
+
+              {confirmDelete && (
+                <div className="rounded-2xl bg-surface-card border border-red-500/40 p-4 space-y-3">
+                  <p className="text-sm font-bold text-on-surface">
+                    Удалить карточку?
+                  </p>
+                  <p className="text-xs text-on-surface-variant">
+                    Карточка пропадёт у ученика и не вернётся в черновики.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleDelete}
+                      disabled={isPending}
+                      className="flex-1 py-2.5 rounded-xl text-xs font-bold bg-red-500 text-white min-h-[44px] disabled:opacity-40"
+                    >
+                      {isPending ? "Удаляем…" : "Удалить"}
+                    </button>
+                    <button
+                      onClick={() => setConfirmDelete(false)}
+                      disabled={isPending}
+                      className="flex-1 py-2.5 rounded-xl text-xs font-bold border border-border-dim text-on-surface min-h-[44px] disabled:opacity-40"
+                    >
+                      Отмена
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="w-full text-left rounded-2xl p-4 space-y-2 bg-surface-card border border-border-dim active:scale-[0.99] transition-transform cursor-pointer min-h-[44px]"
+      >
+        <p className="text-sm font-bold text-on-surface">{displayText}</p>
+        {displayBody && (
+          <p className="text-xs text-on-surface-variant leading-relaxed">
+            {displayBody}
+          </p>
+        )}
+        {card.quote && (
+          <p className="text-[10px] text-on-surface-variant italic border-l-2 border-primary/40 pl-2">
+            «{card.quote}»
+          </p>
+        )}
+      </button>
+
+      {sheet}
+
+      {editing && (
+        <EditAiCardModal card={card} onClose={() => setEditing(false)} />
+      )}
+    </>
+  );
+}

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -93,6 +93,24 @@ export async function rejectInsightCard(
   return { success: true };
 }
 
+export async function deleteAiInsightCard(
+  cardId: string
+): Promise<{ success: true } | { error: string }> {
+  const ctx = await requireTrainerOwnsCard(cardId);
+  if (!ctx) return { error: "Forbidden" };
+
+  const { supabase, sessionId } = ctx;
+  const { error } = await supabase
+    .from("insight_cards")
+    .delete()
+    .eq("id", cardId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true };
+}
+
 const VALID_TAGS = new Set(["техника", "тактика", "физика", "ментал"]);
 
 export async function updateAiInsightCard(


### PR DESCRIPTION
## Что

Approved-инсайты в секции «Approved» под каруселью AI-черновиков теперь тапабельны. По тапу открывается **bottom-sheet через portal** (mobile-first, AGENTS.md) с тем же визуалом, что и карточка AI-черновика (белая карточка + title + body + цитата + пилюли), и тремя действиями под ней:

- **×** — удалить инсайт (с подтверждением; карточка не возвращается в черновики)
- **✎** — открыть `EditAiCardModal` (переиспользован) для редактирования title/body/tag
- **✓** — закрыть sheet

## Изменённые файлы

- `src/components/insights/ApprovedInsightCard.tsx` — новый client-компонент (тёмная компактная карточка в списке + portal-sheet с действиями)
- `src/app/sessions/[id]/page.tsx` — approved-цикл рендерит `ApprovedInsightCard` вместо `AiInsightCard`
- `src/lib/actions/aiInsights.ts` — новый server action `deleteAiInsightCard` (hard delete, авторизация через существующий `requireTrainerOwnsCard`)

## Auth

`deleteAiInsightCard` использует существующий `requireTrainerOwnsCard` — только тренер-владелец карточки может удалить.

## UX

- Тач-зоны кнопок ≥ 44px (64×64 и 80×80 px).
- Карточка-триггер имеет `cursor-pointer` + `active:scale-[0.99]`.
- Backdrop — `bg-background/80 backdrop-blur-sm`, тап вне sheet закрывает.
- Body scroll lock пока sheet открыт.

## Отклонения от плана

- Использовал новый компонент `ApprovedInsightCard` вместо переиспользования `AiInsightCard` для approved-кейса — у `AiInsightCard` сейчас компактный inline-вид без поддержки тапа/sheet, и расширять его в обратимом виде было бы рискованнее. `AiInsightCard.tsx` оставлен без изменений (после этого PR он становится unused; удаление вынесу отдельным chore-PR).
- Большая белая карточка в sheet дублирует визуал из `DraftCardsList::DraftCardFace` (не импортирована, т.к. та — приватная функция и завязана на свайп). Это сознательная минимальная копия markup без свайп-логики.

## Риск конфликта

Возможен конфликт с PR `feat/ai-draft-card-layout` (параллельный агент правит layout AI-черновика). Этот PR не трогает `DraftCardsList.tsx` / `AiInsightCard.tsx` — конфликт маловероятен. Если возникнет — разрешается тривиально.

## Test plan

- [ ] Тренер открывает сессию с approved-инсайтами → тап по тёмной карточке → открывается sheet с белой карточкой и тремя кнопками.
- [ ] ✎ → открывается `EditAiCardModal`, сохранение применяется к карточке.
- [ ] × → confirm → карточка удаляется, sheet закрывается, refresh.
- [ ] ✓ или backdrop → закрытие без изменений.
- [ ] Не-тренер (или чужая сессия) не может вызвать delete (Forbidden).