### PR TITLE
feat: сортировка карточек на странице сессии

### DIFF
--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -7,7 +7,7 @@ import type { InsightCard } from "@/lib/types";
 import { AudioUploader } from "@/components/sessions/AudioUploader";
 import { PasteInsightsButton } from "@/components/sessions/PasteInsightsButton";
 import { DraftCardsList } from "@/components/insights/DraftCardsList";
-import { ApprovedInsightCard } from "@/components/insights/ApprovedInsightCard";
+import { ApprovedCardsReorderable } from "@/components/insights/ApprovedCardsReorderable";
 import BackButton from "@/components/navigation/BackButton";
 import { DownloadTranscriptButton } from "./transcript/DownloadTranscriptButton";
 
@@ -158,9 +158,7 @@ export default async function SessionDetailPage({
               <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
                 {isRu ? `Approved (${approvedCards.length})` : `Approved (${approvedCards.length})`}
               </p>
-              {approvedCards.map((c) => (
-                <ApprovedInsightCard key={c.id} card={c} />
-              ))}
+              <ApprovedCardsReorderable sessionId={id} cards={approvedCards} />
             </div>
           )}
 

--- a/src/components/insights/ApprovedCardsReorderable.tsx
+++ b/src/components/insights/ApprovedCardsReorderable.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { reorderInsightCards } from "@/lib/actions/insightCards";
+import { ApprovedInsightCard } from "./ApprovedInsightCard";
+import type { InsightCard } from "@/lib/types";
+
+interface Props {
+  sessionId: string;
+  cards: InsightCard[];
+}
+
+export function ApprovedCardsReorderable({ sessionId, cards }: Props) {
+  const [order, setOrder] = useState<InsightCard[]>(cards);
+  const [, startTransition] = useTransition();
+
+  function move(index: number, direction: -1 | 1) {
+    const target = index + direction;
+    if (target < 0 || target >= order.length) return;
+    const next = [...order];
+    [next[index], next[target]] = [next[target], next[index]];
+    setOrder(next);
+    startTransition(async () => {
+      await reorderInsightCards(sessionId, next.map((c) => c.id));
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      {order.map((card, i) => (
+        <div key={card.id} className="flex items-start gap-2">
+          <div className="flex flex-col gap-1 pt-3 flex-shrink-0">
+            <button
+              onClick={() => move(i, -1)}
+              disabled={i === 0}
+              aria-label="Переместить вверх"
+              className="w-7 h-7 flex items-center justify-center rounded-lg border border-border-dim text-on-surface-variant disabled:opacity-20 active:bg-surface-card"
+            >
+              <span className="material-symbols-outlined text-base">keyboard_arrow_up</span>
+            </button>
+            <button
+              onClick={() => move(i, 1)}
+              disabled={i === order.length - 1}
+              aria-label="Переместить вниз"
+              className="w-7 h-7 flex items-center justify-center rounded-lg border border-border-dim text-on-surface-variant disabled:opacity-20 active:bg-surface-card"
+            >
+              <span className="material-symbols-outlined text-base">keyboard_arrow_down</span>
+            </button>
+          </div>
+          <div className="flex-1 min-w-0">
+            <ApprovedInsightCard card={card} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Добавил стрелки ↑↓ к approved-карточкам на /sessions/[id] — теперь не нужно заходить на отдельную страницу /trainer/sessions/[id]/insights.