### PR TITLE
feat(ux): loading.tsx скелетоны для всех route-сегментов

### DIFF
--- a/src/app/dashboard/loading.tsx
+++ b/src/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton hero rows={3} />;
+}

--- a/src/app/goals/new/loading.tsx
+++ b/src/app/goals/new/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/src/app/insights/loading.tsx
+++ b/src/app/insights/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={6} />;
+}

--- a/src/app/invite/[token]/loading.tsx
+++ b/src/app/invite/[token]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={2} />;
+}

--- a/src/app/masterplan/loading.tsx
+++ b/src/app/masterplan/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/src/app/matches/[id]/loading.tsx
+++ b/src/app/matches/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton hero rows={3} />;
+}

--- a/src/app/matches/loading.tsx
+++ b/src/app/matches/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/src/app/sessions/[id]/insights/loading.tsx
+++ b/src/app/sessions/[id]/insights/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton hero rows={2} />;
+}

--- a/src/app/sessions/[id]/loading.tsx
+++ b/src/app/sessions/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton hero rows={4} />;
+}

--- a/src/app/sessions/[id]/transcript/loading.tsx
+++ b/src/app/sessions/[id]/transcript/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={6} />;
+}

--- a/src/app/trainer/library/loading.tsx
+++ b/src/app/trainer/library/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton narrow={false} rows={6} />;
+}

--- a/src/app/trainer/sessions/[id]/insights/loading.tsx
+++ b/src/app/trainer/sessions/[id]/insights/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={4} />;
+}

--- a/src/app/trainer/sessions/new/loading.tsx
+++ b/src/app/trainer/sessions/new/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/src/app/trainer/students/[id]/loading.tsx
+++ b/src/app/trainer/students/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton narrow={false} hero rows={4} />;
+}

--- a/src/app/trainer/students/[id]/preview/loading.tsx
+++ b/src/app/trainer/students/[id]/preview/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton hero rows={4} />;
+}

--- a/src/app/trainer/students/loading.tsx
+++ b/src/app/trainer/students/loading.tsx
@@ -1,0 +1,5 @@
+import PageSkeleton from "@/components/ui/PageSkeleton";
+
+export default function Loading() {
+  return <PageSkeleton narrow={false} rows={5} />;
+}

--- a/src/components/ui/PageSkeleton.tsx
+++ b/src/components/ui/PageSkeleton.tsx
@@ -1,0 +1,37 @@
+interface PageSkeletonProps {
+  /** Number of placeholder rows/cards in the main area. */
+  rows?: number;
+  /** Render a tall hero block above the rows (used for dashboard-like pages). */
+  hero?: boolean;
+  /** Constrain main width to the mobile container. Defaults to true. */
+  narrow?: boolean;
+}
+
+function Block({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded-xl bg-surface-elevated ${className}`} />;
+}
+
+export default function PageSkeleton({
+  rows = 4,
+  hero = false,
+  narrow = true,
+}: PageSkeletonProps) {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
+        <div className="h-6 w-6 animate-pulse rounded-md bg-surface-elevated" />
+        <div className="h-5 w-28 animate-pulse rounded-md bg-surface-elevated" />
+        <div className="h-6 w-6 animate-pulse rounded-md bg-surface-elevated" />
+      </header>
+
+      <main
+        className={`px-5 pt-6 pb-36 ${narrow ? "max-w-[430px]" : "max-w-4xl"} mx-auto space-y-4`}
+      >
+        {hero && <Block className="h-40 w-full" />}
+        {Array.from({ length: rows }).map((_, i) => (
+          <Block key={i} className="h-24 w-full" />
+        ))}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Проблема

Во всём `src/app` не было ни одного `loading.tsx`. Из-за этого при навигации между страницами Next.js не показывал мгновенный Suspense-fallback и ждал полного серверного рендера (с запросами к Supabase) перед сменой страницы — старая страница «висла» на экране 1-2 секунды, потом резко открывалась новая.

## Решение

Добавлен `loading.tsx` в каждый навигируемый route-сегмент. Теперь переход мгновенный: сразу показывается скелетон-каркас, контент подгружается на его месте.

### Shared-компонент

Создан `src/components/ui/PageSkeleton.tsx` — структура страниц однотипная (sticky `glass-nav` header h-16 + `main` с `max-w-[430px]`/`max-w-4xl`), поэтому один параметризованный компонент вместо 16 почти одинаковых инлайн-разметок. Пропсы: `rows`, `hero`, `narrow`. Плейсхолдеры — `animate-pulse` блоки на `bg-surface-elevated` (тёмная палитра приложения), без layout-прыжка.

### Сегменты с loading.tsx

- `dashboard/`
- `insights/`
- `masterplan/`
- `matches/`, `matches/[id]/`
- `goals/new/`
- `sessions/[id]/`, `sessions/[id]/insights/`, `sessions/[id]/transcript/`
- `trainer/students/`, `trainer/students/[id]/`, `trainer/students/[id]/preview/`
- `trainer/library/`
- `trainer/sessions/new/`, `trainer/sessions/[id]/insights/`
- `invite/[token]/`

Пропущены: `api/` (не нужен), `login/` (не критичен), root `page.tsx` (просто `redirect`).

## Тесты

- `npx tsc --noEmit` — чисто.
- В браузере не проверял (UI dev-сервер не запускал).