### PR TITLE
feat: убрать блок «Упражнения» полностью

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -28,7 +28,6 @@ export default async function SessionDetailPage({
   const isTrainer = user.role === "trainer" && !previewAsStudent;
   const locale = await getLocale();
   const isRu = locale === "ru";
-  const nameCol = isRu ? "name_ru" : "name_en";
   const dateLocale = isRu ? "ru-RU" : "en-US";
 
   const { data: session } = await supabase
@@ -38,36 +37,6 @@ export default async function SessionDetailPage({
     .single();
 
   if (!session) redirect("/dashboard");
-
-  const { data: sessionExercises } = await supabase
-    .from("session_exercises")
-    .select("*, exercises(name_ru, name_en), session_exercise_skills(skill_id, skills(name_ru, name_en))")
-    .eq("session_id", id)
-    .order("sort_order");
-
-  const exercises = (sessionExercises || []).map(
-    (se: Record<string, unknown>) => {
-      const exercise = se.exercises as Record<string, unknown>;
-      const skillLinks = (se.session_exercise_skills as Array<Record<string, unknown>>) || [];
-      return {
-        id: se.id as number,
-        name: (exercise?.[nameCol] as string) || "",
-        skills: skillLinks.map((sl) => {
-          const skill = sl.skills as Record<string, unknown>;
-          return {
-            id: sl.skill_id as number,
-            name: (skill?.[nameCol] as string) || "",
-          };
-        }),
-      };
-    }
-  );
-
-  const allSkills = [
-    ...new Map(
-      exercises.flatMap((e) => e.skills).map((s) => [s.id, s])
-    ).values(),
-  ];
 
   const { data: transcript } = await supabase
     .from("transcripts")
@@ -124,57 +93,6 @@ export default async function SessionDetailPage({
             })}
           </p>
         </div>
-
-        <section className="bg-surface-card rounded-3xl p-5">
-          <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-4">
-            {isRu ? "Упражнения" : "Exercises"}
-          </p>
-          <div className="space-y-3">
-            {exercises.map((exercise) => (
-              <div key={exercise.id} className="space-y-2">
-                <div className="flex items-center gap-3 text-sm text-on-surface">
-                  <span className="w-1.5 h-1.5 rounded-full bg-secondary opacity-60 flex-shrink-0" />
-                  {exercise.name}
-                </div>
-                {exercise.skills.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 pl-4">
-                    {exercise.skills.map((skill) => (
-                      <span
-                        key={skill.id}
-                        className="text-[9px] font-black px-1.5 py-0.5 rounded bg-primary/10 text-primary uppercase tracking-wide"
-                      >
-                        +{skill.name}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
-            {exercises.length === 0 && (
-              <p className="text-on-surface-variant text-sm">
-                {isRu ? "Упражнения ещё не добавлены" : "No exercises added yet"}
-              </p>
-            )}
-          </div>
-        </section>
-
-        {allSkills.length > 0 && (
-          <section className="bg-surface-high rounded-3xl p-5">
-            <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-3">
-              {isRu ? "Прокачка навыков" : "Skill gains"}
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {allSkills.map((skill) => (
-                <span
-                  key={skill.id}
-                  className="text-xs font-black px-3 py-1.5 rounded-lg bg-primary/10 text-primary"
-                >
-                  {skill.name} +1
-                </span>
-              ))}
-            </div>
-          </section>
-        )}
 
         {isTrainer && (
           <section>

--- a/src/lib/dashboard/data.ts
+++ b/src/lib/dashboard/data.ts
@@ -38,7 +38,6 @@ export interface DashboardNextSession {
   id: string;
   session_number: number;
   scheduled_at: string | null;
-  exercises: string[];
 }
 
 export interface DashboardProfile {
@@ -126,9 +125,7 @@ export async function loadDashboardData(
       .is("student_decision", null),
     supabase
       .from("sessions")
-      .select(
-        `*, goals!inner(user_id), session_exercises(id, exercises(${nameCol}))`
-      )
+      .select("*, goals!inner(user_id)")
       .eq("goals.user_id", userId)
       .eq("status", "planned")
       .order("scheduled_at", { ascending: true, nullsFirst: false })
@@ -240,9 +237,6 @@ export async function loadDashboardData(
         id: nextSessionRow.id as string,
         session_number: nextSessionRow.session_number as number,
         scheduled_at: (nextSessionRow.scheduled_at as string) ?? null,
-        exercises: ((nextSessionRow.session_exercises as Array<Record<string, unknown>>) || [])
-          .map((se) => (se.exercises as Record<string, unknown>)?.[nameCol] as string)
-          .filter(Boolean),
       }
     : null;
 

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -55,7 +55,6 @@ const ru = {
   "dashboard.sessionHistory": "Тренировки",
   "dashboard.session": "Сессия",
   "dashboard.nextSession": "Следующая сессия",
-  "dashboard.exercises": "Упражнения",
 
   // Insights / vault
   "insights.title": "Инсайты",
@@ -96,7 +95,6 @@ const ru = {
   "sessions.status.planned": "Запланирована",
   "sessions.status.completed": "Завершена",
   "sessions.notes": "Заметки",
-  "sessions.exercises": "Упражнения",
   "sessions.insights": "Инсайты",
   "sessions.markComplete": "Отметить как завершённую",
 
@@ -213,7 +211,6 @@ const en: Record<keyof typeof ru, string> = {
   "dashboard.sessionHistory": "Trainings",
   "dashboard.session": "Session",
   "dashboard.nextSession": "Next session",
-  "dashboard.exercises": "Exercises",
 
   "insights.title": "Insight vault",
   "insights.empty": "No insights yet. They appear after sessions with your coach.",
@@ -250,7 +247,6 @@ const en: Record<keyof typeof ru, string> = {
   "sessions.status.planned": "Planned",
   "sessions.status.completed": "Completed",
   "sessions.notes": "Notes",
-  "sessions.exercises": "Exercises",
   "sessions.insights": "Insights",
   "sessions.markComplete": "Mark complete",
 


### PR DESCRIPTION
Closes #147

По обновлённой просьбе пользователя — блок «Упражнения» не нужен ни на странице тренировки, ни на главной. Заменяет PR #153 (закрыт без мержа).

## Что удалено

- `src/app/sessions/[id]/page.tsx` — секция «Упражнения» (UI + Supabase-запрос к `session_exercises` с join на `exercises` и `session_exercise_skills`).
- Там же — производный блок «Прокачка навыков», который строился из `exercises.flatMap(e => e.skills)` и без блока упражнений больше не имел источника данных.
- `src/lib/dashboard/data.ts` — поле `exercises: string[]` из `DashboardNextSession` и связанный join `session_exercises(id, exercises(...))` в запросе следующей сессии. Поле нигде не отрисовывалось.
- `src/lib/i18n/dict.ts` — ключи `dashboard.exercises` и `sessions.exercises` (ru + en), grep подтвердил что они нигде не используются.

## Что НЕ тронуто (намеренно)

- Таблицы БД `exercises`, `session_exercises`, `session_exercise_skills` — данные сохранены.
- Трейнерский flow создания сессии с упражнениями (`src/app/trainer/sessions/new/page.tsx`, `src/lib/actions/sessions.ts`) — это отдельная фича.
- Библиотека упражнений тренера (`src/app/trainer/library/page.tsx`, `src/lib/actions/library.ts`) — отдельная фича.

## Отклонения от плана

- На главной (`src/app/dashboard/page.tsx`) блока «Упражнения» нет — PR #153 не был смержен, поэтому удалять там нечего. Чтобы не оставлять мусор, убрал заодно неотрисовываемое поле `exercises` из `DashboardNextSession` и соответствующий join в запросе.

## Проверка

- `npx tsc --noEmit` — чисто.
- Страница тренировки больше не запрашивает `session_exercises`.