### PR TITLE
fix(auth): claim-токен через OAuth state вместо cookie

### DIFF
--- a/src/app/api/auth/grechka-callback/route.ts
+++ b/src/app/api/auth/grechka-callback/route.ts
@@ -9,11 +9,17 @@ export async function GET(request: Request) {
 
   const cookieStore = await cookies();
   const savedState = cookieStore.get("__grechka_state")?.value;
-  const claimToken = cookieStore.get("__grechka_claim")?.value ?? null;
   cookieStore.delete("__grechka_state");
+  // Legacy fallback: claim used to ride in its own cookie.
+  const legacyClaimCookie = cookieStore.get("__grechka_claim")?.value ?? null;
   cookieStore.delete("__grechka_claim");
 
-  if (!token || !state || state !== savedState) {
+  // `state` is `${csrf}` or `${csrf}~${claimToken}` — the claim token rides
+  // inside state so it survives the OAuth round-trip even when cookies don't.
+  const [csrf, claimFromState] = (state ?? "").split("~");
+  const claimToken = claimFromState ?? legacyClaimCookie;
+
+  if (!token || !csrf || csrf !== savedState) {
     return NextResponse.redirect(`${origin}/login?error=invalid_state`);
   }
 

--- a/src/app/api/auth/grechka/route.ts
+++ b/src/app/api/auth/grechka/route.ts
@@ -6,29 +6,20 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const claim = searchParams.get("claim");
 
-  const state = randomBytes(16).toString("hex");
-  const cookieStore = await cookies();
+  // CSRF nonce stored in cookie; claim token rides along inside `state` itself,
+  // because the OAuth `state` round-trips reliably through Гречка while a
+  // separate cookie can be dropped by in-app browsers / long redirect chains.
+  const csrf = randomBytes(16).toString("hex");
+  const state = claim ? `${csrf}~${claim}` : csrf;
 
-  cookieStore.set("__grechka_state", state, {
+  const cookieStore = await cookies();
+  cookieStore.set("__grechka_state", csrf, {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     maxAge: 600, // 10 min
     path: "/",
   });
-
-  if (claim) {
-    cookieStore.set("__grechka_claim", claim, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      maxAge: 600, // 10 min — must outlive the round-trip
-      path: "/",
-    });
-  } else {
-    // Defensive: clear any stale claim cookie.
-    cookieStore.delete("__grechka_claim");
-  }
 
   const grechkaUrl = process.env.NEXT_PUBLIC_GRECHKA_URL?.trim();
   const nivelUrl = process.env.NEXT_PUBLIC_NIVEL_URL?.trim();


### PR DESCRIPTION
## Проблема

Ученик переходил по invite-ссылке, авторизовался через Гречку, но попадал в **новый пустой профиль** вместо shadow-профиля, созданного тренером.

Причина: claim-токен передавался через cookie `__grechka_claim`. In-app браузеры и длинная цепочка редиректов (Nivel → Гречка → Google → обратно) теряли cookie. Callback не видел claim → вызывал `createSession` → создавал свежий профиль.

## Фикс

Claim-токен теперь едет внутри OAuth-параметра `state` (`${csrf}~${claim}`), который по спеке echo-ится провайдером обратно verbatim. CSRF-nonce по-прежнему сверяется с cookie `__grechka_state`. Cookie `__grechka_claim` оставлен как legacy-fallback.

## Что проверить

- [ ] Тренер создаёт ученика → invite-ссылка
- [ ] Ученик открывает ссылку, жмёт «Войти через Гречку»
- [ ] После авторизации попадает в **свой** профиль с целями/инсайтами, не в пустой

🤖 Generated with [Claude Code](https://claude.com/claude-code)