### PR TITLE
feat: вынести блок «Упражнения» со страницы тренировки на главную

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -98,7 +98,7 @@ export default async function DashboardPage() {
   const { data: nextSessionRaw } = await supabase
     .from("sessions")
     .select(
-      "*, goals!inner(user_id), session_exercises(id, exercises(name_ru, name_en))"
+      "*, goals!inner(user_id), session_exercises(id, sort_order, exercises(name_ru, name_en), session_exercise_skills(skill_id, skills(name_ru, name_en)))"
     )
     .eq("goals.user_id", user.id)
     .eq("status", "planned")
@@ -110,8 +110,22 @@ export default async function DashboardPage() {
   const exerciseNameCol = locale === "en" ? "name_en" : "name_ru";
   const nextExercises = nextSession
     ? ((nextSession.session_exercises as Array<Record<string, unknown>>) || [])
-        .map((se) => (se.exercises as Record<string, unknown>)?.[exerciseNameCol] as string)
-        .filter(Boolean)
+        .map((se) => {
+          const ex = se.exercises as Record<string, unknown>;
+          const skillLinks =
+            (se.session_exercise_skills as Array<Record<string, unknown>>) || [];
+          return {
+            id: se.id as number,
+            name: (ex?.[exerciseNameCol] as string) || "",
+            skills: skillLinks
+              .map(
+                (sl) =>
+                  (sl.skills as Record<string, unknown>)?.[exerciseNameCol] as string
+              )
+              .filter(Boolean),
+          };
+        })
+        .filter((e) => e.name)
     : [];
 
   const { data: pendingByCard } = await supabase
@@ -468,31 +482,40 @@ export default async function DashboardPage() {
                       : t(locale, "common.upcoming")}
                   </p>
                 </div>
-                <h4 className="text-xl font-black tracking-tight mb-4">
+                <h4 className="text-xl font-black tracking-tight">
                   {t(locale, "dashboard.session")} {nextSession.session_number as number}
                 </h4>
-                {nextExercises.length > 0 && (
-                  <div className="bg-surface-card rounded-2xl p-4 space-y-2">
-                    <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-2">
-                      {t(locale, "dashboard.exercises")}
-                    </p>
-                    {nextExercises.slice(0, 3).map((ex, i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-3 text-sm text-on-surface-variant"
-                      >
-                        <span className="w-1.5 h-1.5 rounded-full bg-secondary opacity-60" />
-                        {ex}
+              </Link>
+            </section>
+          )}
+
+          {nextExercises.length > 0 && (
+            <section className="bg-surface-card rounded-3xl p-5">
+              <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-4">
+                {t(locale, "dashboard.exercises")}
+              </p>
+              <div className="space-y-3">
+                {nextExercises.map((exercise) => (
+                  <div key={exercise.id} className="space-y-2">
+                    <div className="flex items-center gap-3 text-sm text-on-surface">
+                      <span className="w-1.5 h-1.5 rounded-full bg-secondary opacity-60 flex-shrink-0" />
+                      {exercise.name}
+                    </div>
+                    {exercise.skills.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5 pl-4">
+                        {exercise.skills.map((skill, i) => (
+                          <span
+                            key={i}
+                            className="text-[9px] font-black px-1.5 py-0.5 rounded bg-primary/10 text-primary uppercase tracking-wide"
+                          >
+                            +{skill}
+                          </span>
+                        ))}
                       </div>
-                    ))}
-                    {nextExercises.length > 3 && (
-                      <p className="text-xs text-on-surface-variant opacity-50 pl-4">
-                        + {nextExercises.length - 3} {t(locale, "common.more")}
-                      </p>
                     )}
                   </div>
-                )}
-              </Link>
+                ))}
+              </div>
             </section>
           )}
         </>

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -104,39 +104,6 @@ export default async function SessionDetailPage({
           </p>
         </div>
 
-        <section className="bg-surface-card rounded-3xl p-5">
-          <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-4">
-            {isRu ? "Упражнения" : "Exercises"}
-          </p>
-          <div className="space-y-3">
-            {exercises.map((exercise) => (
-              <div key={exercise.id} className="space-y-2">
-                <div className="flex items-center gap-3 text-sm text-on-surface">
-                  <span className="w-1.5 h-1.5 rounded-full bg-secondary opacity-60 flex-shrink-0" />
-                  {exercise.name}
-                </div>
-                {exercise.skills.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 pl-4">
-                    {exercise.skills.map((skill) => (
-                      <span
-                        key={skill.id}
-                        className="text-[9px] font-black px-1.5 py-0.5 rounded bg-primary/10 text-primary uppercase tracking-wide"
-                      >
-                        +{skill.name}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
-            {exercises.length === 0 && (
-              <p className="text-on-surface-variant text-sm">
-                {isRu ? "Упражнения ещё не добавлены" : "No exercises added yet"}
-              </p>
-            )}
-          </div>
-        </section>
-
         {allSkills.length > 0 && (
           <section className="bg-surface-high rounded-3xl p-5">
             <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-3">


### PR DESCRIPTION
Closes #147

## Что сделано

- Блок «Упражнения» вынесен на главную `/dashboard` как отдельная секция (`bg-surface-card rounded-3xl`), показывает упражнения ближайшей запланированной сессии вместе со скилл-тегами.
- Запрос `nextSession` на дашборде расширен: подтягиваются `session_exercises` со связанными скиллами (`session_exercise_skills → skills`).
- Блок «Упражнения» удалён со страницы сессии `/sessions/[id]`.
- Удалён дублирующий мини-список упражнений, который раньше был внутри карточки «Следующая сессия» — чтобы не было дублирования.

## Отклонения от плана

- На странице сессии раньше показывались упражнения именно этой сессии. На дашборде логично показывать упражнения ближайшей запланированной сессии — поэтому новая секция привязана к `nextSession`. Для прошедших сессий отдельного списка упражнений теперь нет (как и требует Acceptance — «убрать со страницы тренировки»). Секция «Прокачка навыков» на странице сессии сохранена.
- «Страница тренировки» в кодовой базе — это `/sessions/[id]`; отдельной trainer-страницы детали сессии с блоком «Упражнения» нет, других мест с этим блоком не найдено.

## Что проверить

- На `/dashboard` при наличии запланированной сессии видна секция «Упражнения» со скилл-тегами, вёрстка корректна на ~390px.
- На `/sessions/[id]` блока «Упражнения» больше нет, дублирования нет.

https://claude.ai/code/session_015K4ZbP5GSeitUFuCYttnMs

---
_Generated by [Claude Code](https://claude.ai/code/session_015K4ZbP5GSeitUFuCYttnMs)_