### PR TITLE
feat(dashboard): заголовок тренировки — день недели + время

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -372,7 +372,12 @@ export default function DashboardView({ data, locale, editable }: Props) {
                       </div>
                       <div className="flex-1 min-w-0">
                         <p className="font-semibold text-sm">
-                          {t(locale, "dashboard.trainingType.individual")} {session.session_number}
+                          {(() => {
+                            const d = new Date(session.created_at);
+                            const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long" }).format(d);
+                            const time = new Intl.DateTimeFormat(dateLocale, { hour: "2-digit", minute: "2-digit", hour12: false }).format(d);
+                            return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${time}`;
+                          })()}
                         </p>
                         <p className="text-[11px] text-on-surface-variant">
                           {new Date(session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long" })}

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -53,7 +53,6 @@ const ru = {
   "dashboard.skillProgression": "Прогресс навыков",
   "dashboard.sessionHistory": "Тренировки",
   "dashboard.session": "Сессия",
-  "dashboard.trainingType.individual": "Индивидуальная",
   "dashboard.nextSession": "Следующая сессия",
   "dashboard.exercises": "Упражнения",
 
@@ -211,7 +210,6 @@ const en: Record<keyof typeof ru, string> = {
   "dashboard.skillProgression": "Skill progression",
   "dashboard.sessionHistory": "Trainings",
   "dashboard.session": "Session",
-  "dashboard.trainingType.individual": "Individual",
   "dashboard.nextSession": "Next session",
   "dashboard.exercises": "Exercises",
 


### PR DESCRIPTION
## Что

В карточке тренировки в секции «ТРЕНИРОВКИ» (DashboardView.tsx) заголовок «Индивидуальная N» заменён на «День_недели HH:MM» (например «Среда 16:30»). Подзаголовок (дата + статус) сохранён.

## Детали

- День недели и время форматируются через `Intl.DateTimeFormat` (`ru-RU` / `en-US`), без новых i18n-ключей.
- Первая буква дня недели приведена в uppercase.
- Время в 24h формате `HH:MM`.
- Источник — `session.created_at` (см. ниже).
- Удалён неиспользуемый i18n-ключ `dashboard.trainingType.individual` из `src/lib/i18n/dict.ts` (ru + en).

## Отклонения от плана

В типе `SessionListItem` (`src/lib/dashboard/data.ts`) нет поля `scheduled_at` — только `created_at`. Использован `created_at` (то же поле, что и в подзаголовке «13 мая»), чтобы день недели/время были согласованы с датой ниже.

## Проверка

- [x] `npx tsc --noEmit` — чисто
- [ ] Визуально: в секции «ТРЕНИРОВКИ» заголовок карточки — «Среда 16:30» вместо «Индивидуальная 1»
- [ ] Подзаголовок «13 мая · Завершено» на месте
- [ ] EN-локаль — «Wednesday 16:30»

🤖 Generated with [Claude Code](https://claude.com/claude-code)