### PR TITLE
feat(insights): flip-карточки, счётчик, side-тег

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -107,8 +107,7 @@ body {
   position: absolute;
   inset: 0;
   border-radius: 1.5rem;
-  background: var(--surface-card);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  background: transparent;
   touch-action: none;
   user-select: none;
   will-change: transform, opacity;
@@ -126,6 +125,46 @@ body {
 .tinder-card.swipe-left {
   transform: translateX(-140%) rotate(-20deg);
   opacity: 0;
+}
+
+/* ─── Insight flip ─── */
+.insight-flip {
+  position: absolute;
+  inset: 0;
+  perspective: 1400px;
+}
+.insight-flip-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s cubic-bezier(0.2, 1, 0.3, 1);
+  transform-style: preserve-3d;
+}
+.insight-flip-inner.flipped {
+  transform: rotateY(180deg);
+}
+.insight-flip-face {
+  position: absolute;
+  inset: 0;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  background: #ffffff;
+  color: #111;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+}
+.insight-flip-back {
+  transform: rotateY(180deg);
+}
+@keyframes insight-intro-flip {
+  0%   { transform: rotateY(0); }
+  25%  { transform: rotateY(-26deg); }
+  55%  { transform: rotateY(22deg); }
+  100% { transform: rotateY(0); }
+}
+.insight-flip-inner.intro {
+  animation: insight-intro-flip 1.6s cubic-bezier(0.2, 1, 0.3, 1) 0.3s 1 both;
 }
 
 /* ─── Vault flip card ─── */

--- a/src/components/insights/EditAiCardModal.tsx
+++ b/src/components/insights/EditAiCardModal.tsx
@@ -6,6 +6,7 @@ import { updateAiInsightCard } from "@/lib/actions/aiInsights";
 import type { InsightCard } from "@/lib/types";
 
 const TAGS = ["техника", "тактика", "физика", "ментал"] as const;
+const SIDES = ["защита", "атака"] as const;
 
 interface Props {
   card: InsightCard;
@@ -17,12 +18,17 @@ export function EditAiCardModal({ card, onClose }: Props) {
   const [title, setTitle] = useState(card.title || card.front_text);
   const [body, setBody] = useState(card.body || card.context_text || "");
   const [tag, setTag] = useState<string>(card.tags?.[0] ?? "техника");
+  const initialSide = (card.tags?.[1] as typeof SIDES[number] | undefined) ?? "атака";
+  const [side, setSide] = useState<typeof SIDES[number]>(
+    SIDES.includes(initialSide) ? initialSide : "атака"
+  );
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const isValid = title.trim().length > 0 && title.trim().length <= 80 &&
     body.trim().length > 0 && body.trim().length <= 400 &&
-    TAGS.includes(tag as typeof TAGS[number]);
+    TAGS.includes(tag as typeof TAGS[number]) &&
+    SIDES.includes(side);
 
   function handleSave() {
     if (!isValid) return;
@@ -32,6 +38,7 @@ export function EditAiCardModal({ card, onClose }: Props) {
         title: title.trim(),
         body: body.trim(),
         tag,
+        side,
       });
       if ("error" in result) {
         setError(result.error);
@@ -101,6 +108,28 @@ export function EditAiCardModal({ card, onClose }: Props) {
               <option key={t} value={t}>{t}</option>
             ))}
           </select>
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+            Сторона
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {SIDES.map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setSide(s)}
+                className={`py-2.5 rounded-xl text-xs font-black uppercase tracking-widest min-h-[44px] ${
+                  side === s
+                    ? "kinetic-gradient text-on-primary"
+                    : "bg-surface-elevated text-on-surface-variant border border-border-dim"
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
         </div>
 
         {card.quote && (

--- a/src/components/insights/InsightTinder.tsx
+++ b/src/components/insights/InsightTinder.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { decideInsightCard } from "@/lib/actions/insightCards";
 import type { InsightCardWithRelations } from "@/lib/types";
@@ -10,17 +10,34 @@ interface Props {
 }
 
 const SWIPE_THRESHOLD = 110;
+const TAP_THRESHOLD = 8;
 
 export default function InsightTinder({ cards }: Props) {
   const router = useRouter();
   const [queue, setQueue] = useState(cards);
   const [drag, setDrag] = useState<{ x: number; y: number } | null>(null);
   const [exiting, setExiting] = useState<"left" | "right" | null>(null);
+  const [flipped, setFlipped] = useState(false);
+  const [intro, setIntro] = useState(false);
   const [, startTransition] = useTransition();
   const startRef = useRef<{ x: number; y: number } | null>(null);
+  const introPlayedRef = useRef(false);
+  const total = cards.length;
 
   const top = queue[0];
   const next = queue[1];
+  const currentIndex = total - queue.length + 1;
+  const topId = top?.id;
+
+  // Play hint flip only on first card the user sees
+  useEffect(() => {
+    setFlipped(false);
+    if (!topId || introPlayedRef.current) return;
+    introPlayedRef.current = true;
+    setIntro(true);
+    const t = setTimeout(() => setIntro(false), 1900);
+    return () => clearTimeout(t);
+  }, [topId]);
 
   if (!top) {
     return (
@@ -71,7 +88,13 @@ export default function InsightTinder({ cards }: Props) {
     }
     if (drag.x > SWIPE_THRESHOLD) commit("taken");
     else if (drag.x < -SWIPE_THRESHOLD) commit("skipped");
-    else setDrag(null);
+    else if (Math.abs(drag.x) < TAP_THRESHOLD && Math.abs(drag.y) < TAP_THRESHOLD) {
+      setIntro(false);
+      setFlipped((f) => !f);
+      setDrag(null);
+    } else {
+      setDrag(null);
+    }
     startRef.current = null;
   }
 
@@ -80,9 +103,27 @@ export default function InsightTinder({ cards }: Props) {
   const opacity = exiting ? 0 : 1 - Math.min(Math.abs(dx) / 400, 0.4);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
+      <p className="text-center text-xs font-black uppercase tracking-[0.25em] text-on-surface-variant">
+        <span className="text-primary">{currentIndex}</span>
+        <span className="opacity-60"> / {total}</span>
+      </p>
+
       <div className="tinder-stack">
-        {next && <CardFace card={next} stacked />}
+        {next && (
+          <div
+            className="tinder-card"
+            style={{ transform: "scale(0.94) translateY(-12px)", opacity: 0.4 }}
+          >
+            <div className="insight-flip">
+              <div className="insight-flip-inner">
+                <div className="insight-flip-face">
+                  <FrontFace card={next} dx={0} stacked />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
         <div
           className={`tinder-card ${drag ? "dragging" : ""} ${
             exiting === "right" ? "swipe-right" : exiting === "left" ? "swipe-left" : ""
@@ -98,11 +139,24 @@ export default function InsightTinder({ cards }: Props) {
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp}
         >
-          <CardFace card={top} dx={dx} />
+          <div className="insight-flip">
+            <div
+              className={`insight-flip-inner ${flipped ? "flipped" : ""} ${
+                intro && !flipped ? "intro" : ""
+              }`}
+            >
+              <div className="insight-flip-face">
+                <FrontFace card={top} dx={dx} />
+              </div>
+              <div className="insight-flip-face insight-flip-back">
+                <BackFace card={top} />
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
-      <div className="flex items-center justify-center gap-6">
+      <div className="flex items-center justify-center gap-6 pt-2">
         <button
           onClick={() => commit("skipped")}
           aria-label="Пропустить"
@@ -120,74 +174,105 @@ export default function InsightTinder({ cards }: Props) {
           </span>
         </button>
       </div>
-
-      <p className="text-center text-xs uppercase tracking-widest text-on-surface-variant">
-        осталось: {queue.length}
-      </p>
     </div>
   );
 }
 
-function CardFace({
+function sideMeta(side: string | null | undefined) {
+  if (side === "защита" || side === "defense") {
+    return { label: "Защита", className: "bg-sky-100 text-sky-700" };
+  }
+  if (side === "атака" || side === "attack") {
+    return { label: "Атака", className: "bg-rose-100 text-rose-700" };
+  }
+  return null;
+}
+
+function FrontFace({
   card,
+  dx,
   stacked,
-  dx = 0,
 }: {
   card: InsightCardWithRelations;
+  dx: number;
   stacked?: boolean;
-  dx?: number;
 }) {
+  const topic = card.tags?.[0] ?? null;
+  const side = sideMeta(card.tags?.[1] ?? null);
+  const displayTitle = card.title || card.front_text;
+
   return (
-    <div
-      className={`absolute inset-0 rounded-3xl p-6 flex flex-col justify-between bg-surface-card border border-border-dim ${
-        stacked ? "scale-[0.94] -translate-y-3 opacity-60" : ""
-      }`}
-    >
+    <div className="relative h-full w-full p-6 flex flex-col justify-between">
       {!stacked && (
         <>
           <div
-            className="absolute top-6 left-6 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-primary text-on-primary"
+            className="absolute top-5 left-5 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-primary text-on-primary z-10"
             style={{ opacity: Math.max(0, Math.min(1, dx / 80)) }}
           >
             Взять
           </div>
           <div
-            className="absolute top-6 right-6 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-error text-white"
+            className="absolute top-5 right-5 px-3 py-1 rounded-full text-xs font-black uppercase tracking-wider bg-rose-500 text-white z-10"
             style={{ opacity: Math.max(0, Math.min(1, -dx / 80)) }}
           >
             Пропустить
           </div>
         </>
       )}
-      <div className="flex flex-col gap-3 mt-12">
+
+      <div className="flex flex-col gap-4 mt-10">
         <div className="flex flex-wrap items-center gap-2">
-          {card.category && (
-            <span className="text-xs uppercase tracking-widest text-secondary font-bold">
-              {card.category.name}
+          {topic && (
+            <span className="text-[10px] font-black uppercase tracking-[0.18em] px-2.5 py-1 rounded-full bg-gray-100 text-gray-700">
+              {topic}
             </span>
           )}
-          {card.tags && card.tags.length > 0 && (
-            <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">
-              {card.tags[0]}
+          {side && (
+            <span
+              className={`text-[10px] font-black uppercase tracking-[0.18em] px-2.5 py-1 rounded-full ${side.className}`}
+            >
+              {side.label}
             </span>
           )}
         </div>
-        <p className="text-2xl font-black text-on-surface leading-tight">
-          {card.title || card.front_text}
+        <p className="text-[28px] font-black text-gray-900 leading-[1.1] tracking-tight">
+          {displayTitle}
         </p>
       </div>
-      <div className="flex flex-col gap-2">
-        {(card.body || card.context_text) && (
-          <p className="text-sm text-on-surface-variant leading-relaxed">
-            {card.body || card.context_text}
-          </p>
-        )}
-        {card.quote && (
-          <p className="text-xs text-on-surface-variant italic border-l-2 border-primary/40 pl-2">
-            «{card.quote}»
-          </p>
-        )}
+
+      <div className="flex items-center justify-center gap-2 text-gray-400 select-none pointer-events-none">
+        <span className="material-symbols-outlined text-base">touch_app</span>
+        <span className="text-[10px] font-bold uppercase tracking-[0.2em]">
+          Тап — перевернуть
+        </span>
       </div>
+    </div>
+  );
+}
+
+function BackFace({ card }: { card: InsightCardWithRelations }) {
+  const body = card.body || card.context_text;
+  return (
+    <div className="h-full w-full p-6 flex flex-col gap-4 overflow-y-auto">
+      <div className="flex items-center gap-2 text-gray-400">
+        <span className="material-symbols-outlined text-base">flip_to_front</span>
+        <span className="text-[10px] font-bold uppercase tracking-[0.2em]">
+          Разбор
+        </span>
+      </div>
+      {body && (
+        <p className="text-base text-gray-800 leading-relaxed whitespace-pre-line">
+          {body}
+        </p>
+      )}
+      {card.quote && (
+        <p className="text-sm text-gray-600 italic border-l-2 border-amber-400 pl-3 mt-auto">
+          «{card.quote}»
+        </p>
+      )}
+      {!body && !card.quote && (
+        <p className="text-sm text-gray-500">Описание не добавлено.</p>
+      )}
     </div>
   );
 }

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -112,19 +112,25 @@ export async function deleteAiInsightCard(
 }
 
 const VALID_TAGS = new Set(["техника", "тактика", "физика", "ментал"]);
+const VALID_SIDES = new Set(["защита", "атака"]);
 
 export async function updateAiInsightCard(
   cardId: string,
-  patch: { title: string; body: string; tag: string }
+  patch: { title: string; body: string; tag: string; side?: string | null }
 ): Promise<{ success: true } | { error: string }> {
   if (!patch.title.trim()) return { error: "Заголовок обязателен" };
   if (patch.title.trim().length > 80) return { error: "Заголовок не более 80 знаков" };
   if (!patch.body.trim()) return { error: "Описание обязательно" };
   if (patch.body.trim().length > 400) return { error: "Описание не более 400 знаков" };
   if (!VALID_TAGS.has(patch.tag)) return { error: `Недопустимая тема: ${patch.tag}` };
+  if (patch.side && !VALID_SIDES.has(patch.side)) {
+    return { error: `Недопустимая сторона: ${patch.side}` };
+  }
 
   const ctx = await requireTrainerOwnsCard(cardId);
   if (!ctx) return { error: "Forbidden" };
+
+  const tags = patch.side ? [patch.tag, patch.side] : [patch.tag];
 
   const { supabase, sessionId } = ctx;
   const { error } = await supabase
@@ -132,7 +138,7 @@ export async function updateAiInsightCard(
     .update({
       title: patch.title.trim(),
       body: patch.body.trim(),
-      tags: [patch.tag],
+      tags,
       front_text: patch.title.trim(),
       context_text: patch.body.trim(),
     })


### PR DESCRIPTION
## Что сделано

Переделан экран свайпа инсайтов:

- **Счётчик** `N / Total` над карточкой
- **Карточка снова белая** (раньше отображалась тёмной из-за класса `.tinder-card`)
- Добавлен второй тег **side** (\`защита\` / \`атака\`) — выбирается тренером в `EditAiCardModal`, хранится в `tags[1]`
- **Лицевая сторона**: chip с темой + chip со стороной + крупный заголовок + иконка-подсказка «тап — перевернуть»
- **Обратная сторона**: разбор (body) и цитата
- **Анимация перевёртывания** по тапу (3D rotateY)
- **Intro-hint**: при первом заходе карточка автоматически качается в одну сторону, потом в другую — показывает, что её можно перевернуть

## Файлы

- `src/components/insights/InsightTinder.tsx` — полная переработка
- `src/app/globals.css` — `.insight-flip*` классы и keyframes
- `src/components/insights/EditAiCardModal.tsx` — переключатель стороны
- `src/lib/actions/aiInsights.ts` — `updateAiInsightCard` принимает `side`, сохраняет `tags = [tag, side]`

## Что проверить

- [ ] Открыть `/sessions/<id>/insights` от ученика
- [ ] Видно `1 / N` сверху, белая карточка с тенью
- [ ] При первом показе — анимация-подсказка
- [ ] Тап по карточке → перевод на back-сторону с разбором и цитатой
- [ ] Свайп влево/вправо работает как раньше
- [ ] В тренерском editor (Approved → Edit) появилась секция «Сторона», выбор сохраняется

🤖 Generated with [Claude Code](https://claude.com/claude-code)