### PR TITLE
fix: увеличить текст на обратной стороне карточки инсайта

### DIFF
--- a/src/components/insights/InsightTinder.tsx
+++ b/src/components/insights/InsightTinder.tsx
@@ -323,15 +323,15 @@ function BackFace({ card }: { card: InsightCardWithRelations }) {
   const total = body.length + quote.length;
 
   const bodySize =
-    total > 520 ? "text-[11px] leading-snug" :
-    total > 320 ? "text-[12px] leading-snug" :
-    total > 160 ? "text-[13px] leading-relaxed" :
-    "text-[15px] leading-relaxed";
+    total > 520 ? "text-[13px] leading-snug" :
+    total > 320 ? "text-[14px] leading-snug" :
+    total > 160 ? "text-[15px] leading-relaxed" :
+    "text-[17px] leading-relaxed";
 
   const quoteSize =
-    total > 520 ? "text-[10px]" :
-    total > 320 ? "text-[11px]" :
-    "text-xs";
+    total > 520 ? "text-[12px]" :
+    total > 320 ? "text-[13px]" :
+    "text-sm";
 
   return (
     <div className="h-full w-full p-5 flex flex-col">


### PR DESCRIPTION
Немного увеличил размер текста на обратной стороне карточки в swipe-режиме (`InsightTinder`).

| Уровень (длина текста) | Body было | Body стало | Quote было | Quote стало |
|---|---|---|---|---|
| > 520 символов | 11px | 13px | 10px | 12px |
| > 320 символов | 12px | 14px | 11px | 13px |
| > 160 символов | 13px | 15px | xs | sm |
| короткий | 15px | 17px | xs | sm |

`VaultGrid` (карточки-миниатюры в библиотеке) не трогал — там размер уместен.