### PR TITLE
feat(nav): smart back button (history.back)

### DIFF
--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -7,6 +7,7 @@ import { t } from "@/lib/i18n/dict";
 import AttachInsightModal from "@/components/matches/AttachInsightModal";
 import ReflectionTextarea from "@/components/matches/ReflectionTextarea";
 import { getVaultCards } from "@/lib/actions/insightCards";
+import BackButton from "@/components/navigation/BackButton";
 
 const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
 
@@ -189,14 +190,10 @@ export default async function MatchDetailPage({ params }: PageProps) {
     <div className="min-h-screen bg-background">
       {/* Header */}
       <header className="sticky top-0 z-30 glass-nav h-16 flex items-center gap-3 px-4">
-        <Link
-          href="/matches"
-          className="flex items-center justify-center w-9 h-9 rounded-xl bg-surface-elevated hover:bg-border-dim transition-colors"
-        >
-          <span className="material-symbols-outlined text-[20px] text-on-surface-variant">
-            arrow_back
-          </span>
-        </Link>
+        <BackButton
+          fallbackHref="/matches"
+          className="flex items-center justify-center w-9 h-9 rounded-xl bg-surface-elevated hover:bg-border-dim transition-colors text-[20px] text-on-surface-variant"
+        />
         <span className="text-base font-black text-primary uppercase italic tracking-tight">
           {match.location ?? t(locale, "matches.title")}
         </span>

--- a/src/app/sessions/[id]/insights/page.tsx
+++ b/src/app/sessions/[id]/insights/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import InsightTinder from "@/components/insights/InsightTinder";
+import BackButton from "@/components/navigation/BackButton";
 import type { InsightCardWithRelations } from "@/lib/types";
 
 export default async function SessionInsightsPage({
@@ -51,9 +52,7 @@ export default async function SessionInsightsPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={backHref} className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref={backHref} />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           Insights
         </span>

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -8,6 +8,7 @@ import { AudioUploader } from "@/components/sessions/AudioUploader";
 import { PasteInsightsButton } from "@/components/sessions/PasteInsightsButton";
 import { DraftCardsList } from "@/components/insights/DraftCardsList";
 import { ApprovedInsightCard } from "@/components/insights/ApprovedInsightCard";
+import BackButton from "@/components/navigation/BackButton";
 
 export default async function SessionDetailPage({
   params,
@@ -91,16 +92,13 @@ export default async function SessionDetailPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link
-          href={
+        <BackButton
+          fallbackHref={
             previewAsStudent && session.goals?.user_id
               ? `/trainer/students/${session.goals.user_id}/preview`
               : "/dashboard"
           }
-          className="text-on-surface-variant"
-        >
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           {isRu ? "Сессия" : "Session"} {session.session_number}
         </span>

--- a/src/app/sessions/[id]/transcript/page.tsx
+++ b/src/app/sessions/[id]/transcript/page.tsx
@@ -6,6 +6,7 @@ import { DeleteTranscriptButton } from "./DeleteTranscriptButton";
 import { DownloadTranscriptButton } from "./DownloadTranscriptButton";
 import { TranscriptView } from "./TranscriptView";
 import { ReTranscribeButton } from "./ReTranscribeButton";
+import BackButton from "@/components/navigation/BackButton";
 
 export default async function TranscriptPage({
   params,
@@ -57,9 +58,7 @@ export default async function TranscriptPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={`/sessions/${id}`} className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref={`/sessions/${id}`} />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           Транскрипт
         </span>

--- a/src/app/trainer/library/page.tsx
+++ b/src/app/trainer/library/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
+import BackButton from "@/components/navigation/BackButton";
 
 export default async function LibraryPage() {
   const user = await getSession();
@@ -22,9 +23,7 @@ export default async function LibraryPage() {
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href="/dashboard" className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref="/dashboard" />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           Library
         </span>

--- a/src/app/trainer/sessions/[id]/insights/page.tsx
+++ b/src/app/trainer/sessions/[id]/insights/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import Link from "next/link";
 import TrainerCardEditor from "@/components/insights/TrainerCardEditor";
+import BackButton from "@/components/navigation/BackButton";
 import type { InsightCard, ProblemCategory, Problem } from "@/lib/types";
 
 export default async function TrainerSessionInsightsPage({
@@ -37,9 +38,7 @@ export default async function TrainerSessionInsightsPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={`/sessions/${id}`} className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref={`/sessions/${id}`} />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           Session {session.session_number} cards
         </span>

--- a/src/app/trainer/sessions/new/page.tsx
+++ b/src/app/trainer/sessions/new/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { createSession } from "@/lib/actions/sessions";
 import Link from "next/link";
+import BackButton from "@/components/navigation/BackButton";
 
 interface ExerciseRow {
   name: string;
@@ -139,12 +140,7 @@ function NewSessionContent() {
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link
-          href={`/trainer/students/${studentId}`}
-          className="text-on-surface-variant"
-        >
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref={`/trainer/students/${studentId}`} />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           New session
         </span>

--- a/src/app/trainer/students/[id]/page.tsx
+++ b/src/app/trainer/students/[id]/page.tsx
@@ -6,6 +6,7 @@ import { loadDashboardData } from "@/lib/dashboard/data";
 import DashboardView from "@/components/dashboard/DashboardView";
 import InviteBlock from "@/components/trainer/InviteBlock";
 import TrainerMatchesBlock from "@/components/trainer/TrainerMatchesBlock";
+import BackButton from "@/components/navigation/BackButton";
 
 export default async function TrainerStudentDetailPage({
   params,
@@ -23,9 +24,7 @@ export default async function TrainerStudentDetailPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href="/trainer/students" className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref="/trainer/students" />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">Student</span>
         <Link
           href={`/trainer/students/${studentId}/preview`}

--- a/src/app/trainer/students/[id]/preview/page.tsx
+++ b/src/app/trainer/students/[id]/preview/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getLocale } from "@/lib/i18n";
 import { loadDashboardData } from "@/lib/dashboard/data";
 import DashboardView from "@/components/dashboard/DashboardView";
+import BackButton from "@/components/navigation/BackButton";
 
 export default async function TrainerStudentPreviewPage({
   params,
@@ -21,9 +22,7 @@ export default async function TrainerStudentPreviewPage({
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <Link href={`/trainer/students/${studentId}`} className="text-on-surface-variant">
-          <span className="material-symbols-outlined">arrow_back</span>
-        </Link>
+        <BackButton fallbackHref={`/trainer/students/${studentId}`} />
         <span className="text-lg font-black text-primary uppercase italic tracking-tight">
           Preview
         </span>

--- a/src/components/navigation/BackButton.tsx
+++ b/src/components/navigation/BackButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface Props {
+  fallbackHref: string;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export default function BackButton({
+  fallbackHref,
+  className = "text-on-surface-variant",
+  ariaLabel = "Назад",
+}: Props) {
+  const router = useRouter();
+
+  function handleClick() {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push(fallbackHref);
+    }
+  }
+
+  return (
+    <button type="button" onClick={handleClick} aria-label={ariaLabel} className={className}>
+      <span className="material-symbols-outlined">arrow_back</span>
+    </button>
+  );
+}


### PR DESCRIPTION
Создан клиентский BackButton, использует router.back() с fallback на конкретный href. Заменены жёсткие Link arrow_back на BackButton: session, insights, transcript, matches, trainer library/students/preview/sessions/new. Возврат теперь ведёт туда, откуда пришёл.

🤖 Generated with [Claude Code](https://claude.com/claude-code)