### PR TITLE
fix: инвайт-блок для студентов без токена + сторона в карточках

### DIFF
--- a/src/components/insights/TrainerCardEditor.tsx
+++ b/src/components/insights/TrainerCardEditor.tsx
@@ -123,13 +123,19 @@ function CardRow({
   const [front, setFront] = useState(card.front_text);
   const [context, setContext] = useState(card.context_text ?? "");
   const [problemId, setProblemId] = useState<number | "">(card.problem_id ?? "");
+  const [side, setSide] = useState<"" | "защита" | "атака">(
+    (card.tags?.[1] as "" | "защита" | "атака") ?? ""
+  );
 
   function save() {
+    const topic = card.tags?.[0] ?? "техника";
+    const newTags = side ? [topic, side] : [topic];
     startTransition(async () => {
       await updateInsightCard(card.id, {
         frontText: front,
         contextText: context || null,
         problemId: problemId === "" ? null : Number(problemId),
+        tags: newTags,
       });
       setEditing(false);
       onChanged();
@@ -209,6 +215,15 @@ function CardRow({
                 {p.name}
               </option>
             ))}
+          </select>
+          <select
+            value={side}
+            onChange={(e) => setSide(e.target.value as "" | "защита" | "атака")}
+            className="w-full bg-surface-elevated rounded-xl p-2 text-sm text-on-surface border border-border-dim"
+          >
+            <option value="">Сторона: не указана</option>
+            <option value="защита">Защита</option>
+            <option value="атака">Атака</option>
           </select>
           <div className="flex gap-2">
             <button

--- a/src/components/trainer/InviteBlock.tsx
+++ b/src/components/trainer/InviteBlock.tsx
@@ -7,7 +7,7 @@ export default async function InviteBlock({ studentId }: { studentId: string }) 
   if (!invite) return null;
 
   const baseUrl = process.env.NEXT_PUBLIC_NIVEL_URL ?? "http://localhost:3000";
-  const claimUrl = `${baseUrl}/claim/${invite.token}`;
+  const claimUrl = invite.token ? `${baseUrl}/claim/${invite.token}` : "";
 
   return (
     <InviteBlockClient

--- a/src/components/trainer/InviteBlockClient.tsx
+++ b/src/components/trainer/InviteBlockClient.tsx
@@ -8,7 +8,7 @@ import { regenerateInvite, revokeInvite } from "@/lib/actions/students";
 interface Props {
   studentId: string;
   claimUrl: string;
-  status: "pending" | "claimed" | "revoked";
+  status: "none" | "pending" | "claimed" | "revoked";
   claimedAt: string | null;
 }
 
@@ -42,6 +42,7 @@ export default function InviteBlockClient({ studentId, claimUrl, status, claimed
   }
 
   const badge = {
+    none: { text: "Not sent", className: "bg-surface-elevated text-on-surface-variant" },
     pending: { text: "Pending claim", className: "bg-secondary/20 text-secondary" },
     claimed: { text: "Claimed", className: "bg-primary/20 text-primary" },
     revoked: { text: "Revoked", className: "bg-error/20 text-error" },
@@ -57,6 +58,15 @@ export default function InviteBlockClient({ studentId, claimUrl, status, claimed
       </div>
       {status === "claimed" && claimedAt && (
         <p className="text-xs text-on-surface-variant">Claimed {new Date(claimedAt).toLocaleString()}</p>
+      )}
+      {status === "none" && (
+        <button
+          onClick={handleRegenerate}
+          disabled={isPending}
+          className="w-full py-2.5 rounded-xl text-xs font-bold kinetic-gradient text-on-primary disabled:opacity-40"
+        >
+          {isPending ? "Generating…" : "Generate invite link"}
+        </button>
       )}
       {status === "pending" && (
         <>

--- a/src/lib/actions/insightCards.ts
+++ b/src/lib/actions/insightCards.ts
@@ -107,6 +107,7 @@ export async function updateInsightCard(
     frontText?: string;
     contextText?: string | null;
     problemId?: number | null;
+    tags?: string[] | null;
   }
 ): Promise<Result> {
   const auth = await requireTrainer();
@@ -121,6 +122,7 @@ export async function updateInsightCard(
     update.problem_id = patch.problemId;
     update.category_id = await resolveCategoryFromProblem(supabase, patch.problemId);
   }
+  if (patch.tags !== undefined) update.tags = patch.tags;
 
   const { data, error } = await supabase
     .from("insight_cards")

--- a/src/lib/actions/students.ts
+++ b/src/lib/actions/students.ts
@@ -144,7 +144,7 @@ export async function updateStudentProfile(
 
 export type StudentInvite = {
   token: string;
-  status: "pending" | "claimed" | "revoked";
+  status: "none" | "pending" | "claimed" | "revoked";
   claimed_at: string | null;
 };
 
@@ -166,7 +166,7 @@ export async function getStudentInvite(
     return { token: data.claim_token ?? "", status: "claimed", claimed_at: data.claimed_at };
   }
   if (!data.claim_token) {
-    return null;
+    return { token: "", status: "none", claimed_at: null };
   }
   return { token: data.claim_token, status: "pending", claimed_at: null };
 }


### PR DESCRIPTION
## Что исправлено

### Инвайт-блок (основная проблема)
У студентов без `claim_token` (например, Ольга Низаева) блок инвайта вообще не отображался — `getStudentInvite` возвращал `null`, и компонент рендерил `null`.

**Исправление:** добавлен статус `"none"` — когда профиль есть, но токен не создан, показывается кнопка **Generate invite link**. При нажатии используется уже существующий `regenerateInvite`.

### Сторона (Атака/Защита) в карточках инсайтов
Карточки, созданные вручную через `TrainerCardEditor`, не имели поля `side` в `tags`. В `InsightTinder` бейдж "Защита"/"Атака" читается из `tags[1]` — который был пустым.

**Исправление:**
- `updateInsightCard` теперь принимает `tags` в patch
- В форме редактирования `TrainerCardEditor` добавлен дропдаун "Сторона: не указана / Защита / Атака"

## Что проверить
- Открыть страницу студента без инвайта → должен появиться блок "Student invite" с кнопкой "Generate invite link"
- Нажать кнопку → страница обновляется, появляется ссылка
- В тренерском редакторе карточек → нажать Edit → появляется поле Сторона → Save → в инсайтах у ученика появляется бейдж