### PR TITLE
feat(ui): combined — тренировки, layout AI-черновика, approved tap-to-edit

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -6,8 +6,8 @@ import Link from "next/link";
 import type { InsightCard } from "@/lib/types";
 import { AudioUploader } from "@/components/sessions/AudioUploader";
 import { PasteInsightsButton } from "@/components/sessions/PasteInsightsButton";
-import { AiInsightCard } from "@/components/insights/AiInsightCard";
 import { DraftCardsList } from "@/components/insights/DraftCardsList";
+import { ApprovedInsightCard } from "@/components/insights/ApprovedInsightCard";
 
 export default async function SessionDetailPage({
   params,
@@ -227,7 +227,7 @@ export default async function SessionDetailPage({
                 {isRu ? `Approved (${approvedCards.length})` : `Approved (${approvedCards.length})`}
               </p>
               {approvedCards.map((c) => (
-                <AiInsightCard key={c.id} card={c} isTrainer={isTrainer} />
+                <ApprovedInsightCard key={c.id} card={c} />
               ))}
             </div>
           )}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -372,7 +372,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="font-semibold text-sm">
-                          {t(locale, "dashboard.session")} {session.session_number}
+                          {t(locale, "dashboard.trainingType.individual")} {session.session_number}
                         </p>
                         <p className="text-[11px] text-on-surface-variant">
                           {new Date(session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long" })}

--- a/src/components/insights/ApprovedInsightCard.tsx
+++ b/src/components/insights/ApprovedInsightCard.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { deleteAiInsightCard } from "@/lib/actions/aiInsights";
+import { EditAiCardModal } from "./EditAiCardModal";
+import type { InsightCard } from "@/lib/types";
+
+interface Props {
+  card: InsightCard;
+}
+
+export function ApprovedInsightCard({ card }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  const displayText = card.title || card.front_text;
+  const displayBody = card.body || card.context_text;
+  const tag = card.tags?.[0] ?? null;
+
+  function handleDelete() {
+    startTransition(async () => {
+      const res = await deleteAiInsightCard(card.id);
+      if ("error" in res) {
+        setConfirmDelete(false);
+        return;
+      }
+      setOpen(false);
+      setConfirmDelete(false);
+      router.refresh();
+    });
+  }
+
+  function handleEdit() {
+    setOpen(false);
+    setEditing(true);
+  }
+
+  const sheet =
+    open && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
+            onClick={() => setOpen(false)}
+          >
+            <div
+              className="w-full max-w-[430px] mx-auto p-5 pb-8 space-y-5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="relative rounded-3xl p-6 bg-white border border-gray-200 shadow-lg space-y-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-green-100 text-green-700">
+                    Approved
+                  </span>
+                  {tag && (
+                    <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500">
+                      {tag}
+                    </span>
+                  )}
+                </div>
+                <p className="text-2xl font-black text-gray-900 leading-tight">
+                  {displayText}
+                </p>
+                {displayBody && (
+                  <p className="text-sm text-gray-700 leading-relaxed">
+                    {displayBody}
+                  </p>
+                )}
+                {card.quote && (
+                  <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
+                    «{card.quote}»
+                  </p>
+                )}
+              </div>
+
+              <div className="flex items-center justify-center gap-4">
+                <button
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={isPending}
+                  aria-label="Удалить"
+                  className="w-16 h-16 rounded-full bg-white/95 border border-red-200 flex items-center justify-center active:scale-95 transition-transform shadow disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined text-red-500 text-3xl">
+                    close
+                  </span>
+                </button>
+                <button
+                  onClick={handleEdit}
+                  disabled={isPending}
+                  aria-label="Редактировать"
+                  className="w-16 h-16 rounded-full bg-white/95 border border-gray-200 flex items-center justify-center active:scale-95 transition-transform shadow disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined text-gray-700 text-2xl">
+                    edit
+                  </span>
+                </button>
+                <button
+                  onClick={() => setOpen(false)}
+                  disabled={isPending}
+                  aria-label="Готово"
+                  className="w-20 h-20 rounded-full kinetic-gradient glow-primary flex items-center justify-center active:scale-95 transition-transform disabled:opacity-40"
+                >
+                  <span className="material-symbols-outlined fill-icon text-on-primary text-4xl">
+                    check
+                  </span>
+                </button>
+              </div>
+
+              {confirmDelete && (
+                <div className="rounded-2xl bg-surface-card border border-red-500/40 p-4 space-y-3">
+                  <p className="text-sm font-bold text-on-surface">
+                    Удалить карточку?
+                  </p>
+                  <p className="text-xs text-on-surface-variant">
+                    Карточка пропадёт у ученика и не вернётся в черновики.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleDelete}
+                      disabled={isPending}
+                      className="flex-1 py-2.5 rounded-xl text-xs font-bold bg-red-500 text-white min-h-[44px] disabled:opacity-40"
+                    >
+                      {isPending ? "Удаляем…" : "Удалить"}
+                    </button>
+                    <button
+                      onClick={() => setConfirmDelete(false)}
+                      disabled={isPending}
+                      className="flex-1 py-2.5 rounded-xl text-xs font-bold border border-border-dim text-on-surface min-h-[44px] disabled:opacity-40"
+                    >
+                      Отмена
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="w-full text-left rounded-2xl p-4 space-y-2 bg-surface-card border border-border-dim active:scale-[0.99] transition-transform cursor-pointer min-h-[44px]"
+      >
+        <p className="text-sm font-bold text-on-surface">{displayText}</p>
+        {displayBody && (
+          <p className="text-xs text-on-surface-variant leading-relaxed">
+            {displayBody}
+          </p>
+        )}
+        {card.quote && (
+          <p className="text-[10px] text-on-surface-variant italic border-l-2 border-primary/40 pl-2">
+            «{card.quote}»
+          </p>
+        )}
+      </button>
+
+      {sheet}
+
+      {editing && (
+        <EditAiCardModal card={card} onClose={() => setEditing(false)} />
+      )}
+    </>
+  );
+}

--- a/src/components/insights/DraftCardsList.tsx
+++ b/src/components/insights/DraftCardsList.tsx
@@ -88,11 +88,23 @@ export function DraftCardsList({ cards, isTrainer }: Props) {
   const dx = drag?.x ?? 0;
   const rot = dx / 18;
   const opacity = exiting ? 0 : 1 - Math.min(Math.abs(dx) / 400, 0.4);
+  const topTag = top.tags?.[0] ?? null;
 
   return (
     <>
       <div className="space-y-5">
-        <div className="tinder-stack">
+        <div>
+          <div className="flex items-center gap-2 px-1 mb-2">
+            <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-300">
+              AI черновик
+            </span>
+            {topTag && (
+              <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+                {topTag}
+              </span>
+            )}
+          </div>
+          <div className="tinder-stack">
           {next && <DraftCardFace card={next} stacked />}
           <div
             className={`tinder-card ${drag ? "dragging" : ""} ${
@@ -111,6 +123,7 @@ export function DraftCardsList({ cards, isTrainer }: Props) {
           >
             <DraftCardFace card={top} dx={dx} />
           </div>
+        </div>
         </div>
 
         {isTrainer && (
@@ -164,53 +177,38 @@ function DraftCardFace({
 }) {
   const title = card.title || card.front_text || "";
   const body = card.body || card.context_text || "";
-  const tag = card.tags?.[0] ?? null;
 
   return (
     <div
-      className={`absolute inset-0 rounded-3xl p-6 flex flex-col justify-between bg-white border border-gray-200 shadow-lg ${
+      className={`absolute inset-0 rounded-3xl p-6 flex flex-col gap-3 bg-white border border-gray-200 shadow-lg overflow-hidden ${
         stacked ? "scale-[0.94] -translate-y-3 opacity-60" : ""
       }`}
     >
       {!stacked && (
         <>
           <div
-            className="absolute top-6 left-6 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-green-500 text-white"
+            className="absolute top-4 left-4 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-green-500 text-white pointer-events-none"
             style={{ opacity: Math.max(0, Math.min(1, dx / 80)) }}
           >
             Принять
           </div>
           <div
-            className="absolute top-6 right-6 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-red-500 text-white"
+            className="absolute top-4 right-4 z-10 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-red-500 text-white pointer-events-none"
             style={{ opacity: Math.max(0, Math.min(1, -dx / 80)) }}
           >
             Отклонить
           </div>
         </>
       )}
-      <div className="flex flex-col gap-3 mt-10">
-        <div className="flex items-center gap-2">
-          <span className="text-[9px] font-black uppercase tracking-widest px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">
-            AI черновик
-          </span>
-          {tag && (
-            <span className="text-[10px] font-bold uppercase tracking-widest text-gray-500">
-              {tag}
-            </span>
-          )}
-        </div>
-        <p className="text-2xl font-black text-gray-900 leading-tight">{title}</p>
-      </div>
-      <div className="flex flex-col gap-3 mt-4">
-        {body && (
-          <p className="text-sm text-gray-700 leading-relaxed">{body}</p>
-        )}
-        {card.quote && (
-          <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
-            «{card.quote}»
-          </p>
-        )}
-      </div>
+      <p className="text-2xl font-black text-gray-900 leading-tight">{title}</p>
+      {body && (
+        <p className="text-sm text-gray-700 leading-relaxed">{body}</p>
+      )}
+      {card.quote && (
+        <p className="text-xs text-gray-500 italic border-l-2 border-amber-400 pl-2">
+          «{card.quote}»
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -93,6 +93,24 @@ export async function rejectInsightCard(
   return { success: true };
 }
 
+export async function deleteAiInsightCard(
+  cardId: string
+): Promise<{ success: true } | { error: string }> {
+  const ctx = await requireTrainerOwnsCard(cardId);
+  if (!ctx) return { error: "Forbidden" };
+
+  const { supabase, sessionId } = ctx;
+  const { error } = await supabase
+    .from("insight_cards")
+    .delete()
+    .eq("id", cardId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true };
+}
+
 const VALID_TAGS = new Set(["техника", "тактика", "физика", "ментал"]);
 
 export async function updateAiInsightCard(

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -51,8 +51,9 @@ const ru = {
   "dashboard.activeGoals": "Активные цели",
   "dashboard.sessions": "сессий",
   "dashboard.skillProgression": "Прогресс навыков",
-  "dashboard.sessionHistory": "История сессий",
+  "dashboard.sessionHistory": "Тренировки",
   "dashboard.session": "Сессия",
+  "dashboard.trainingType.individual": "Индивидуальная",
   "dashboard.nextSession": "Следующая сессия",
   "dashboard.exercises": "Упражнения",
 
@@ -208,8 +209,9 @@ const en: Record<keyof typeof ru, string> = {
   "dashboard.activeGoals": "Active goals",
   "dashboard.sessions": "sessions",
   "dashboard.skillProgression": "Skill progression",
-  "dashboard.sessionHistory": "Session history",
+  "dashboard.sessionHistory": "Trainings",
   "dashboard.session": "Session",
+  "dashboard.trainingType.individual": "Individual",
   "dashboard.nextSession": "Next session",
   "dashboard.exercises": "Exercises",
 


### PR DESCRIPTION
Объединяет три PR: #129, #130, #131. Конфликтов при мерже нет, typecheck чист.

## Что вошло
- **#129 — Тренировки/Индивидуальная**: `dashboard.sessionHistory` → «Тренировки», карточка в списке → «Индивидуальная N». Кнопка `+ SESSION` не тронута. Файлы: `src/lib/i18n/dict.ts`, `src/components/dashboard/DashboardView.tsx`.
- **#130 — Layout AI-черновика**: пилюли «AI черновик» + тег вынесены ИЗ белой карточки на тёмный фон над ней (`mb-2`); внутри карточки `flex flex-col gap-3` вместо `justify-between + mt-10` — заголовок/body/quote читаются как один блок. Свайп-индикаторы перепозиционированы в углы. Файл: `src/components/insights/DraftCardsList.tsx`.
- **#131 — Approved tap-to-edit**: новая карточка `ApprovedInsightCard` (client) с bottom-sheet через portal, действия ×/✎/✓. Edit переиспользует существующий `EditAiCardModal`. Новый server action `deleteAiInsightCard` (hard delete + revalidate, auth через `requireTrainerOwnsCard`). Файлы: `src/components/insights/ApprovedInsightCard.tsx` (новый), `src/app/sessions/[id]/page.tsx`, `src/lib/actions/aiInsights.ts`.

## Проверки
- `git merge` всех трёх веток в `feat/combined-ui-updates` — без конфликтов.
- `npx tsc --noEmit` — чисто.

После мержа этого PR закройте #129, #130, #131 (они дублируют изменения).