### PR TITLE
fix: показывать scheduled_at вместо created_at в тренировках

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -122,8 +122,8 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
                 kind: "session" as const,
                 id: s.id,
                 session_number: s.session_number,
-                scheduled_at: null,
-                date: new Date(s.created_at).getTime(),
+                scheduled_at: s.scheduled_at,
+                date: new Date(s.scheduled_at ?? s.created_at).getTime(),
               }));
 
             // Also include nextSession if it has a scheduled_at

--- a/src/lib/dashboard/data.ts
+++ b/src/lib/dashboard/data.ts
@@ -116,7 +116,7 @@ export async function loadDashboardData(
       .from("sessions")
       .select("*, goals!inner(user_id)")
       .eq("goals.user_id", userId)
-      .order("created_at", { ascending: false })
+      .order("scheduled_at", { ascending: false, nullsFirst: false })
       .limit(20),
     supabase
       .from("insight_cards")

--- a/supabase/migrations/013_sessions_scheduled_at.sql
+++ b/supabase/migrations/013_sessions_scheduled_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.sessions
+  ADD COLUMN IF NOT EXISTS scheduled_at TIMESTAMPTZ;


### PR DESCRIPTION
## Что исправлено

В двух местах UI отображалось `created_at` (время создания записи) вместо `scheduled_at` (выбранного тренером времени тренировки).

## Изменения

- **`DashboardView.tsx`** — блок «Актуальное»: planned-сессии из массива `sessions` маппились с `scheduled_at: null` и датой из `created_at`. Теперь используется `s.scheduled_at ?? s.created_at`
- **`data.ts`** — сортировка главного списка сессий изменена с `created_at DESC` на `scheduled_at DESC (nullsFirst: false)` — сессии идут в порядке тренировок, а не записей
- **`013_sessions_scheduled_at.sql`** — housekeeping-миграция: колонка уже есть в prod, но отсутствовала в файлах миграций

## Проверить

1. Дашборд студента с planned-сессией → в «Актуальное» должно быть время тренировки, а не время создания записи
2. История сессий → порядок по дате тренировки
3. Старые сессии без `scheduled_at` → корректный fallback на `created_at`