### PR TITLE
feat(dashboard): insights back→/dashboard, удалён блок Текущий план

### DIFF
--- a/src/app/sessions/[id]/insights/page.tsx
+++ b/src/app/sessions/[id]/insights/page.tsx
@@ -10,14 +10,20 @@ export default async function SessionInsightsPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ include?: string; as?: string }>;
+  searchParams: Promise<{ include?: string; as?: string; from?: string }>;
 }) {
   const user = await getSession();
   if (!user) redirect("/login");
 
   const { id } = await params;
-  const { include, as } = await searchParams;
+  const { include, as, from } = await searchParams;
   const previewAsStudent = user.role === "trainer" && as === "student";
+
+  const backHref = previewAsStudent
+    ? `/sessions/${id}?as=student`
+    : from === "dashboard"
+    ? "/dashboard"
+    : `/sessions/${id}`;
   const supabase = await createClient();
 
   let query = supabase
@@ -45,7 +51,7 @@ export default async function SessionInsightsPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={`/sessions/${id}${previewAsStudent ? "?as=student" : ""}`} className="text-on-surface-variant">
+        <Link href={backHref} className="text-on-surface-variant">
           <span className="material-symbols-outlined">arrow_back</span>
         </Link>
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -46,14 +46,6 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
   const firstName = profile.full_name?.split(" ")[0] || profile.email?.split("@")[0] || t(locale, "dashboard.player");
   const masterPlanPreview = masterPlan?.sections.slice(0, 2) ?? [];
 
-  const planGoal =
-    goals.find((g) => g.total_sessions > 0) ??
-    goals.find((g) => g.session_count > 0) ??
-    goals[0];
-  const planPercent = planGoal && planGoal.session_count > 0
-    ? Math.min(100, Math.round((planGoal.total_sessions / planGoal.session_count) * 100))
-    : 0;
-
   const isEmpty = goals.length === 0 && skillProgress.length === 0 && !masterPlan && sessions.length === 0;
 
   return (
@@ -95,7 +87,7 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
           {/* Pending banner — student only */}
           {!isTrainer && totalPendingCards > 0 && firstPendingSessionId && (
             <Link
-              href={`/sessions/${firstPendingSessionId}/insights${sessionLinkSuffix}`}
+              href={`/sessions/${firstPendingSessionId}/insights?from=dashboard${sessionLinkSuffix ? `&as=student` : ""}`}
               className="block kinetic-gradient text-on-primary rounded-3xl p-5 glow-primary"
               style={{ boxShadow: "0 10px 30px rgba(202,253,0,0.35)" }}
             >
@@ -271,23 +263,6 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
               </div>
             </Link>
           ) : null}
-
-          {/* Plan progress — student only */}
-          {!isTrainer && planGoal && planGoal.session_count > 0 && (
-            <section className="bg-surface-low rounded-2xl p-4">
-              <div className="flex justify-between items-baseline mb-2">
-                <div className="flex items-baseline gap-2">
-                  <p className="text-secondary text-[10px] font-black uppercase tracking-[0.2em]">
-                    {t(locale, "dashboard.currentPlan")}
-                  </p>
-                  <span className="text-sm font-black tracking-tight">
-                    {Math.min(planGoal.total_sessions, planGoal.session_count)}/{planGoal.session_count}
-                  </span>
-                </div>
-                <span className="text-base font-black italic kinetic-text">{planPercent}%</span>
-              </div>
-            </section>
-          )}
 
           {/* Goals */}
           <section>


### PR DESCRIPTION
- Кнопка «назад» на странице инсайтов теперь возвращает туда, откуда пришёл: с дашборда → /dashboard, со страницы сессии → /sessions/[id]
- Pending-баннер на главной передаёт ?from=dashboard
- Удалён блок «Текущий план» с дашборда ученика

🤖 Generated with [Claude Code](https://claude.com/claude-code)