### PR TITLE
feat(trainer): preview ученика как видит он сам

### DIFF
--- a/src/app/sessions/[id]/insights/page.tsx
+++ b/src/app/sessions/[id]/insights/page.tsx
@@ -10,13 +10,14 @@ export default async function SessionInsightsPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ include?: string }>;
+  searchParams: Promise<{ include?: string; as?: string }>;
 }) {
   const user = await getSession();
   if (!user) redirect("/login");
 
   const { id } = await params;
-  const { include } = await searchParams;
+  const { include, as } = await searchParams;
+  const previewAsStudent = user.role === "trainer" && as === "student";
   const supabase = await createClient();
 
   let query = supabase
@@ -44,7 +45,7 @@ export default async function SessionInsightsPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={`/sessions/${id}`} className="text-on-surface-variant">
+        <Link href={`/sessions/${id}${previewAsStudent ? "?as=student" : ""}`} className="text-on-surface-variant">
           <span className="material-symbols-outlined">arrow_back</span>
         </Link>
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -11,15 +11,19 @@ import { ApprovedInsightCard } from "@/components/insights/ApprovedInsightCard";
 
 export default async function SessionDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ as?: string }>;
 }) {
   const { id } = await params;
+  const { as } = await searchParams;
   const user = await getSession();
   if (!user) redirect("/login");
 
   const supabase = await createClient();
-  const isTrainer = user.role === "trainer";
+  const previewAsStudent = user.role === "trainer" && as === "student";
+  const isTrainer = user.role === "trainer" && !previewAsStudent;
   const locale = await getLocale();
   const isRu = locale === "ru";
   const nameCol = isRu ? "name_ru" : "name_en";
@@ -87,7 +91,14 @@ export default async function SessionDetailPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href="/dashboard" className="text-on-surface-variant">
+        <Link
+          href={
+            previewAsStudent && session.goals?.user_id
+              ? `/trainer/students/${session.goals.user_id}/preview`
+              : "/dashboard"
+          }
+          className="text-on-surface-variant"
+        >
           <span className="material-symbols-outlined">arrow_back</span>
         </Link>
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
@@ -246,7 +257,7 @@ export default async function SessionDetailPage({
 
           {!isTrainer && pendingForStudent.length > 0 && (
             <Link
-              href={`/sessions/${id}/insights`}
+              href={`/sessions/${id}/insights${previewAsStudent ? "?as=student" : ""}`}
               className="block rounded-2xl kinetic-gradient text-on-primary p-4 glow-primary"
             >
               <p className="font-black text-base">
@@ -290,7 +301,7 @@ export default async function SessionDetailPage({
                   : `Skipped (${skippedCards.length}) — review again any time`}
               </p>
               <Link
-                href={`/sessions/${id}/insights?include=skipped`}
+                href={`/sessions/${id}/insights?include=skipped${previewAsStudent ? "&as=student" : ""}`}
                 className="block text-xs text-secondary font-bold uppercase tracking-wider"
               >
                 {isRu ? "Открыть пропущенные →" : "Re-open skipped →"}

--- a/src/app/trainer/students/[id]/preview/page.tsx
+++ b/src/app/trainer/students/[id]/preview/page.tsx
@@ -4,10 +4,8 @@ import Link from "next/link";
 import { getLocale } from "@/lib/i18n";
 import { loadDashboardData } from "@/lib/dashboard/data";
 import DashboardView from "@/components/dashboard/DashboardView";
-import InviteBlock from "@/components/trainer/InviteBlock";
-import TrainerMatchesBlock from "@/components/trainer/TrainerMatchesBlock";
 
-export default async function TrainerStudentDetailPage({
+export default async function TrainerStudentPreviewPage({
   params,
 }: {
   params: Promise<{ id: string }>;
@@ -23,28 +21,24 @@ export default async function TrainerStudentDetailPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href="/trainer/students" className="text-on-surface-variant">
+        <Link href={`/trainer/students/${studentId}`} className="text-on-surface-variant">
           <span className="material-symbols-outlined">arrow_back</span>
         </Link>
-        <span className="text-lg font-black text-primary uppercase italic tracking-tight">Student</span>
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
+          Preview
+        </span>
         <Link
-          href={`/trainer/students/${studentId}/preview`}
+          href={`/trainer/students/${studentId}`}
           className="flex items-center gap-1 text-[10px] font-black uppercase tracking-[0.15em] text-on-surface-variant"
-          title="Preview as student"
+          title="Switch to admin view"
         >
-          <span className="material-symbols-outlined text-base">visibility</span>
-          View
+          <span className="material-symbols-outlined text-base">edit</span>
+          Admin
         </Link>
       </header>
 
-      <main className="px-5 pt-6 pb-36 max-w-4xl mx-auto space-y-6">
-        <InviteBlock studentId={studentId} />
-        <DashboardView
-          data={data!}
-          locale={locale}
-          editable={{ studentId, trainerId: user!.id }}
-        />
-        <TrainerMatchesBlock studentId={studentId} locale={locale} />
+      <main className="px-5 pt-6 pb-36 max-w-[430px] mx-auto">
+        <DashboardView data={data!} locale={locale} previewMode />
       </main>
     </div>
   );

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -19,12 +19,14 @@ interface Props {
   data: DashboardData;
   locale: Locale;
   editable?: DashboardViewEditable | false;
+  previewMode?: boolean;
 }
 
-export default function DashboardView({ data, locale, editable }: Props) {
+export default function DashboardView({ data, locale, editable, previewMode }: Props) {
   const dateLocale = locale === "ru" ? "ru-RU" : "en-US";
   const { profile, goals, skillProgress, sessions, nextSession, masterPlan, totalPendingCards, firstPendingSessionId, upcomingMatches } = data;
-  const isTrainer = !!editable;
+  const isTrainer = !!editable && !previewMode;
+  const sessionLinkSuffix = previewMode ? "?as=student" : "";
 
   const displayName = profile.full_name || profile.email || "Unnamed";
   const firstName = profile.full_name?.split(" ")[0] || profile.email?.split("@")[0] || t(locale, "dashboard.player");
@@ -54,8 +56,8 @@ export default function DashboardView({ data, locale, editable }: Props) {
         </div>
       )}
 
-      {/* Playtomic connect block — student only */}
-      {!isTrainer && (
+      {/* Playtomic connect block — student only (skip in trainer preview to avoid mutating trainer's account) */}
+      {!isTrainer && !previewMode && (
         <PlaytomicConnectBlock currentUserId={profile.playtomic_user_id ?? null} />
       )}
 
@@ -79,7 +81,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
           {/* Pending banner — student only */}
           {!isTrainer && totalPendingCards > 0 && firstPendingSessionId && (
             <Link
-              href={`/sessions/${firstPendingSessionId}/insights`}
+              href={`/sessions/${firstPendingSessionId}/insights${sessionLinkSuffix}`}
               className="block kinetic-gradient text-on-primary rounded-3xl p-5 glow-primary"
               style={{ boxShadow: "0 10px 30px rgba(202,253,0,0.35)" }}
             >
@@ -169,7 +171,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
                         return (
                           <Link
                             key={`session-${item.id}`}
-                            href={`/sessions/${item.id}`}
+                            href={`/sessions/${item.id}${sessionLinkSuffix}`}
                             className="snap-start shrink-0 w-[78%] flex flex-col gap-3 bg-surface-low rounded-2xl px-4 py-4 active:bg-surface-card transition-colors"
                           >
                             <div className="w-10 h-10 rounded-xl bg-surface-card text-primary flex items-center justify-center font-black text-sm">
@@ -358,7 +360,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
                 {sessions.map((session) => (
                   <div key={session.id} className="flex items-center gap-2">
                     <Link
-                      href={`/sessions/${session.id}`}
+                      href={`/sessions/${session.id}${sessionLinkSuffix}`}
                       className={`flex-1 flex items-center gap-4 rounded-2xl px-4 py-3.5 transition-colors ${
                         session.pending > 0
                           ? "bg-primary/10 border border-primary/40 glow-primary"
@@ -393,7 +395,7 @@ export default function DashboardView({ data, locale, editable }: Props) {
               <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant mb-4 px-1">
                 {t(locale, "dashboard.nextSession")}
               </h3>
-              <Link href={`/sessions/${nextSession.id}`} className="block bg-surface-low rounded-3xl p-5">
+              <Link href={`/sessions/${nextSession.id}${sessionLinkSuffix}`} className="block bg-surface-low rounded-3xl p-5">
                 <h4 className="text-xl font-black tracking-tight mb-4">
                   {t(locale, "dashboard.session")} {nextSession.session_number}
                 </h4>


### PR DESCRIPTION
## Что сделано

Тренерская страница ученика разделена на два режима:

- `/trainer/students/[id]` — админка (как было). В хедере появилась кнопка **👁 View** → переход в preview.
- `/trainer/students/[id]/preview` — точная копия дашборда ученика через `DashboardView` с `previewMode`. Кнопка **✎ Admin** возвращает в админку.

Из preview ссылки на сессии и инсайты несут `?as=student`. `/sessions/[id]` и `/sessions/[id]/insights` уважают этот флаг: тренеру показывают student-view (без drafts/audio uploader/PasteInsights), back-стрелка ведёт обратно в `/trainer/students/<studentId>/preview`.

В preview спрятан `PlaytomicConnectBlock` — чтобы тренер случайно не привязал playtomic к своему аккаунту.

## Что проверить

- [ ] Тренер открывает `/trainer/students/[id]` → видит admin-вью с кнопкой View
- [ ] Клик по View → preview совпадает с тем что видит ученик на `/dashboard`
- [ ] Клик по сессии в preview → student-вью сессии, back ведёт в preview
- [ ] Пендинг-баннер инсайтов / "разобрать карточки" → student-листание, back в preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)