### PR TITLE
feat: trainer cards library with collections

### DIFF
--- a/src/app/trainer/cards/loading.tsx
+++ b/src/app/trainer/cards/loading.tsx
@@ -1,0 +1,22 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
+        <div className="w-10" />
+        <div className="h-5 w-32 rounded-lg bg-surface-card animate-pulse" />
+        <div className="w-10" />
+      </header>
+      <main className="px-5 pt-6 pb-36 max-w-[430px] mx-auto md:max-w-none md:px-8 space-y-4">
+        <div className="h-10 rounded-2xl bg-surface-card animate-pulse" />
+        <div className="flex gap-2">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-8 w-20 rounded-full bg-surface-card animate-pulse" />
+          ))}
+        </div>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="h-24 rounded-2xl bg-surface-card animate-pulse" />
+        ))}
+      </main>
+    </div>
+  );
+}

--- a/src/app/trainer/cards/page.tsx
+++ b/src/app/trainer/cards/page.tsx
@@ -1,0 +1,83 @@
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth/session";
+import type { CardTemplate, InsightCollection, InsightTrainerStatus } from "@/lib/types";
+import { CardsLibrary } from "@/components/trainer/CardsLibrary";
+
+export default async function TrainerCardsPage() {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") redirect("/dashboard");
+
+  const supabase = await createClient();
+
+  const [
+    { data: allCards },
+    { data: students },
+    { data: collections },
+  ] = await Promise.all([
+    supabase
+      .from("insight_cards")
+      .select("id, template_id, title, body, quote, tags, trainer_status, created_at, student_id, student_decision")
+      .eq("trainer_id", user.id)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("profiles")
+      .select("id, full_name, avatar_url")
+      .eq("role", "student")
+      .order("full_name"),
+    supabase
+      .from("insight_collections")
+      .select("id, name, created_at, insight_collection_cards(template_id)")
+      .eq("trainer_id", user.id)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  // Deduplicate by template_id, aggregate stats
+  const templateMap = new Map<string, CardTemplate & { student_ids: string[] }>();
+  for (const card of allCards ?? []) {
+    const key = card.template_id ?? card.id;
+    if (!templateMap.has(key)) {
+      templateMap.set(key, {
+        id: card.id,
+        template_id: card.template_id,
+        title: card.title,
+        body: card.body,
+        quote: card.quote,
+        tags: card.tags,
+        trainer_status: card.trainer_status as InsightTrainerStatus,
+        created_at: card.created_at,
+        student_count: 0,
+        taken_count: 0,
+        skipped_count: 0,
+        pending_count: 0,
+        student_ids: [],
+      });
+    }
+    const t = templateMap.get(key)!;
+    t.student_count++;
+    t.student_ids.push(card.student_id);
+    if (card.student_decision === "taken") t.taken_count++;
+    else if (card.student_decision === "skipped") t.skipped_count++;
+    else t.pending_count++;
+  }
+  const templates = Array.from(templateMap.values());
+
+  const collectionsWithCount: (InsightCollection & { template_ids: string[] })[] = (
+    collections ?? []
+  ).map((c) => ({
+    id: c.id,
+    trainer_id: user.id,
+    name: c.name,
+    created_at: c.created_at,
+    card_count: (c.insight_collection_cards as { template_id: string }[]).length,
+    template_ids: (c.insight_collection_cards as { template_id: string }[]).map((x) => x.template_id),
+  }));
+
+  return (
+    <CardsLibrary
+      templates={templates}
+      students={(students ?? []) as { id: string; full_name: string | null; avatar_url: string | null }[]}
+      collections={collectionsWithCount}
+    />
+  );
+}

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -40,6 +40,13 @@ const tabs: Tab[] = [
     match: (p) => p.startsWith("/matches"),
     roles: ["student", "trainer"],
   },
+  {
+    labelKey: "nav.cards",
+    icon: "auto_stories",
+    href: "/trainer/cards",
+    match: (p) => p.startsWith("/trainer/cards"),
+    roles: ["trainer"],
+  },
 ];
 
 export default function BottomNav({ role, locale }: BottomNavProps) {

--- a/src/components/trainer/ApplyCardSheet.tsx
+++ b/src/components/trainer/ApplyCardSheet.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { createPortal } from "react-dom";
+import { applyTemplateToStudent, getStudentSessions } from "@/lib/actions/insightCards";
+import type { StudentSessionOption } from "@/lib/actions/insightCards";
+
+interface Student {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface Props {
+  templateId: string;
+  templateTitle: string | null;
+  students: Student[];
+  onClose: () => void;
+}
+
+export function ApplyCardSheet({ templateId, templateTitle, students, onClose }: Props) {
+  const [step, setStep] = useState<"student" | "session">("student");
+  const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
+  const [sessions, setSessions] = useState<StudentSessionOption[]>([]);
+  const [loadingSessions, setLoadingSessions] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  async function selectStudent(student: Student) {
+    setSelectedStudent(student);
+    setLoadingSessions(true);
+    setError(null);
+    const result = await getStudentSessions(student.id);
+    setSessions(result);
+    setLoadingSessions(false);
+    setStep("session");
+  }
+
+  function applyToSession(sessionId: string) {
+    setError(null);
+    startTransition(async () => {
+      const result = await applyTemplateToStudent(templateId, sessionId);
+      if (!result.success) {
+        setError(result.error);
+      } else {
+        setSuccessMsg(`Карточка добавлена в сессию`);
+      }
+    });
+  }
+
+  const content = (
+    <div
+      className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-card rounded-t-3xl w-full max-w-[430px] mx-auto p-6 pb-10 space-y-4 max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-black tracking-tight">
+            {step === "student" ? "Выбери ученика" : `Выбери сессию — ${selectedStudent?.full_name}`}
+          </h3>
+          <button
+            onClick={onClose}
+            aria-label="Закрыть"
+            className="w-11 h-11 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
+          >
+            <span className="material-symbols-outlined text-base">close</span>
+          </button>
+        </div>
+
+        {templateTitle && (
+          <p className="text-xs text-on-surface-variant bg-surface-elevated rounded-xl px-3 py-2 line-clamp-2">
+            {templateTitle}
+          </p>
+        )}
+
+        {successMsg ? (
+          <div className="text-center py-6 space-y-3">
+            <span className="material-symbols-outlined text-4xl text-primary">check_circle</span>
+            <p className="font-bold text-on-surface">{successMsg}</p>
+            <button
+              onClick={onClose}
+              className="w-full py-3 rounded-xl kinetic-gradient text-on-primary font-bold text-sm min-h-[44px]"
+            >
+              Готово
+            </button>
+          </div>
+        ) : step === "student" ? (
+          <div className="space-y-2">
+            {students.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => selectStudent(s)}
+                className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:bg-surface-card"
+              >
+                <span className="material-symbols-outlined text-on-surface-variant">person</span>
+                <span className="font-bold text-sm text-on-surface">{s.full_name ?? "—"}</span>
+                <span className="material-symbols-outlined text-on-surface-variant ml-auto text-base">
+                  chevron_right
+                </span>
+              </button>
+            ))}
+          </div>
+        ) : loadingSessions ? (
+          <div className="py-8 flex justify-center">
+            <span className="material-symbols-outlined text-on-surface-variant animate-spin">
+              progress_activity
+            </span>
+          </div>
+        ) : sessions.length === 0 ? (
+          <p className="text-sm text-on-surface-variant text-center py-6">
+            У ученика нет сессий
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <button
+              onClick={() => setStep("student")}
+              className="flex items-center gap-1 text-xs text-secondary font-bold"
+            >
+              <span className="material-symbols-outlined text-sm">arrow_back</span>
+              Другой ученик
+            </button>
+            {sessions.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => applyToSession(s.id)}
+                disabled={isPending}
+                className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:bg-surface-card disabled:opacity-50"
+              >
+                <span className="material-symbols-outlined text-on-surface-variant text-sm">
+                  fitness_center
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="font-bold text-sm text-on-surface">
+                    Сессия {s.session_number}
+                    {s.trainer_notes ? ` — ${s.trainer_notes}` : ""}
+                  </p>
+                  <p className="text-xs text-on-surface-variant">
+                    {new Date(s.scheduled_at ?? s.created_at).toLocaleDateString("ru-RU", {
+                      day: "numeric",
+                      month: "short",
+                    })}
+                  </p>
+                </div>
+                {isPending ? (
+                  <span className="material-symbols-outlined text-on-surface-variant text-sm animate-spin">
+                    progress_activity
+                  </span>
+                ) : (
+                  <span className="material-symbols-outlined text-primary text-sm">add_circle</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-400 bg-red-500/10 rounded-xl p-3">{error}</p>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+}

--- a/src/components/trainer/CardsLibrary.tsx
+++ b/src/components/trainer/CardsLibrary.tsx
@@ -10,17 +10,11 @@ import {
   applyCollectionToStudent,
   getStudentSessions,
 } from "@/lib/actions/insightCards";
-import { ApplyCardSheet } from "./ApplyCardSheet";
+import type { StudentSessionOption } from "@/lib/actions/insightCards";
 
 type Tab = "cards" | "collections";
 
 const TAGS = ["техника", "тактика", "физика", "менталка"] as const;
-const STATUS_OPTIONS: { value: InsightTrainerStatus | "all"; label: string }[] = [
-  { value: "all", label: "Все" },
-  { value: "approved", label: "Approved" },
-  { value: "draft", label: "Draft" },
-  { value: "rejected", label: "Rejected" },
-];
 
 interface Student {
   id: string;
@@ -42,12 +36,9 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
   const [studentFilter, setStudentFilter] = useState<string | null>(null);
   const [collections, setCollections] = useState(initialCollections);
   const [newCollName, setNewCollName] = useState("");
-  const [applyCollectionState, setApplyCollectionState] = useState<{
-    collectionId: string;
-    collectionName: string;
-  } | null>(null);
+  const [collApplyState, setCollApplyState] = useState<{ id: string; name: string } | null>(null);
   const [collApplyStudentId, setCollApplyStudentId] = useState<string | null>(null);
-  const [collApplySessions, setCollApplySessions] = useState<{ id: string; session_number: number; trainer_notes: string | null; scheduled_at: string | null; created_at: string }[]>([]);
+  const [collApplySessions, setCollApplySessions] = useState<StudentSessionOption[]>([]);
   const [loadingCollSessions, setLoadingCollSessions] = useState(false);
   const [collApplyResult, setCollApplyResult] = useState<string | null>(null);
   const [, startTransition] = useTransition();
@@ -60,6 +51,8 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
     if (studentFilter && !t.student_ids.includes(studentFilter)) return false;
     return true;
   });
+
+  const hasFilters = !!(search || tagFilter || statusFilter !== "all" || studentFilter);
 
   function handleAddToCollection(collectionId: string, templateId: string) {
     startTransition(async () => {
@@ -89,11 +82,12 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
 
   function handleCreateCollection() {
     if (!newCollName.trim()) return;
+    const name = newCollName.trim();
     startTransition(async () => {
-      const result = await createCollection(newCollName.trim());
+      const result = await createCollection(name);
       if (result.success) {
         setCollections((prev) => [
-          { id: result.id, trainer_id: "", name: newCollName.trim(), created_at: new Date().toISOString(), card_count: 0, template_ids: [] },
+          { id: result.id, trainer_id: "", name, created_at: new Date().toISOString(), card_count: 0, template_ids: [] },
           ...prev,
         ]);
         setNewCollName("");
@@ -101,8 +95,8 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
     });
   }
 
-  async function startCollectionApply(collectionId: string, collectionName: string) {
-    setApplyCollectionState({ collectionId, collectionName });
+  async function startCollectionApply(id: string, name: string) {
+    setCollApplyState({ id, name });
     setCollApplyStudentId(null);
     setCollApplySessions([]);
     setCollApplyResult(null);
@@ -117,141 +111,218 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
   }
 
   function applyCollectionToSession(sessionId: string) {
-    if (!applyCollectionState) return;
+    if (!collApplyState) return;
     startTransition(async () => {
-      const result = await applyCollectionToStudent(applyCollectionState.collectionId, sessionId);
-      if (result.success) {
-        setCollApplyResult(`Добавлено ${result.applied} карточек`);
-      }
+      const result = await applyCollectionToStudent(collApplyState.id, sessionId);
+      if (result.success) setCollApplyResult(`Добавлено ${result.applied} карточек`);
     });
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
-        <div className="w-10" />
-        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
-          Библиотека карточек
-        </span>
-        <div className="w-10" />
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Top header bar */}
+      <header className="sticky top-0 z-30 glass-nav border-b border-border-dim">
+        <div className="flex items-center gap-6 px-6 h-14 max-w-screen-xl mx-auto">
+          {/* Logo / title */}
+          <span className="text-base font-black text-primary uppercase italic tracking-tight hidden md:block">
+            Nivel
+          </span>
+          <div className="w-px h-5 bg-border-dim hidden md:block" />
+          <span className="text-sm font-bold text-on-surface">Библиотека карточек</span>
+
+          {/* Tabs */}
+          <div className="flex gap-1 ml-4">
+            {(["cards", "collections"] as Tab[]).map((t) => (
+              <button
+                key={t}
+                onClick={() => setTab(t)}
+                className={`px-4 py-1.5 rounded-lg text-xs font-black uppercase tracking-widest transition-colors ${
+                  tab === t ? "bg-primary/15 text-primary" : "text-on-surface-variant hover:text-on-surface"
+                }`}
+              >
+                {t === "cards" ? `Карточки · ${templates.length}` : `Коллекции · ${collections.length}`}
+              </button>
+            ))}
+          </div>
+
+          {/* Right: search (desktop) */}
+          <div className="ml-auto hidden md:flex items-center gap-2 w-72">
+            <div className="relative flex-1">
+              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
+                search
+              </span>
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Поиск по карточкам…"
+                className="w-full bg-surface-elevated rounded-xl pl-9 pr-3 py-2 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
       </header>
 
-      {/* Tab switcher */}
-      <div className="sticky top-16 z-20 bg-background border-b border-border-dim px-5 flex gap-1 py-2">
-        <button
-          onClick={() => setTab("cards")}
-          className={`flex-1 py-2 rounded-xl text-xs font-black uppercase tracking-widest min-h-[36px] transition-colors ${
-            tab === "cards" ? "bg-primary/10 text-primary" : "text-on-surface-variant"
-          }`}
-        >
-          Карточки ({templates.length})
-        </button>
-        <button
-          onClick={() => setTab("collections")}
-          className={`flex-1 py-2 rounded-xl text-xs font-black uppercase tracking-widest min-h-[36px] transition-colors ${
-            tab === "collections" ? "bg-primary/10 text-primary" : "text-on-surface-variant"
-          }`}
-        >
-          Коллекции ({collections.length})
-        </button>
-      </div>
-
-      <main className="pb-36">
-        {/* Desktop layout wrapper */}
-        <div className="md:flex md:gap-6 md:px-8 md:pt-6">
-          {/* === CARDS TAB === */}
-          {tab === "cards" && (
-            <>
-              {/* Sidebar filters (desktop) / inline filters (mobile) */}
-              <aside className="md:w-56 md:flex-shrink-0 md:sticky md:top-32 md:self-start md:space-y-4 px-5 pt-4 md:px-0 md:pt-0 space-y-3">
-                {/* Search */}
-                <div className="relative">
-                  <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
-                    search
-                  </span>
-                  <input
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    placeholder="Поиск…"
-                    className="w-full bg-surface-card rounded-2xl pl-9 pr-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
-                  />
-                </div>
-
-                {/* Tag filter chips */}
-                <div className="flex gap-1.5 flex-wrap md:flex-col md:gap-1.5">
+      {tab === "cards" && (
+        <div className="flex flex-1 overflow-hidden">
+          {/* ── Sidebar (desktop only) ── */}
+          <aside className="hidden md:flex flex-col w-60 shrink-0 border-r border-border-dim sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-4 space-y-6">
+            {/* Tag filter */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
+                Тема
+              </p>
+              <div className="space-y-1">
+                <button
+                  onClick={() => setTagFilter(null)}
+                  className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
+                    !tagFilter ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
+                  }`}
+                >
+                  Все темы
+                </button>
+                {TAGS.map((tag) => (
                   <button
-                    onClick={() => setTagFilter(null)}
-                    className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
-                      !tagFilter ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
+                    key={tag}
+                    onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
+                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium capitalize transition-colors ${
+                      tagFilter === tag ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
                     }`}
                   >
-                    Все темы
+                    {tag}
                   </button>
-                  {TAGS.map((tag) => (
-                    <button
-                      key={tag}
-                      onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
-                      className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
-                        tagFilter === tag ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
-                      }`}
-                    >
-                      {tag}
-                    </button>
-                  ))}
-                </div>
+                ))}
+              </div>
+            </div>
 
-                {/* Status filter */}
-                <div className="flex gap-1.5 flex-wrap md:flex-col md:gap-1.5">
-                  {STATUS_OPTIONS.map((opt) => (
-                    <button
-                      key={opt.value}
-                      onClick={() => setStatusFilter(opt.value)}
-                      className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
-                        statusFilter === opt.value ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
-                      }`}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
+            <div className="h-px bg-border-dim" />
 
-                {/* Student filter */}
-                {students.length > 0 && (
-                  <select
-                    value={studentFilter ?? ""}
-                    onChange={(e) => setStudentFilter(e.target.value || null)}
-                    className="w-full bg-surface-card rounded-2xl px-3 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
-                  >
-                    <option value="">Все ученики</option>
-                    {students.map((s) => (
-                      <option key={s.id} value={s.id}>
-                        {s.full_name ?? "—"}
-                      </option>
-                    ))}
-                  </select>
-                )}
-
-                {(search || tagFilter || statusFilter !== "all" || studentFilter) && (
+            {/* Status filter */}
+            <div className="space-y-2">
+              <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
+                Статус
+              </p>
+              <div className="space-y-1">
+                {(["all", "approved", "draft", "rejected"] as const).map((s) => (
                   <button
-                    onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
-                    className="text-xs text-secondary font-bold flex items-center gap-1"
+                    key={s}
+                    onClick={() => setStatusFilter(s)}
+                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
+                      statusFilter === s ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
+                    }`}
                   >
-                    <span className="material-symbols-outlined text-sm">close</span>
-                    Сбросить фильтры
+                    {s === "all" ? "Все" : s === "approved" ? "Approved" : s === "draft" ? "Draft" : "Rejected"}
                   </button>
-                )}
-              </aside>
+                ))}
+              </div>
+            </div>
 
-              {/* Card list */}
-              <div className="flex-1 min-w-0 px-5 pt-3 md:px-0 md:pt-0 space-y-3 md:grid md:grid-cols-2 md:gap-3 md:content-start">
-                {filtered.length === 0 ? (
-                  <p className="text-sm text-on-surface-variant col-span-2 py-12 text-center">
-                    {search || tagFilter || statusFilter !== "all" || studentFilter
-                      ? "Нет карточек по фильтрам"
-                      : "Нет карточек в библиотеке"}
+            <div className="h-px bg-border-dim" />
+
+            {/* Student filter */}
+            {students.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
+                  Ученик
+                </p>
+                <div className="space-y-1">
+                  <button
+                    onClick={() => setStudentFilter(null)}
+                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
+                      !studentFilter ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
+                    }`}
+                  >
+                    Все ученики
+                  </button>
+                  {students.map((s) => (
+                    <button
+                      key={s.id}
+                      onClick={() => setStudentFilter(s.id === studentFilter ? null : s.id)}
+                      className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors truncate ${
+                        studentFilter === s.id ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
+                      }`}
+                    >
+                      {s.full_name ?? "—"}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {hasFilters && (
+              <button
+                onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
+                className="flex items-center gap-1.5 text-xs text-on-surface-variant hover:text-on-surface transition-colors px-1"
+              >
+                <span className="material-symbols-outlined text-sm">close</span>
+                Сбросить фильтры
+              </button>
+            )}
+          </aside>
+
+          {/* ── Main content ── */}
+          <main className="flex-1 overflow-y-auto">
+            {/* Mobile search */}
+            <div className="md:hidden px-5 pt-4">
+              <div className="relative">
+                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
+                  search
+                </span>
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Поиск…"
+                  className="w-full bg-surface-card rounded-2xl pl-9 pr-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Mobile filter chips */}
+            <div className="md:hidden flex gap-2 px-5 pt-3 pb-1 overflow-x-auto scrollbar-hide">
+              {TAGS.map((tag) => (
+                <button
+                  key={tag}
+                  onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
+                  className={`shrink-0 px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
+                    tagFilter === tag ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
+                  }`}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+
+            {/* Summary bar */}
+            <div className="flex items-center justify-between px-5 md:px-8 py-4 border-b border-border-dim">
+              <p className="text-xs text-on-surface-variant">
+                {filtered.length === templates.length
+                  ? `${templates.length} карточек`
+                  : `${filtered.length} из ${templates.length}`}
+              </p>
+              {hasFilters && (
+                <button
+                  onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
+                  className="text-xs text-secondary font-bold flex items-center gap-1"
+                >
+                  <span className="material-symbols-outlined text-sm">close</span>
+                  Сбросить
+                </button>
+              )}
+            </div>
+
+            {/* Card grid */}
+            <div className="p-5 md:p-8 pb-36">
+              {filtered.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-24 text-center">
+                  <span className="material-symbols-outlined text-5xl text-on-surface-variant/30 mb-4">
+                    search_off
+                  </span>
+                  <p className="text-sm text-on-surface-variant">
+                    {hasFilters ? "Нет карточек по фильтрам" : "Нет карточек в библиотеке"}
                   </p>
-                ) : (
-                  filtered.map((template) => (
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {filtered.map((template) => (
                     <LibraryCardItem
                       key={template.template_id ?? template.id}
                       template={template}
@@ -260,97 +331,104 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                       onAddToCollection={handleAddToCollection}
                       onRemoveFromCollection={handleRemoveFromCollection}
                     />
-                  ))
-                )}
-              </div>
-            </>
-          )}
-
-          {/* === COLLECTIONS TAB === */}
-          {tab === "collections" && (
-            <div className="flex-1 px-5 pt-4 md:px-0 md:pt-0 space-y-4">
-              {/* Create new collection */}
-              <div className="flex gap-2">
-                <input
-                  value={newCollName}
-                  onChange={(e) => setNewCollName(e.target.value)}
-                  onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
-                  placeholder="Название коллекции…"
-                  className="flex-1 bg-surface-card rounded-2xl px-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
-                />
-                <button
-                  onClick={handleCreateCollection}
-                  disabled={!newCollName.trim()}
-                  className="px-4 rounded-2xl kinetic-gradient text-on-primary text-sm font-bold disabled:opacity-40 min-h-[44px]"
-                >
-                  Создать
-                </button>
-              </div>
-
-              {collections.length === 0 ? (
-                <p className="text-sm text-on-surface-variant text-center py-12">
-                  Создай коллекцию, чтобы группировать карточки
-                </p>
-              ) : (
-                collections.map((col) => (
-                  <div key={col.id} className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
-                    <div className="flex items-center justify-between px-4 py-4">
-                      <div>
-                        <p className="font-bold text-sm text-on-surface">{col.name}</p>
-                        <p className="text-xs text-on-surface-variant mt-0.5">
-                          {col.card_count ?? col.template_ids.length} карточек
-                        </p>
-                      </div>
-                      <button
-                        onClick={() => startCollectionApply(col.id, col.name)}
-                        className="flex items-center gap-1.5 px-3 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
-                      >
-                        <span className="material-symbols-outlined text-sm">send</span>
-                        Применить
-                      </button>
-                    </div>
-                    {col.template_ids.length > 0 && (
-                      <div className="px-4 pb-4 space-y-1.5 border-t border-border-dim pt-3">
-                        {templates
-                          .filter((t) => col.template_ids.includes(t.template_id ?? t.id))
-                          .map((t) => (
-                            <div key={t.id} className="flex items-center gap-2">
-                              <p className="flex-1 text-xs text-on-surface truncate">{t.title}</p>
-                              <button
-                                onClick={() => handleRemoveFromCollection(col.id, t.template_id ?? t.id)}
-                                className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant"
-                                aria-label="Убрать из коллекции"
-                              >
-                                <span className="material-symbols-outlined text-sm">close</span>
-                              </button>
-                            </div>
-                          ))}
-                      </div>
-                    )}
-                  </div>
-                ))
+                  ))}
+                </div>
               )}
             </div>
-          )}
+          </main>
         </div>
-      </main>
+      )}
 
-      {/* Collection apply bottom sheet */}
-      {applyCollectionState && (
+      {/* ── Collections tab ── */}
+      {tab === "collections" && (
+        <main className="flex-1 p-5 md:p-8 pb-36 max-w-2xl">
+          {/* Create */}
+          <div className="flex gap-3 mb-6">
+            <input
+              value={newCollName}
+              onChange={(e) => setNewCollName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
+              placeholder="Название новой коллекции…"
+              className="flex-1 bg-surface-card rounded-2xl px-4 py-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
+            />
+            <button
+              onClick={handleCreateCollection}
+              disabled={!newCollName.trim()}
+              className="px-5 rounded-2xl kinetic-gradient text-on-primary text-sm font-bold disabled:opacity-40 min-h-[44px]"
+            >
+              Создать
+            </button>
+          </div>
+
+          {collections.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <span className="material-symbols-outlined text-5xl text-on-surface-variant/30 mb-4">
+                bookmarks
+              </span>
+              <p className="text-sm text-on-surface-variant">
+                Создай коллекцию, чтобы группировать карточки
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {collections.map((col) => (
+                <div key={col.id} className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
+                  <div className="flex items-center justify-between px-5 py-4">
+                    <div>
+                      <p className="font-bold text-sm text-on-surface">{col.name}</p>
+                      <p className="text-xs text-on-surface-variant mt-0.5">
+                        {col.card_count ?? col.template_ids.length} карточек
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => startCollectionApply(col.id, col.name)}
+                      className="flex items-center gap-1.5 px-4 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
+                    >
+                      <span className="material-symbols-outlined text-sm">send</span>
+                      Применить к ученику
+                    </button>
+                  </div>
+                  {col.template_ids.length > 0 && (
+                    <div className="border-t border-border-dim">
+                      {templates
+                        .filter((t) => col.template_ids.includes(t.template_id ?? t.id))
+                        .map((t) => (
+                          <div key={t.id} className="flex items-center gap-3 px-5 py-3 border-b border-border-dim last:border-0">
+                            <span className="material-symbols-outlined text-on-surface-variant text-sm">
+                              drag_indicator
+                            </span>
+                            <p className="flex-1 text-sm text-on-surface truncate">{t.title}</p>
+                            <button
+                              onClick={() => handleRemoveFromCollection(col.id, t.template_id ?? t.id)}
+                              className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                            >
+                              <span className="material-symbols-outlined text-sm">close</span>
+                            </button>
+                          </div>
+                        ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </main>
+      )}
+
+      {/* Collection apply sheet */}
+      {collApplyState && (
         <div
           className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
-          onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+          onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
         >
           <div
             className="bg-surface-card rounded-t-3xl w-full max-w-[430px] mx-auto p-6 pb-10 space-y-4 max-h-[80vh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
-              <h3 className="text-base font-black tracking-tight">
-                Применить «{applyCollectionState.collectionName}»
-              </h3>
+              <h3 className="text-base font-black tracking-tight">«{collApplyState.name}»</h3>
               <button
-                onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+                onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
                 className="w-11 h-11 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
               >
                 <span className="material-symbols-outlined text-base">close</span>
@@ -362,7 +440,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                 <span className="material-symbols-outlined text-4xl text-primary">check_circle</span>
                 <p className="font-bold text-on-surface">{collApplyResult}</p>
                 <button
-                  onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+                  onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
                   className="w-full py-3 rounded-xl kinetic-gradient text-on-primary font-bold text-sm min-h-[44px]"
                 >
                   Готово
@@ -375,7 +453,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   <button
                     key={s.id}
                     onClick={() => selectStudentForCollection(s.id)}
-                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px]"
+                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:opacity-80"
                   >
                     <span className="material-symbols-outlined text-on-surface-variant">person</span>
                     <span className="font-bold text-sm text-on-surface">{s.full_name ?? "—"}</span>
@@ -391,7 +469,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
               <div className="space-y-2">
                 <button
                   onClick={() => { setCollApplyStudentId(null); setCollApplySessions([]); }}
-                  className="flex items-center gap-1 text-xs text-secondary font-bold"
+                  className="flex items-center gap-1 text-xs text-secondary font-bold mb-2"
                 >
                   <span className="material-symbols-outlined text-sm">arrow_back</span>
                   Другой ученик
@@ -400,7 +478,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   <button
                     key={s.id}
                     onClick={() => applyCollectionToSession(s.id)}
-                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px]"
+                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:opacity-80"
                   >
                     <span className="material-symbols-outlined text-on-surface-variant text-sm">fitness_center</span>
                     <div className="flex-1">

--- a/src/components/trainer/CardsLibrary.tsx
+++ b/src/components/trainer/CardsLibrary.tsx
@@ -16,18 +16,11 @@ type Tab = "cards" | "collections";
 
 const TAGS = ["техника", "тактика", "физика", "менталка"] as const;
 
-const TAG_DOT: Record<string, string> = {
-  техника: "bg-blue-500",
-  тактика: "bg-amber-500",
-  физика: "bg-emerald-500",
-  менталка: "bg-purple-500",
-};
-
-const STATUS_OPTIONS: { value: InsightTrainerStatus | "all"; label: string; dot?: string }[] = [
-  { value: "all", label: "All statuses" },
-  { value: "approved", label: "Approved", dot: "bg-emerald-500" },
-  { value: "draft", label: "Draft", dot: "bg-amber-500" },
-  { value: "rejected", label: "Rejected", dot: "bg-red-500" },
+const STATUS_OPTIONS: { value: InsightTrainerStatus | "all"; label: string }[] = [
+  { value: "all", label: "Все статусы" },
+  { value: "approved", label: "Approved" },
+  { value: "draft", label: "Draft" },
+  { value: "rejected", label: "Rejected" },
 ];
 
 interface Student {
@@ -254,11 +247,11 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
         <div className="flex flex-1 max-w-screen-2xl mx-auto w-full">
           {/* ─────────── Sidebar (desktop) ─────────── */}
           <aside className="hidden md:flex flex-col w-[220px] shrink-0 border-r border-border-dim sticky top-14 self-start h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-3">
-            <SidebarSection title="By Topic">
+            <SidebarSection title="Тема">
               <SidebarItem
                 active={!tagFilter}
                 onClick={() => setTagFilter(null)}
-                label="All topics"
+                label="Все темы"
                 count={templates.length}
               />
               {TAGS.map((tag) => (
@@ -268,13 +261,12 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
                   label={tag}
                   count={tagCounts[tag] ?? 0}
-                  dot={TAG_DOT[tag]}
                   capitalize
                 />
               ))}
             </SidebarSection>
 
-            <SidebarSection title="By Status">
+            <SidebarSection title="Статус">
               {STATUS_OPTIONS.map((opt) => (
                 <SidebarItem
                   key={opt.value}
@@ -282,17 +274,16 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   onClick={() => setStatusFilter(opt.value)}
                   label={opt.label}
                   count={statusCounts[opt.value] ?? 0}
-                  dot={opt.dot}
                 />
               ))}
             </SidebarSection>
 
             {students.length > 0 && (
-              <SidebarSection title="Students">
+              <SidebarSection title="Ученики">
                 <SidebarItem
                   active={!studentFilter}
                   onClick={() => setStudentFilter(null)}
-                  label="All students"
+                  label="Все ученики"
                   count={students.length}
                 />
                 <div className="max-h-[280px] overflow-y-auto">
@@ -339,14 +330,13 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
 
             {/* Mobile filter chips */}
             <div className="md:hidden flex gap-2 px-4 pt-3 pb-1 overflow-x-auto scrollbar-hide">
-              <MobileChip active={!tagFilter} onClick={() => setTagFilter(null)} label="All" />
+              <MobileChip active={!tagFilter} onClick={() => setTagFilter(null)} label="Все" />
               {TAGS.map((tag) => (
                 <MobileChip
                   key={tag}
                   active={tagFilter === tag}
                   onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
                   label={tag}
-                  dot={TAG_DOT[tag]}
                 />
               ))}
             </div>
@@ -357,7 +347,6 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   active={statusFilter === opt.value}
                   onClick={() => setStatusFilter(opt.value)}
                   label={opt.label}
-                  dot={opt.dot}
                 />
               ))}
             </div>
@@ -683,34 +672,27 @@ function SidebarItem({
   onClick,
   label,
   count,
-  dot,
   capitalize,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
   count?: number;
-  dot?: string;
   capitalize?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-all duration-150 ${
+      className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-[13px] transition-all duration-150 ${
         active
-          ? "bg-primary/10 text-primary"
-          : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated/60"
+          ? "bg-surface-card border border-border font-semibold text-on-surface"
+          : "font-medium text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated/40"
       }`}
     >
-      {dot && <span className={`w-2 h-2 rounded-full shrink-0 ${dot}`} />}
-      <span className={`truncate flex-1 text-left ${capitalize ? "capitalize" : ""}`}>{label}</span>
+      <span className={`truncate text-left ${capitalize ? "capitalize" : ""}`}>{label}</span>
       {typeof count === "number" && (
-        <span
-          className={`text-[11px] tabular-nums font-semibold ${
-            active ? "text-primary" : "text-on-surface-variant/70"
-          }`}
-        >
+        <span className={`text-[11px] tabular-nums ml-2 shrink-0 ${active ? "text-on-surface" : "text-on-surface-variant/60"}`}>
           {count}
         </span>
       )}
@@ -722,24 +704,21 @@ function MobileChip({
   active,
   onClick,
   label,
-  dot,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
-  dot?: string;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`shrink-0 inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-[12px] font-semibold whitespace-nowrap transition-colors ${
+      className={`shrink-0 inline-flex items-center px-3 h-8 rounded-md text-[12px] font-semibold whitespace-nowrap transition-colors ${
         active
           ? "bg-primary text-on-primary"
           : "bg-surface-elevated/60 text-on-surface-variant border border-border-dim"
       }`}
     >
-      {dot && <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />}
       <span className="capitalize">{label}</span>
     </button>
   );

--- a/src/components/trainer/CardsLibrary.tsx
+++ b/src/components/trainer/CardsLibrary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import type { CardTemplate, InsightCollection, InsightTrainerStatus } from "@/lib/types";
 import { LibraryCardItem } from "./LibraryCardItem";
 import {
@@ -15,6 +15,20 @@ import type { StudentSessionOption } from "@/lib/actions/insightCards";
 type Tab = "cards" | "collections";
 
 const TAGS = ["техника", "тактика", "физика", "менталка"] as const;
+
+const TAG_DOT: Record<string, string> = {
+  техника: "bg-blue-500",
+  тактика: "bg-amber-500",
+  физика: "bg-emerald-500",
+  менталка: "bg-purple-500",
+};
+
+const STATUS_OPTIONS: { value: InsightTrainerStatus | "all"; label: string; dot?: string }[] = [
+  { value: "all", label: "All statuses" },
+  { value: "approved", label: "Approved", dot: "bg-emerald-500" },
+  { value: "draft", label: "Draft", dot: "bg-amber-500" },
+  { value: "rejected", label: "Rejected", dot: "bg-red-500" },
+];
 
 interface Student {
   id: string;
@@ -43,16 +57,40 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
   const [collApplyResult, setCollApplyResult] = useState<string | null>(null);
   const [, startTransition] = useTransition();
 
-  const q = search.toLowerCase();
-  const filtered = templates.filter((t) => {
-    if (q && !t.title?.toLowerCase().includes(q) && !t.body?.toLowerCase().includes(q)) return false;
-    if (tagFilter && !t.tags?.includes(tagFilter)) return false;
-    if (statusFilter !== "all" && t.trainer_status !== statusFilter) return false;
-    if (studentFilter && !t.student_ids.includes(studentFilter)) return false;
-    return true;
-  });
+  // Counts per tag / status — for sidebar badges
+  const tagCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const t of templates) {
+      for (const tag of t.tags ?? []) counts[tag] = (counts[tag] ?? 0) + 1;
+    }
+    return counts;
+  }, [templates]);
+
+  const statusCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: templates.length, approved: 0, draft: 0, rejected: 0 };
+    for (const t of templates) counts[t.trainer_status] = (counts[t.trainer_status] ?? 0) + 1;
+    return counts;
+  }, [templates]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return templates.filter((t) => {
+      if (q && !t.title?.toLowerCase().includes(q) && !t.body?.toLowerCase().includes(q)) return false;
+      if (tagFilter && !t.tags?.includes(tagFilter)) return false;
+      if (statusFilter !== "all" && t.trainer_status !== statusFilter) return false;
+      if (studentFilter && !t.student_ids.includes(studentFilter)) return false;
+      return true;
+    });
+  }, [templates, search, tagFilter, statusFilter, studentFilter]);
 
   const hasFilters = !!(search || tagFilter || statusFilter !== "all" || studentFilter);
+
+  function resetFilters() {
+    setSearch("");
+    setTagFilter(null);
+    setStatusFilter("all");
+    setStudentFilter(null);
+  }
 
   function handleAddToCollection(collectionId: string, templateId: string) {
     startTransition(async () => {
@@ -73,7 +111,11 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
       setCollections((prev) =>
         prev.map((c) =>
           c.id === collectionId
-            ? { ...c, template_ids: c.template_ids.filter((id) => id !== templateId), card_count: Math.max(0, (c.card_count ?? 1) - 1) }
+            ? {
+                ...c,
+                template_ids: c.template_ids.filter((id) => id !== templateId),
+                card_count: Math.max(0, (c.card_count ?? 1) - 1),
+              }
             : c
         )
       );
@@ -95,7 +137,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
     });
   }
 
-  async function startCollectionApply(id: string, name: string) {
+  function startCollectionApply(id: string, name: string) {
     setCollApplyState({ id, name });
     setCollApplyStudentId(null);
     setCollApplySessions([]);
@@ -120,206 +162,259 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      {/* Top header bar */}
+      {/* ─────────── Top header ─────────── */}
       <header className="sticky top-0 z-30 glass-nav border-b border-border-dim">
-        <div className="flex items-center gap-6 px-6 h-14 max-w-screen-xl mx-auto">
-          {/* Logo / title */}
-          <span className="text-base font-black text-primary uppercase italic tracking-tight hidden md:block">
-            Nivel
-          </span>
-          <div className="w-px h-5 bg-border-dim hidden md:block" />
-          <span className="text-sm font-bold text-on-surface">Библиотека карточек</span>
-
-          {/* Tabs */}
-          <div className="flex gap-1 ml-4">
-            {(["cards", "collections"] as Tab[]).map((t) => (
-              <button
-                key={t}
-                onClick={() => setTab(t)}
-                className={`px-4 py-1.5 rounded-lg text-xs font-black uppercase tracking-widest transition-colors ${
-                  tab === t ? "bg-primary/15 text-primary" : "text-on-surface-variant hover:text-on-surface"
-                }`}
-              >
-                {t === "cards" ? `Карточки · ${templates.length}` : `Коллекции · ${collections.length}`}
-              </button>
-            ))}
-          </div>
-
-          {/* Right: search (desktop) */}
-          <div className="ml-auto hidden md:flex items-center gap-2 w-72">
-            <div className="relative flex-1">
-              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
-                search
+        <div className="max-w-screen-2xl mx-auto px-4 md:px-6">
+          <div className="flex items-center gap-4 h-14">
+            {/* Logo */}
+            <div className="flex items-center gap-3 shrink-0">
+              <span className="text-base font-black text-primary uppercase italic tracking-tight hidden sm:block">
+                Nivel
               </span>
-              <input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Поиск по карточкам…"
-                className="w-full bg-surface-elevated rounded-xl pl-9 pr-3 py-2 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
-              />
+              <span className="w-px h-5 bg-border-dim hidden sm:block" />
+              <div className="flex items-center gap-2">
+                <span className="material-symbols-outlined text-on-surface text-[20px]">style</span>
+                <h1 className="text-[15px] font-bold text-on-surface tracking-tight">Card Library</h1>
+              </div>
+              <span className="hidden md:inline-flex items-center justify-center min-w-[24px] h-[22px] px-1.5 rounded-md bg-surface-elevated text-on-surface-variant text-[11px] font-bold tabular-nums">
+                {templates.length}
+              </span>
             </div>
-          </div>
-        </div>
-      </header>
 
-      {tab === "cards" && (
-        <div className="flex flex-1 overflow-hidden">
-          {/* ── Sidebar (desktop only) ── */}
-          <aside className="hidden md:flex flex-col w-60 shrink-0 border-r border-border-dim sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-4 space-y-6">
-            {/* Tag filter */}
-            <div className="space-y-2">
-              <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
-                Тема
-              </p>
-              <div className="space-y-1">
+            {/* Segmented tabs */}
+            <div className="hidden md:flex items-center bg-surface-elevated/60 rounded-lg p-0.5 ml-2">
+              {(["cards", "collections"] as Tab[]).map((t) => (
                 <button
-                  onClick={() => setTagFilter(null)}
-                  className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
-                    !tagFilter ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
+                  key={t}
+                  type="button"
+                  onClick={() => setTab(t)}
+                  className={`relative px-3 py-1.5 rounded-md text-[12px] font-semibold transition-all duration-200 ${
+                    tab === t
+                      ? "bg-surface-card text-on-surface shadow-sm"
+                      : "text-on-surface-variant hover:text-on-surface"
                   }`}
                 >
-                  Все темы
+                  {t === "cards" ? "Cards" : "Collections"}
+                  <span
+                    className={`ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded-[5px] text-[10px] font-bold tabular-nums ${
+                      tab === t ? "bg-primary/15 text-primary" : "bg-surface-elevated text-on-surface-variant"
+                    }`}
+                  >
+                    {t === "cards" ? templates.length : collections.length}
+                  </span>
                 </button>
-                {TAGS.map((tag) => (
-                  <button
-                    key={tag}
-                    onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium capitalize transition-colors ${
-                      tagFilter === tag ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
-                    }`}
-                  >
-                    {tag}
-                  </button>
-                ))}
-              </div>
+              ))}
             </div>
 
-            <div className="h-px bg-border-dim" />
-
-            {/* Status filter */}
-            <div className="space-y-2">
-              <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
-                Статус
-              </p>
-              <div className="space-y-1">
-                {(["all", "approved", "draft", "rejected"] as const).map((s) => (
-                  <button
-                    key={s}
-                    onClick={() => setStatusFilter(s)}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
-                      statusFilter === s ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
-                    }`}
-                  >
-                    {s === "all" ? "Все" : s === "approved" ? "Approved" : s === "draft" ? "Draft" : "Rejected"}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="h-px bg-border-dim" />
-
-            {/* Student filter */}
-            {students.length > 0 && (
-              <div className="space-y-2">
-                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-1">
-                  Ученик
-                </p>
-                <div className="space-y-1">
-                  <button
-                    onClick={() => setStudentFilter(null)}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors ${
-                      !studentFilter ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
-                    }`}
-                  >
-                    Все ученики
-                  </button>
-                  {students.map((s) => (
-                    <button
-                      key={s.id}
-                      onClick={() => setStudentFilter(s.id === studentFilter ? null : s.id)}
-                      className={`w-full text-left px-3 py-2 rounded-xl text-sm font-medium transition-colors truncate ${
-                        studentFilter === s.id ? "bg-primary/10 text-primary font-bold" : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated"
-                      }`}
-                    >
-                      {s.full_name ?? "—"}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {hasFilters && (
-              <button
-                onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
-                className="flex items-center gap-1.5 text-xs text-on-surface-variant hover:text-on-surface transition-colors px-1"
-              >
-                <span className="material-symbols-outlined text-sm">close</span>
-                Сбросить фильтры
-              </button>
-            )}
-          </aside>
-
-          {/* ── Main content ── */}
-          <main className="flex-1 overflow-y-auto">
-            {/* Mobile search */}
-            <div className="md:hidden px-5 pt-4">
-              <div className="relative">
-                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
+            {/* Search */}
+            <div className="ml-auto flex items-center gap-2">
+              <div className="relative hidden md:block w-64 lg:w-80">
+                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-[18px] pointer-events-none">
                   search
                 </span>
                 <input
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Поиск…"
-                  className="w-full bg-surface-card rounded-2xl pl-9 pr-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+                  placeholder="Search cards…"
+                  className="w-full bg-surface-elevated/60 rounded-lg pl-9 pr-3 h-9 text-[13px] text-on-surface placeholder:text-on-surface-variant/60 border border-transparent focus:border-primary/40 focus:bg-surface-card focus:outline-none transition-colors"
+                />
+                {search && (
+                  <button
+                    type="button"
+                    onClick={() => setSearch("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant hover:text-on-surface"
+                    aria-label="Очистить поиск"
+                  >
+                    <span className="material-symbols-outlined text-[16px]">close</span>
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Mobile tabs */}
+          <div className="md:hidden flex items-center bg-surface-elevated/60 rounded-lg p-0.5 mb-3">
+            {(["cards", "collections"] as Tab[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTab(t)}
+                className={`flex-1 px-3 py-1.5 rounded-md text-[12px] font-semibold transition-all duration-200 ${
+                  tab === t ? "bg-surface-card text-on-surface shadow-sm" : "text-on-surface-variant"
+                }`}
+              >
+                {t === "cards" ? `Cards · ${templates.length}` : `Collections · ${collections.length}`}
+              </button>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {tab === "cards" ? (
+        <div className="flex flex-1 max-w-screen-2xl mx-auto w-full">
+          {/* ─────────── Sidebar (desktop) ─────────── */}
+          <aside className="hidden md:flex flex-col w-[220px] shrink-0 border-r border-border-dim sticky top-14 self-start h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-3">
+            <SidebarSection title="By Topic">
+              <SidebarItem
+                active={!tagFilter}
+                onClick={() => setTagFilter(null)}
+                label="All topics"
+                count={templates.length}
+              />
+              {TAGS.map((tag) => (
+                <SidebarItem
+                  key={tag}
+                  active={tagFilter === tag}
+                  onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
+                  label={tag}
+                  count={tagCounts[tag] ?? 0}
+                  dot={TAG_DOT[tag]}
+                  capitalize
+                />
+              ))}
+            </SidebarSection>
+
+            <SidebarSection title="By Status">
+              {STATUS_OPTIONS.map((opt) => (
+                <SidebarItem
+                  key={opt.value}
+                  active={statusFilter === opt.value}
+                  onClick={() => setStatusFilter(opt.value)}
+                  label={opt.label}
+                  count={statusCounts[opt.value] ?? 0}
+                  dot={opt.dot}
+                />
+              ))}
+            </SidebarSection>
+
+            {students.length > 0 && (
+              <SidebarSection title="Students">
+                <SidebarItem
+                  active={!studentFilter}
+                  onClick={() => setStudentFilter(null)}
+                  label="All students"
+                  count={students.length}
+                />
+                <div className="max-h-[280px] overflow-y-auto">
+                  {students.map((s) => (
+                    <SidebarItem
+                      key={s.id}
+                      active={studentFilter === s.id}
+                      onClick={() => setStudentFilter(s.id === studentFilter ? null : s.id)}
+                      label={s.full_name ?? "—"}
+                    />
+                  ))}
+                </div>
+              </SidebarSection>
+            )}
+
+            {hasFilters && (
+              <button
+                type="button"
+                onClick={resetFilters}
+                className="mt-2 flex items-center gap-1.5 text-[12px] text-on-surface-variant hover:text-on-surface transition-colors px-3 py-2 rounded-lg hover:bg-surface-elevated/60"
+              >
+                <span className="material-symbols-outlined text-[16px]">restart_alt</span>
+                Reset filters
+              </button>
+            )}
+          </aside>
+
+          {/* ─────────── Main ─────────── */}
+          <main className="flex-1 min-w-0">
+            {/* Mobile search */}
+            <div className="md:hidden px-4 pt-3">
+              <div className="relative">
+                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-[18px]">
+                  search
+                </span>
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search cards…"
+                  className="w-full bg-surface-elevated/60 rounded-lg pl-9 pr-3 h-10 text-[13px] text-on-surface border border-transparent focus:border-primary/40 focus:outline-none"
                 />
               </div>
             </div>
 
             {/* Mobile filter chips */}
-            <div className="md:hidden flex gap-2 px-5 pt-3 pb-1 overflow-x-auto scrollbar-hide">
+            <div className="md:hidden flex gap-2 px-4 pt-3 pb-1 overflow-x-auto scrollbar-hide">
+              <MobileChip active={!tagFilter} onClick={() => setTagFilter(null)} label="All" />
               {TAGS.map((tag) => (
-                <button
+                <MobileChip
                   key={tag}
+                  active={tagFilter === tag}
                   onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
-                  className={`shrink-0 px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
-                    tagFilter === tag ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
-                  }`}
-                >
-                  {tag}
-                </button>
+                  label={tag}
+                  dot={TAG_DOT[tag]}
+                />
+              ))}
+            </div>
+            <div className="md:hidden flex gap-2 px-4 pt-2 pb-1 overflow-x-auto scrollbar-hide">
+              {STATUS_OPTIONS.map((opt) => (
+                <MobileChip
+                  key={opt.value}
+                  active={statusFilter === opt.value}
+                  onClick={() => setStatusFilter(opt.value)}
+                  label={opt.label}
+                  dot={opt.dot}
+                />
               ))}
             </div>
 
             {/* Summary bar */}
-            <div className="flex items-center justify-between px-5 md:px-8 py-4 border-b border-border-dim">
-              <p className="text-xs text-on-surface-variant">
-                {filtered.length === templates.length
-                  ? `${templates.length} карточек`
-                  : `${filtered.length} из ${templates.length}`}
-              </p>
+            <div className="flex items-center justify-between px-4 md:px-8 py-4 border-b border-border-dim">
+              <div className="flex items-center gap-2">
+                <p className="text-[13px] text-on-surface">
+                  <span className="font-semibold tabular-nums">{filtered.length}</span>{" "}
+                  <span className="text-on-surface-variant">
+                    {filtered.length === templates.length
+                      ? "cards"
+                      : `of ${templates.length} cards`}
+                  </span>
+                </p>
+                {hasFilters && (
+                  <span className="hidden md:inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-primary/10 text-primary text-[11px] font-semibold">
+                    <span className="material-symbols-outlined text-[14px]">filter_alt</span>
+                    Filtered
+                  </span>
+                )}
+              </div>
               {hasFilters && (
                 <button
-                  onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
-                  className="text-xs text-secondary font-bold flex items-center gap-1"
+                  type="button"
+                  onClick={resetFilters}
+                  className="text-[12px] text-on-surface-variant hover:text-on-surface font-medium flex items-center gap-1 transition-colors"
                 >
-                  <span className="material-symbols-outlined text-sm">close</span>
-                  Сбросить
+                  <span className="material-symbols-outlined text-[15px]">close</span>
+                  Clear
                 </button>
               )}
             </div>
 
             {/* Card grid */}
-            <div className="p-5 md:p-8 pb-36">
+            <div className="p-4 md:p-8 pb-36">
               {filtered.length === 0 ? (
-                <div className="flex flex-col items-center justify-center py-24 text-center">
-                  <span className="material-symbols-outlined text-5xl text-on-surface-variant/30 mb-4">
-                    search_off
-                  </span>
-                  <p className="text-sm text-on-surface-variant">
-                    {hasFilters ? "Нет карточек по фильтрам" : "Нет карточек в библиотеке"}
-                  </p>
-                </div>
+                <EmptyState
+                  icon={hasFilters ? "search_off" : "style"}
+                  title={hasFilters ? "No cards match your filters" : "Your library is empty"}
+                  description={
+                    hasFilters
+                      ? "Try resetting filters or adjusting your search."
+                      : "Cards you create will show up here."
+                  }
+                  action={
+                    hasFilters ? (
+                      <button
+                        type="button"
+                        onClick={resetFilters}
+                        className="px-4 py-2 rounded-lg bg-surface-elevated text-on-surface text-[13px] font-semibold hover:bg-surface-high transition-colors"
+                      >
+                        Reset filters
+                      </button>
+                    ) : null
+                  }
+                />
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {filtered.map((template) => (
@@ -337,72 +432,90 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
             </div>
           </main>
         </div>
-      )}
-
-      {/* ── Collections tab ── */}
-      {tab === "collections" && (
-        <main className="flex-1 p-5 md:p-8 pb-36 max-w-2xl">
+      ) : (
+        /* ─────────── Collections tab ─────────── */
+        <main className="flex-1 max-w-3xl w-full mx-auto px-4 md:px-8 py-6 pb-36">
           {/* Create */}
-          <div className="flex gap-3 mb-6">
-            <input
-              value={newCollName}
-              onChange={(e) => setNewCollName(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
-              placeholder="Название новой коллекции…"
-              className="flex-1 bg-surface-card rounded-2xl px-4 py-3 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
-            />
-            <button
-              onClick={handleCreateCollection}
-              disabled={!newCollName.trim()}
-              className="px-5 rounded-2xl kinetic-gradient text-on-primary text-sm font-bold disabled:opacity-40 min-h-[44px]"
-            >
-              Создать
-            </button>
+          <div className="rounded-2xl bg-surface-card border border-border-dim p-4 mb-6">
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-on-surface-variant mb-2">
+              New collection
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={newCollName}
+                onChange={(e) => setNewCollName(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
+                placeholder="e.g. Beginner essentials"
+                className="flex-1 bg-surface-elevated rounded-lg px-3 h-10 text-[13px] text-on-surface placeholder:text-on-surface-variant/60 border border-transparent focus:border-primary/40 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleCreateCollection}
+                disabled={!newCollName.trim()}
+                className="px-4 h-10 rounded-lg kinetic-gradient text-on-primary text-[13px] font-bold disabled:opacity-40 disabled:cursor-not-allowed hover:shadow-md transition-all"
+              >
+                Create
+              </button>
+            </div>
           </div>
 
           {collections.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-24 text-center">
-              <span className="material-symbols-outlined text-5xl text-on-surface-variant/30 mb-4">
-                bookmarks
-              </span>
-              <p className="text-sm text-on-surface-variant">
-                Создай коллекцию, чтобы группировать карточки
-              </p>
-            </div>
+            <EmptyState
+              icon="bookmarks"
+              title="No collections yet"
+              description="Group related cards into collections to apply them in bulk."
+            />
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-3">
               {collections.map((col) => (
-                <div key={col.id} className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
-                  <div className="flex items-center justify-between px-5 py-4">
-                    <div>
-                      <p className="font-bold text-sm text-on-surface">{col.name}</p>
-                      <p className="text-xs text-on-surface-variant mt-0.5">
-                        {col.card_count ?? col.template_ids.length} карточек
-                      </p>
+                <div
+                  key={col.id}
+                  className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden hover:border-border transition-colors"
+                >
+                  <div className="flex items-center justify-between px-5 py-4 gap-3">
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+                        <span className="material-symbols-outlined text-primary text-[20px]">bookmarks</span>
+                      </div>
+                      <div className="min-w-0">
+                        <p className="font-semibold text-[14px] text-on-surface truncate">{col.name}</p>
+                        <p className="text-[12px] text-on-surface-variant mt-0.5">
+                          {col.card_count ?? col.template_ids.length} cards
+                        </p>
+                      </div>
                     </div>
                     <button
+                      type="button"
                       onClick={() => startCollectionApply(col.id, col.name)}
-                      className="flex items-center gap-1.5 px-4 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
+                      disabled={col.template_ids.length === 0}
+                      className="inline-flex items-center gap-1.5 px-3 h-9 rounded-lg kinetic-gradient text-on-primary text-[12px] font-bold disabled:opacity-40 disabled:cursor-not-allowed hover:shadow-md transition-all shrink-0"
                     >
-                      <span className="material-symbols-outlined text-sm">send</span>
-                      Применить к ученику
+                      <span className="material-symbols-outlined text-[15px]">send</span>
+                      Assign
                     </button>
                   </div>
                   {col.template_ids.length > 0 && (
-                    <div className="border-t border-border-dim">
+                    <div className="border-t border-border-dim divide-y divide-border-dim">
                       {templates
                         .filter((t) => col.template_ids.includes(t.template_id ?? t.id))
                         .map((t) => (
-                          <div key={t.id} className="flex items-center gap-3 px-5 py-3 border-b border-border-dim last:border-0">
-                            <span className="material-symbols-outlined text-on-surface-variant text-sm">
+                          <div
+                            key={t.id}
+                            className="flex items-center gap-3 px-5 py-3 hover:bg-surface-elevated/40 transition-colors"
+                          >
+                            <span className="material-symbols-outlined text-on-surface-variant text-[16px]">
                               drag_indicator
                             </span>
-                            <p className="flex-1 text-sm text-on-surface truncate">{t.title}</p>
+                            <p className="flex-1 text-[13px] text-on-surface truncate">{t.title}</p>
                             <button
-                              onClick={() => handleRemoveFromCollection(col.id, t.template_id ?? t.id)}
-                              className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                              type="button"
+                              onClick={() =>
+                                handleRemoveFromCollection(col.id, t.template_id ?? t.id)
+                              }
+                              className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-error hover:bg-error/10 transition-colors"
+                              aria-label="Удалить из коллекции"
                             >
-                              <span className="material-symbols-outlined text-sm">close</span>
+                              <span className="material-symbols-outlined text-[16px]">close</span>
                             </button>
                           </div>
                         ))}
@@ -415,88 +528,242 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
         </main>
       )}
 
-      {/* Collection apply sheet */}
+      {/* ─────────── Collection apply sheet ─────────── */}
       {collApplyState && (
         <div
-          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
-          onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
+          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end md:items-center justify-center"
+          onClick={() => {
+            setCollApplyState(null);
+            setCollApplyResult(null);
+          }}
         >
           <div
-            className="bg-surface-card rounded-t-3xl w-full max-w-[430px] mx-auto p-6 pb-10 space-y-4 max-h-[80vh] overflow-y-auto"
+            className="bg-surface-card rounded-t-3xl md:rounded-3xl w-full max-w-[430px] mx-auto p-6 pb-10 md:pb-6 space-y-4 max-h-[85vh] overflow-y-auto border border-border-dim"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
-              <h3 className="text-base font-black tracking-tight">«{collApplyState.name}»</h3>
+              <div>
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-on-surface-variant">
+                  Apply collection
+                </p>
+                <h3 className="text-[16px] font-bold tracking-tight text-on-surface mt-0.5">
+                  {collApplyState.name}
+                </h3>
+              </div>
               <button
-                onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
-                className="w-11 h-11 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
+                type="button"
+                onClick={() => {
+                  setCollApplyState(null);
+                  setCollApplyResult(null);
+                }}
+                className="w-10 h-10 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant hover:text-on-surface transition-colors"
+                aria-label="Закрыть"
               >
-                <span className="material-symbols-outlined text-base">close</span>
+                <span className="material-symbols-outlined text-[18px]">close</span>
               </button>
             </div>
 
             {collApplyResult ? (
               <div className="text-center py-6 space-y-3">
-                <span className="material-symbols-outlined text-4xl text-primary">check_circle</span>
+                <span className="material-symbols-outlined text-5xl text-primary">check_circle</span>
                 <p className="font-bold text-on-surface">{collApplyResult}</p>
                 <button
-                  onClick={() => { setCollApplyState(null); setCollApplyResult(null); }}
-                  className="w-full py-3 rounded-xl kinetic-gradient text-on-primary font-bold text-sm min-h-[44px]"
+                  type="button"
+                  onClick={() => {
+                    setCollApplyState(null);
+                    setCollApplyResult(null);
+                  }}
+                  className="w-full h-11 rounded-xl kinetic-gradient text-on-primary font-bold text-[14px]"
                 >
-                  Готово
+                  Done
                 </button>
               </div>
             ) : !collApplyStudentId ? (
               <div className="space-y-2">
-                <p className="text-xs text-on-surface-variant">Выбери ученика</p>
+                <p className="text-[12px] text-on-surface-variant">Choose a student</p>
                 {students.map((s) => (
                   <button
                     key={s.id}
+                    type="button"
                     onClick={() => selectStudentForCollection(s.id)}
-                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:opacity-80"
+                    className="w-full flex items-center gap-3 rounded-xl bg-surface-elevated hover:bg-surface-high p-3.5 text-left transition-colors"
                   >
-                    <span className="material-symbols-outlined text-on-surface-variant">person</span>
-                    <span className="font-bold text-sm text-on-surface">{s.full_name ?? "—"}</span>
-                    <span className="material-symbols-outlined text-on-surface-variant ml-auto text-base">chevron_right</span>
+                    <span className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center">
+                      <span className="material-symbols-outlined text-primary text-[18px]">person</span>
+                    </span>
+                    <span className="font-semibold text-[13px] text-on-surface flex-1">
+                      {s.full_name ?? "—"}
+                    </span>
+                    <span className="material-symbols-outlined text-on-surface-variant text-[18px]">
+                      chevron_right
+                    </span>
                   </button>
                 ))}
               </div>
             ) : loadingCollSessions ? (
               <div className="py-8 flex justify-center">
-                <span className="material-symbols-outlined text-on-surface-variant animate-spin">progress_activity</span>
+                <span className="material-symbols-outlined text-on-surface-variant animate-spin">
+                  progress_activity
+                </span>
               </div>
             ) : (
               <div className="space-y-2">
                 <button
-                  onClick={() => { setCollApplyStudentId(null); setCollApplySessions([]); }}
-                  className="flex items-center gap-1 text-xs text-secondary font-bold mb-2"
+                  type="button"
+                  onClick={() => {
+                    setCollApplyStudentId(null);
+                    setCollApplySessions([]);
+                  }}
+                  className="flex items-center gap-1 text-[12px] text-secondary font-semibold mb-2"
                 >
-                  <span className="material-symbols-outlined text-sm">arrow_back</span>
-                  Другой ученик
+                  <span className="material-symbols-outlined text-[16px]">arrow_back</span>
+                  Different student
                 </button>
-                {collApplySessions.map((s) => (
-                  <button
-                    key={s.id}
-                    onClick={() => applyCollectionToSession(s.id)}
-                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px] active:opacity-80"
-                  >
-                    <span className="material-symbols-outlined text-on-surface-variant text-sm">fitness_center</span>
-                    <div className="flex-1">
-                      <p className="font-bold text-sm text-on-surface">
-                        Сессия {s.session_number}{s.trainer_notes ? ` — ${s.trainer_notes}` : ""}
-                      </p>
-                      <p className="text-xs text-on-surface-variant">
-                        {new Date(s.scheduled_at ?? s.created_at).toLocaleDateString("ru-RU", { day: "numeric", month: "short" })}
-                      </p>
-                    </div>
-                    <span className="material-symbols-outlined text-primary text-sm">add_circle</span>
-                  </button>
-                ))}
+                {collApplySessions.length === 0 ? (
+                  <p className="text-[12px] text-on-surface-variant py-6 text-center">
+                    No sessions for this student.
+                  </p>
+                ) : (
+                  collApplySessions.map((s) => (
+                    <button
+                      key={s.id}
+                      type="button"
+                      onClick={() => applyCollectionToSession(s.id)}
+                      className="w-full flex items-center gap-3 rounded-xl bg-surface-elevated hover:bg-surface-high p-3.5 text-left transition-colors"
+                    >
+                      <span className="w-9 h-9 rounded-lg bg-secondary/10 flex items-center justify-center">
+                        <span className="material-symbols-outlined text-secondary text-[18px]">
+                          fitness_center
+                        </span>
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-semibold text-[13px] text-on-surface truncate">
+                          Session {s.session_number}
+                          {s.trainer_notes ? ` — ${s.trainer_notes}` : ""}
+                        </p>
+                        <p className="text-[11px] text-on-surface-variant">
+                          {new Date(s.scheduled_at ?? s.created_at).toLocaleDateString("ru-RU", {
+                            day: "numeric",
+                            month: "short",
+                          })}
+                        </p>
+                      </div>
+                      <span className="material-symbols-outlined text-primary text-[18px]">
+                        add_circle
+                      </span>
+                    </button>
+                  ))
+                )}
               </div>
             )}
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Local UI primitives
+   ───────────────────────────────────────────────────────────── */
+
+function SidebarSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-4">
+      <p className="text-[10px] font-semibold uppercase tracking-wider text-on-surface-variant/70 px-3 mb-1.5">
+        {title}
+      </p>
+      <div className="space-y-0.5">{children}</div>
+    </div>
+  );
+}
+
+function SidebarItem({
+  active,
+  onClick,
+  label,
+  count,
+  dot,
+  capitalize,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  count?: number;
+  dot?: string;
+  capitalize?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-[13px] font-medium transition-all duration-150 ${
+        active
+          ? "bg-primary/10 text-primary"
+          : "text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated/60"
+      }`}
+    >
+      {dot && <span className={`w-2 h-2 rounded-full shrink-0 ${dot}`} />}
+      <span className={`truncate flex-1 text-left ${capitalize ? "capitalize" : ""}`}>{label}</span>
+      {typeof count === "number" && (
+        <span
+          className={`text-[11px] tabular-nums font-semibold ${
+            active ? "text-primary" : "text-on-surface-variant/70"
+          }`}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function MobileChip({
+  active,
+  onClick,
+  label,
+  dot,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  dot?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`shrink-0 inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-[12px] font-semibold whitespace-nowrap transition-colors ${
+        active
+          ? "bg-primary text-on-primary"
+          : "bg-surface-elevated/60 text-on-surface-variant border border-border-dim"
+      }`}
+    >
+      {dot && <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />}
+      <span className="capitalize">{label}</span>
+    </button>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <div className="w-14 h-14 rounded-2xl bg-surface-elevated/60 flex items-center justify-center mb-4">
+        <span className="material-symbols-outlined text-[28px] text-on-surface-variant">{icon}</span>
+      </div>
+      <p className="text-[14px] font-semibold text-on-surface">{title}</p>
+      <p className="text-[12px] text-on-surface-variant mt-1 max-w-xs">{description}</p>
+      {action && <div className="mt-5">{action}</div>}
     </div>
   );
 }

--- a/src/components/trainer/CardsLibrary.tsx
+++ b/src/components/trainer/CardsLibrary.tsx
@@ -154,9 +154,9 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
   }
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* ─────────── Top header ─────────── */}
-      <header className="sticky top-0 z-30 glass-nav border-b border-border-dim">
+      <header className="sticky top-0 z-30 bg-white border-b border-gray-100">
         <div className="max-w-screen-2xl mx-auto px-4 md:px-6">
           <div className="flex items-center gap-4 h-14">
             {/* Logo */}
@@ -175,7 +175,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
             </div>
 
             {/* Segmented tabs */}
-            <div className="hidden md:flex items-center bg-surface-elevated/60 rounded-lg p-0.5 ml-2">
+            <div className="hidden md:flex items-center bg-gray-100 rounded-lg p-0.5 ml-2">
               {(["cards", "collections"] as Tab[]).map((t) => (
                 <button
                   key={t}
@@ -183,14 +183,14 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   onClick={() => setTab(t)}
                   className={`relative px-3 py-1.5 rounded-md text-[12px] font-semibold transition-all duration-200 ${
                     tab === t
-                      ? "bg-surface-card text-on-surface shadow-sm"
-                      : "text-on-surface-variant hover:text-on-surface"
+                      ? "bg-white text-gray-900 shadow-sm"
+                      : "text-gray-500 hover:text-gray-900"
                   }`}
                 >
                   {t === "cards" ? "Cards" : "Collections"}
                   <span
                     className={`ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded-[5px] text-[10px] font-bold tabular-nums ${
-                      tab === t ? "bg-primary/15 text-primary" : "bg-surface-elevated text-on-surface-variant"
+                      tab === t ? "bg-gray-100 text-gray-600" : "bg-gray-200 text-gray-500"
                     }`}
                   >
                     {t === "cards" ? templates.length : collections.length}
@@ -202,20 +202,20 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
             {/* Search */}
             <div className="ml-auto flex items-center gap-2">
               <div className="relative hidden md:block w-64 lg:w-80">
-                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-[18px] pointer-events-none">
+                <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-[18px] pointer-events-none">
                   search
                 </span>
                 <input
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
                   placeholder="Search cards…"
-                  className="w-full bg-surface-elevated/60 rounded-lg pl-9 pr-3 h-9 text-[13px] text-on-surface placeholder:text-on-surface-variant/60 border border-transparent focus:border-primary/40 focus:bg-surface-card focus:outline-none transition-colors"
+                  className="w-full bg-gray-100 rounded-lg pl-9 pr-3 h-9 text-[13px] text-gray-800 placeholder:text-gray-400 border border-transparent focus:border-gray-300 focus:bg-white focus:outline-none transition-colors"
                 />
                 {search && (
                   <button
                     type="button"
                     onClick={() => setSearch("")}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-on-surface-variant hover:text-on-surface"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700"
                     aria-label="Очистить поиск"
                   >
                     <span className="material-symbols-outlined text-[16px]">close</span>
@@ -246,7 +246,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
       {tab === "cards" ? (
         <div className="flex flex-1 max-w-screen-2xl mx-auto w-full">
           {/* ─────────── Sidebar (desktop) ─────────── */}
-          <aside className="hidden md:flex flex-col w-[220px] shrink-0 border-r border-border-dim sticky top-14 self-start h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-3">
+          <aside className="hidden md:flex flex-col w-[220px] shrink-0 border-r border-gray-100 bg-white sticky top-14 self-start h-[calc(100vh-3.5rem)] overflow-y-auto py-6 px-3">
             <SidebarSection title="Тема">
               <SidebarItem
                 active={!tagFilter}
@@ -352,18 +352,18 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
             </div>
 
             {/* Summary bar */}
-            <div className="flex items-center justify-between px-4 md:px-8 py-4 border-b border-border-dim">
+            <div className="flex items-center justify-between px-4 md:px-8 py-4 border-b border-gray-100 bg-white">
               <div className="flex items-center gap-2">
-                <p className="text-[13px] text-on-surface">
+                <p className="text-[13px] text-gray-700">
                   <span className="font-semibold tabular-nums">{filtered.length}</span>{" "}
-                  <span className="text-on-surface-variant">
+                  <span className="text-gray-400">
                     {filtered.length === templates.length
                       ? "cards"
                       : `of ${templates.length} cards`}
                   </span>
                 </p>
                 {hasFilters && (
-                  <span className="hidden md:inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-primary/10 text-primary text-[11px] font-semibold">
+                  <span className="hidden md:inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-gray-100 text-gray-600 text-[11px] font-semibold">
                     <span className="material-symbols-outlined text-[14px]">filter_alt</span>
                     Filtered
                   </span>
@@ -405,7 +405,7 @@ export function CardsLibrary({ templates, students, collections: initialCollecti
                   }
                 />
               ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
                   {filtered.map((template) => (
                     <LibraryCardItem
                       key={template.template_id ?? template.id}
@@ -686,13 +686,13 @@ function SidebarItem({
       onClick={onClick}
       className={`w-full flex items-center justify-between px-3 py-1.5 rounded-lg text-[13px] transition-all duration-150 ${
         active
-          ? "bg-surface-card border border-border font-semibold text-on-surface"
-          : "font-medium text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated/40"
+          ? "bg-gray-900 font-semibold text-white"
+          : "font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-100"
       }`}
     >
       <span className={`truncate text-left ${capitalize ? "capitalize" : ""}`}>{label}</span>
       {typeof count === "number" && (
-        <span className={`text-[11px] tabular-nums ml-2 shrink-0 ${active ? "text-on-surface" : "text-on-surface-variant/60"}`}>
+        <span className={`text-[11px] tabular-nums ml-2 shrink-0 ${active ? "text-white/70" : "text-gray-400"}`}>
           {count}
         </span>
       )}

--- a/src/components/trainer/CardsLibrary.tsx
+++ b/src/components/trainer/CardsLibrary.tsx
@@ -1,0 +1,424 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { CardTemplate, InsightCollection, InsightTrainerStatus } from "@/lib/types";
+import { LibraryCardItem } from "./LibraryCardItem";
+import {
+  createCollection,
+  addCardToCollection,
+  removeCardFromCollection,
+  applyCollectionToStudent,
+  getStudentSessions,
+} from "@/lib/actions/insightCards";
+import { ApplyCardSheet } from "./ApplyCardSheet";
+
+type Tab = "cards" | "collections";
+
+const TAGS = ["техника", "тактика", "физика", "менталка"] as const;
+const STATUS_OPTIONS: { value: InsightTrainerStatus | "all"; label: string }[] = [
+  { value: "all", label: "Все" },
+  { value: "approved", label: "Approved" },
+  { value: "draft", label: "Draft" },
+  { value: "rejected", label: "Rejected" },
+];
+
+interface Student {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface Props {
+  templates: (CardTemplate & { student_ids: string[] })[];
+  students: Student[];
+  collections: (InsightCollection & { template_ids: string[] })[];
+}
+
+export function CardsLibrary({ templates, students, collections: initialCollections }: Props) {
+  const [tab, setTab] = useState<Tab>("cards");
+  const [search, setSearch] = useState("");
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<InsightTrainerStatus | "all">("all");
+  const [studentFilter, setStudentFilter] = useState<string | null>(null);
+  const [collections, setCollections] = useState(initialCollections);
+  const [newCollName, setNewCollName] = useState("");
+  const [applyCollectionState, setApplyCollectionState] = useState<{
+    collectionId: string;
+    collectionName: string;
+  } | null>(null);
+  const [collApplyStudentId, setCollApplyStudentId] = useState<string | null>(null);
+  const [collApplySessions, setCollApplySessions] = useState<{ id: string; session_number: number; trainer_notes: string | null; scheduled_at: string | null; created_at: string }[]>([]);
+  const [loadingCollSessions, setLoadingCollSessions] = useState(false);
+  const [collApplyResult, setCollApplyResult] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const q = search.toLowerCase();
+  const filtered = templates.filter((t) => {
+    if (q && !t.title?.toLowerCase().includes(q) && !t.body?.toLowerCase().includes(q)) return false;
+    if (tagFilter && !t.tags?.includes(tagFilter)) return false;
+    if (statusFilter !== "all" && t.trainer_status !== statusFilter) return false;
+    if (studentFilter && !t.student_ids.includes(studentFilter)) return false;
+    return true;
+  });
+
+  function handleAddToCollection(collectionId: string, templateId: string) {
+    startTransition(async () => {
+      await addCardToCollection(collectionId, templateId);
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === collectionId && !c.template_ids.includes(templateId)
+            ? { ...c, template_ids: [...c.template_ids, templateId], card_count: (c.card_count ?? 0) + 1 }
+            : c
+        )
+      );
+    });
+  }
+
+  function handleRemoveFromCollection(collectionId: string, templateId: string) {
+    startTransition(async () => {
+      await removeCardFromCollection(collectionId, templateId);
+      setCollections((prev) =>
+        prev.map((c) =>
+          c.id === collectionId
+            ? { ...c, template_ids: c.template_ids.filter((id) => id !== templateId), card_count: Math.max(0, (c.card_count ?? 1) - 1) }
+            : c
+        )
+      );
+    });
+  }
+
+  function handleCreateCollection() {
+    if (!newCollName.trim()) return;
+    startTransition(async () => {
+      const result = await createCollection(newCollName.trim());
+      if (result.success) {
+        setCollections((prev) => [
+          { id: result.id, trainer_id: "", name: newCollName.trim(), created_at: new Date().toISOString(), card_count: 0, template_ids: [] },
+          ...prev,
+        ]);
+        setNewCollName("");
+      }
+    });
+  }
+
+  async function startCollectionApply(collectionId: string, collectionName: string) {
+    setApplyCollectionState({ collectionId, collectionName });
+    setCollApplyStudentId(null);
+    setCollApplySessions([]);
+    setCollApplyResult(null);
+  }
+
+  async function selectStudentForCollection(studentId: string) {
+    setCollApplyStudentId(studentId);
+    setLoadingCollSessions(true);
+    const sess = await getStudentSessions(studentId);
+    setCollApplySessions(sess);
+    setLoadingCollSessions(false);
+  }
+
+  function applyCollectionToSession(sessionId: string) {
+    if (!applyCollectionState) return;
+    startTransition(async () => {
+      const result = await applyCollectionToStudent(applyCollectionState.collectionId, sessionId);
+      if (result.success) {
+        setCollApplyResult(`Добавлено ${result.applied} карточек`);
+      }
+    });
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-30 glass-nav flex items-center justify-between px-6 h-16">
+        <div className="w-10" />
+        <span className="text-lg font-black text-primary uppercase italic tracking-tight">
+          Библиотека карточек
+        </span>
+        <div className="w-10" />
+      </header>
+
+      {/* Tab switcher */}
+      <div className="sticky top-16 z-20 bg-background border-b border-border-dim px-5 flex gap-1 py-2">
+        <button
+          onClick={() => setTab("cards")}
+          className={`flex-1 py-2 rounded-xl text-xs font-black uppercase tracking-widest min-h-[36px] transition-colors ${
+            tab === "cards" ? "bg-primary/10 text-primary" : "text-on-surface-variant"
+          }`}
+        >
+          Карточки ({templates.length})
+        </button>
+        <button
+          onClick={() => setTab("collections")}
+          className={`flex-1 py-2 rounded-xl text-xs font-black uppercase tracking-widest min-h-[36px] transition-colors ${
+            tab === "collections" ? "bg-primary/10 text-primary" : "text-on-surface-variant"
+          }`}
+        >
+          Коллекции ({collections.length})
+        </button>
+      </div>
+
+      <main className="pb-36">
+        {/* Desktop layout wrapper */}
+        <div className="md:flex md:gap-6 md:px-8 md:pt-6">
+          {/* === CARDS TAB === */}
+          {tab === "cards" && (
+            <>
+              {/* Sidebar filters (desktop) / inline filters (mobile) */}
+              <aside className="md:w-56 md:flex-shrink-0 md:sticky md:top-32 md:self-start md:space-y-4 px-5 pt-4 md:px-0 md:pt-0 space-y-3">
+                {/* Search */}
+                <div className="relative">
+                  <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-base">
+                    search
+                  </span>
+                  <input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Поиск…"
+                    className="w-full bg-surface-card rounded-2xl pl-9 pr-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none"
+                  />
+                </div>
+
+                {/* Tag filter chips */}
+                <div className="flex gap-1.5 flex-wrap md:flex-col md:gap-1.5">
+                  <button
+                    onClick={() => setTagFilter(null)}
+                    className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
+                      !tagFilter ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
+                    }`}
+                  >
+                    Все темы
+                  </button>
+                  {TAGS.map((tag) => (
+                    <button
+                      key={tag}
+                      onClick={() => setTagFilter(tag === tagFilter ? null : tag)}
+                      className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
+                        tagFilter === tag ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
+                      }`}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Status filter */}
+                <div className="flex gap-1.5 flex-wrap md:flex-col md:gap-1.5">
+                  {STATUS_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      onClick={() => setStatusFilter(opt.value)}
+                      className={`px-3 py-1.5 rounded-full text-[11px] font-black uppercase tracking-widest min-h-[32px] ${
+                        statusFilter === opt.value ? "bg-primary text-on-primary" : "bg-surface-card text-on-surface-variant border border-border-dim"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Student filter */}
+                {students.length > 0 && (
+                  <select
+                    value={studentFilter ?? ""}
+                    onChange={(e) => setStudentFilter(e.target.value || null)}
+                    className="w-full bg-surface-card rounded-2xl px-3 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
+                  >
+                    <option value="">Все ученики</option>
+                    {students.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.full_name ?? "—"}
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {(search || tagFilter || statusFilter !== "all" || studentFilter) && (
+                  <button
+                    onClick={() => { setSearch(""); setTagFilter(null); setStatusFilter("all"); setStudentFilter(null); }}
+                    className="text-xs text-secondary font-bold flex items-center gap-1"
+                  >
+                    <span className="material-symbols-outlined text-sm">close</span>
+                    Сбросить фильтры
+                  </button>
+                )}
+              </aside>
+
+              {/* Card list */}
+              <div className="flex-1 min-w-0 px-5 pt-3 md:px-0 md:pt-0 space-y-3 md:grid md:grid-cols-2 md:gap-3 md:content-start">
+                {filtered.length === 0 ? (
+                  <p className="text-sm text-on-surface-variant col-span-2 py-12 text-center">
+                    {search || tagFilter || statusFilter !== "all" || studentFilter
+                      ? "Нет карточек по фильтрам"
+                      : "Нет карточек в библиотеке"}
+                  </p>
+                ) : (
+                  filtered.map((template) => (
+                    <LibraryCardItem
+                      key={template.template_id ?? template.id}
+                      template={template}
+                      students={students}
+                      collections={collections}
+                      onAddToCollection={handleAddToCollection}
+                      onRemoveFromCollection={handleRemoveFromCollection}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          )}
+
+          {/* === COLLECTIONS TAB === */}
+          {tab === "collections" && (
+            <div className="flex-1 px-5 pt-4 md:px-0 md:pt-0 space-y-4">
+              {/* Create new collection */}
+              <div className="flex gap-2">
+                <input
+                  value={newCollName}
+                  onChange={(e) => setNewCollName(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleCreateCollection()}
+                  placeholder="Название коллекции…"
+                  className="flex-1 bg-surface-card rounded-2xl px-4 py-2.5 text-sm text-on-surface border border-border-dim focus:border-primary focus:outline-none min-h-[44px]"
+                />
+                <button
+                  onClick={handleCreateCollection}
+                  disabled={!newCollName.trim()}
+                  className="px-4 rounded-2xl kinetic-gradient text-on-primary text-sm font-bold disabled:opacity-40 min-h-[44px]"
+                >
+                  Создать
+                </button>
+              </div>
+
+              {collections.length === 0 ? (
+                <p className="text-sm text-on-surface-variant text-center py-12">
+                  Создай коллекцию, чтобы группировать карточки
+                </p>
+              ) : (
+                collections.map((col) => (
+                  <div key={col.id} className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
+                    <div className="flex items-center justify-between px-4 py-4">
+                      <div>
+                        <p className="font-bold text-sm text-on-surface">{col.name}</p>
+                        <p className="text-xs text-on-surface-variant mt-0.5">
+                          {col.card_count ?? col.template_ids.length} карточек
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => startCollectionApply(col.id, col.name)}
+                        className="flex items-center gap-1.5 px-3 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
+                      >
+                        <span className="material-symbols-outlined text-sm">send</span>
+                        Применить
+                      </button>
+                    </div>
+                    {col.template_ids.length > 0 && (
+                      <div className="px-4 pb-4 space-y-1.5 border-t border-border-dim pt-3">
+                        {templates
+                          .filter((t) => col.template_ids.includes(t.template_id ?? t.id))
+                          .map((t) => (
+                            <div key={t.id} className="flex items-center gap-2">
+                              <p className="flex-1 text-xs text-on-surface truncate">{t.title}</p>
+                              <button
+                                onClick={() => handleRemoveFromCollection(col.id, t.template_id ?? t.id)}
+                                className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant"
+                                aria-label="Убрать из коллекции"
+                              >
+                                <span className="material-symbols-outlined text-sm">close</span>
+                              </button>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {/* Collection apply bottom sheet */}
+      {applyCollectionState && (
+        <div
+          className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-end justify-center"
+          onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+        >
+          <div
+            className="bg-surface-card rounded-t-3xl w-full max-w-[430px] mx-auto p-6 pb-10 space-y-4 max-h-[80vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-black tracking-tight">
+                Применить «{applyCollectionState.collectionName}»
+              </h3>
+              <button
+                onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+                className="w-11 h-11 flex items-center justify-center rounded-xl bg-surface-elevated text-on-surface-variant"
+              >
+                <span className="material-symbols-outlined text-base">close</span>
+              </button>
+            </div>
+
+            {collApplyResult ? (
+              <div className="text-center py-6 space-y-3">
+                <span className="material-symbols-outlined text-4xl text-primary">check_circle</span>
+                <p className="font-bold text-on-surface">{collApplyResult}</p>
+                <button
+                  onClick={() => { setApplyCollectionState(null); setCollApplyResult(null); }}
+                  className="w-full py-3 rounded-xl kinetic-gradient text-on-primary font-bold text-sm min-h-[44px]"
+                >
+                  Готово
+                </button>
+              </div>
+            ) : !collApplyStudentId ? (
+              <div className="space-y-2">
+                <p className="text-xs text-on-surface-variant">Выбери ученика</p>
+                {students.map((s) => (
+                  <button
+                    key={s.id}
+                    onClick={() => selectStudentForCollection(s.id)}
+                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px]"
+                  >
+                    <span className="material-symbols-outlined text-on-surface-variant">person</span>
+                    <span className="font-bold text-sm text-on-surface">{s.full_name ?? "—"}</span>
+                    <span className="material-symbols-outlined text-on-surface-variant ml-auto text-base">chevron_right</span>
+                  </button>
+                ))}
+              </div>
+            ) : loadingCollSessions ? (
+              <div className="py-8 flex justify-center">
+                <span className="material-symbols-outlined text-on-surface-variant animate-spin">progress_activity</span>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <button
+                  onClick={() => { setCollApplyStudentId(null); setCollApplySessions([]); }}
+                  className="flex items-center gap-1 text-xs text-secondary font-bold"
+                >
+                  <span className="material-symbols-outlined text-sm">arrow_back</span>
+                  Другой ученик
+                </button>
+                {collApplySessions.map((s) => (
+                  <button
+                    key={s.id}
+                    onClick={() => applyCollectionToSession(s.id)}
+                    className="w-full flex items-center gap-3 rounded-2xl bg-surface-elevated p-4 text-left min-h-[56px]"
+                  >
+                    <span className="material-symbols-outlined text-on-surface-variant text-sm">fitness_center</span>
+                    <div className="flex-1">
+                      <p className="font-bold text-sm text-on-surface">
+                        Сессия {s.session_number}{s.trainer_notes ? ` — ${s.trainer_notes}` : ""}
+                      </p>
+                      <p className="text-xs text-on-surface-variant">
+                        {new Date(s.scheduled_at ?? s.created_at).toLocaleDateString("ru-RU", { day: "numeric", month: "short" })}
+                      </p>
+                    </div>
+                    <span className="material-symbols-outlined text-primary text-sm">add_circle</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -7,21 +7,21 @@ import { ApplyCardSheet } from "./ApplyCardSheet";
 import type { InsightCard } from "@/lib/types";
 
 const TAG_COLORS: Record<string, string> = {
-  техника: "text-blue-400 bg-blue-500/10",
-  тактика: "text-amber-400 bg-amber-500/10",
-  физика: "text-green-400 bg-green-500/10",
-  менталка: "text-purple-400 bg-purple-500/10",
+  техника: "text-blue-400 bg-blue-500/10 border-blue-500/20",
+  тактика: "text-amber-400 bg-amber-500/10 border-amber-500/20",
+  физика: "text-emerald-400 bg-emerald-500/10 border-emerald-500/20",
+  менталка: "text-purple-400 bg-purple-500/10 border-purple-500/20",
 };
 
+const STATUS_COLORS: Record<string, string> = {
+  approved: "text-primary bg-primary/10 border-primary/20",
+  draft: "text-amber-400 bg-amber-500/10 border-amber-500/20",
+  rejected: "text-red-400 bg-red-500/10 border-red-500/20",
+};
 const STATUS_LABELS: Record<string, string> = {
   approved: "Approved",
   draft: "Draft",
   rejected: "Rejected",
-};
-const STATUS_COLORS: Record<string, string> = {
-  approved: "text-green-400 bg-green-500/10",
-  draft: "text-amber-400 bg-amber-500/10",
-  rejected: "text-red-400 bg-red-500/10",
 };
 
 interface Student {
@@ -45,14 +45,15 @@ export function LibraryCardItem({
   onAddToCollection,
   onRemoveFromCollection,
 }: Props) {
-  const [expanded, setExpanded] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [applyOpen, setApplyOpen] = useState(false);
   const [collectionsOpen, setCollectionsOpen] = useState(false);
 
   const mainTag = template.tags?.[0];
   const sideTag = template.tags?.[1];
-  const tagColor = mainTag ? TAG_COLORS[mainTag] ?? "text-on-surface-variant bg-surface-elevated" : "";
+  const tagColor = mainTag
+    ? TAG_COLORS[mainTag] ?? "text-on-surface-variant bg-surface-elevated border-border-dim"
+    : "";
 
   const pseudoCard: InsightCard = {
     id: template.id,
@@ -77,125 +78,141 @@ export function LibraryCardItem({
     template_id: template.template_id,
   };
 
+  const tid = template.template_id ?? template.id;
+
   return (
     <>
-      <div className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
-        {/* Header row */}
-        <button
-          className="w-full flex items-start gap-3 p-4 text-left"
-          onClick={() => setExpanded((v) => !v)}
-        >
-          <div className="flex-1 min-w-0 space-y-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              {mainTag && (
-                <span className={`text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 ${tagColor}`}>
-                  {mainTag}
-                </span>
-              )}
-              {sideTag && (
-                <span className="text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 text-on-surface-variant bg-surface-elevated">
-                  {sideTag}
-                </span>
-              )}
-              <span className={`text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 ${STATUS_COLORS[template.trainer_status]}`}>
-                {STATUS_LABELS[template.trainer_status]}
+      <div className="group flex flex-col rounded-2xl bg-surface-card border border-border-dim hover:border-border transition-all duration-150 hover:shadow-[0_4px_24px_rgba(0,0,0,0.4)] overflow-hidden">
+        {/* Card body */}
+        <div className="flex-1 p-5 space-y-3">
+          {/* Tags row */}
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {mainTag && (
+              <span className={`text-[10px] font-black uppercase tracking-widest border rounded-full px-2 py-0.5 ${tagColor}`}>
+                {mainTag}
               </span>
-            </div>
-            <p className="text-sm font-bold text-on-surface line-clamp-2">
-              {template.title ?? template.body ?? "—"}
-            </p>
-            {/* Stats */}
-            <p className="text-[11px] text-on-surface-variant">
-              <span className="mr-2">👤 {template.student_count}</span>
-              <span className="mr-2">✅ {template.taken_count}</span>
-              {template.skipped_count > 0 && <span className="mr-2">⏭ {template.skipped_count}</span>}
-              {template.pending_count > 0 && <span>⏳ {template.pending_count}</span>}
-            </p>
+            )}
+            {sideTag && (
+              <span className="text-[10px] font-black uppercase tracking-widest border border-border-dim rounded-full px-2 py-0.5 text-on-surface-variant bg-surface-elevated">
+                {sideTag}
+              </span>
+            )}
+            <span className={`ml-auto text-[10px] font-black uppercase tracking-widest border rounded-full px-2 py-0.5 ${STATUS_COLORS[template.trainer_status]}`}>
+              {STATUS_LABELS[template.trainer_status]}
+            </span>
           </div>
-          <span className="material-symbols-outlined text-on-surface-variant text-base mt-0.5 flex-shrink-0">
-            {expanded ? "expand_less" : "expand_more"}
-          </span>
-        </button>
 
-        {/* Expanded content */}
-        {expanded && (
-          <div className="px-4 pb-4 space-y-3 border-t border-border-dim">
-            {template.body && (
-              <p className="text-sm text-on-surface pt-3">{template.body}</p>
-            )}
-            {template.quote && (
-              <p className="text-xs text-on-surface-variant italic border-l-2 border-primary/40 pl-3">
-                «{template.quote}»
-              </p>
-            )}
+          {/* Title */}
+          <p className="text-sm font-bold text-on-surface leading-snug">
+            {template.title ?? "—"}
+          </p>
 
-            {/* Action buttons */}
-            <div className="flex gap-2 pt-1 flex-wrap">
-              <button
-                onClick={() => setEditOpen(true)}
-                className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-on-surface text-xs font-bold min-h-[44px] border border-border-dim"
-              >
-                <span className="material-symbols-outlined text-sm">edit</span>
-                Редактировать
-              </button>
-              <button
-                onClick={() => setApplyOpen(true)}
-                className="flex items-center gap-1.5 px-3 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
-              >
-                <span className="material-symbols-outlined text-sm">person_add</span>
-                Применить
-              </button>
-              {collections.length > 0 && (
+          {/* Body preview */}
+          {template.body && (
+            <p className="text-xs text-on-surface-variant leading-relaxed line-clamp-3">
+              {template.body}
+            </p>
+          )}
+
+          {/* Quote */}
+          {template.quote && (
+            <p className="text-[11px] text-on-surface-variant italic border-l-2 border-primary/30 pl-3 line-clamp-2">
+              «{template.quote}»
+            </p>
+          )}
+        </div>
+
+        {/* Stats + actions footer */}
+        <div className="border-t border-border-dim px-5 py-3 flex items-center gap-4">
+          {/* Stats */}
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <span className="flex items-center gap-1 text-[11px] text-on-surface-variant">
+              <span className="material-symbols-outlined text-[14px]">group</span>
+              {template.student_count}
+            </span>
+            {template.taken_count > 0 && (
+              <span className="flex items-center gap-1 text-[11px] text-primary">
+                <span className="material-symbols-outlined text-[14px]">check_circle</span>
+                {template.taken_count}
+              </span>
+            )}
+            {template.skipped_count > 0 && (
+              <span className="flex items-center gap-1 text-[11px] text-on-surface-variant">
+                <span className="material-symbols-outlined text-[14px]">skip_next</span>
+                {template.skipped_count}
+              </span>
+            )}
+            {template.pending_count > 0 && (
+              <span className="flex items-center gap-1 text-[11px] text-amber-400">
+                <span className="material-symbols-outlined text-[14px]">schedule</span>
+                {template.pending_count}
+              </span>
+            )}
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-1">
+            {collections.length > 0 && (
+              <div className="relative">
                 <button
                   onClick={() => setCollectionsOpen((v) => !v)}
-                  className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-on-surface-variant text-xs font-bold min-h-[44px] border border-border-dim"
+                  className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated transition-colors"
+                  aria-label="Добавить в коллекцию"
                 >
-                  <span className="material-symbols-outlined text-sm">bookmark</span>
-                  В коллекцию
+                  <span className="material-symbols-outlined text-[16px]">bookmark_border</span>
                 </button>
-              )}
-            </div>
-
-            {/* Collections picker */}
-            {collectionsOpen && (
-              <div className="space-y-1.5 pt-1">
-                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
-                  Коллекции
-                </p>
-                {collections.map((col) => {
-                  const inCollection = col.template_ids.includes(template.template_id ?? template.id);
-                  return (
-                    <button
-                      key={col.id}
-                      onClick={() =>
-                        inCollection
-                          ? onRemoveFromCollection(col.id, template.template_id ?? template.id)
-                          : onAddToCollection(col.id, template.template_id ?? template.id)
-                      }
-                      className="w-full flex items-center gap-2 rounded-xl bg-surface-elevated px-3 py-2.5 text-sm min-h-[44px]"
-                    >
-                      <span className={`material-symbols-outlined text-base ${inCollection ? "text-primary" : "text-on-surface-variant"}`}>
-                        {inCollection ? "bookmark" : "bookmark_border"}
-                      </span>
-                      <span className="font-medium text-on-surface">{col.name}</span>
-                      {inCollection && (
-                        <span className="ml-auto text-[10px] text-primary font-black uppercase">Добавлено</span>
-                      )}
-                    </button>
-                  );
-                })}
+                {collectionsOpen && (
+                  <div className="absolute bottom-10 right-0 z-20 w-56 rounded-2xl bg-surface-elevated border border-border shadow-2xl p-2 space-y-1">
+                    <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-2 py-1">
+                      Коллекции
+                    </p>
+                    {collections.map((col) => {
+                      const inCollection = col.template_ids.includes(tid);
+                      return (
+                        <button
+                          key={col.id}
+                          onClick={() => {
+                            inCollection
+                              ? onRemoveFromCollection(col.id, tid)
+                              : onAddToCollection(col.id, tid);
+                            setCollectionsOpen(false);
+                          }}
+                          className="w-full flex items-center gap-2 px-2 py-2 rounded-xl hover:bg-surface-card text-left min-h-[36px]"
+                        >
+                          <span className={`material-symbols-outlined text-[16px] ${inCollection ? "text-primary fill-icon" : "text-on-surface-variant"}`}>
+                            bookmark
+                          </span>
+                          <span className="text-sm text-on-surface truncate">{col.name}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             )}
+            <button
+              onClick={() => setEditOpen(true)}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated transition-colors"
+              aria-label="Редактировать"
+            >
+              <span className="material-symbols-outlined text-[16px]">edit</span>
+            </button>
+            <button
+              onClick={() => setApplyOpen(true)}
+              className="flex items-center gap-1.5 px-3 h-8 rounded-lg kinetic-gradient text-on-primary text-[11px] font-black uppercase tracking-wide"
+              aria-label="Применить к студенту"
+            >
+              <span className="material-symbols-outlined text-[14px]">add</span>
+              Дать
+            </button>
           </div>
-        )}
+        </div>
       </div>
 
-      {editOpen && (
-        <EditAiCardModal card={pseudoCard} onClose={() => setEditOpen(false)} />
-      )}
+      {editOpen && <EditAiCardModal card={pseudoCard} onClose={() => setEditOpen(false)} />}
       {applyOpen && (
         <ApplyCardSheet
-          templateId={template.template_id ?? template.id}
+          templateId={tid}
           templateTitle={template.title}
           students={students}
           onClose={() => setApplyOpen(false)}

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -1,27 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import type { CardTemplate, InsightCollection } from "@/lib/types";
+import { useEffect, useRef, useState } from "react";
+import type { CardTemplate, InsightCollection, InsightCard } from "@/lib/types";
 import { EditAiCardModal } from "@/components/insights/EditAiCardModal";
 import { ApplyCardSheet } from "./ApplyCardSheet";
-import type { InsightCard } from "@/lib/types";
 
-const TAG_COLORS: Record<string, string> = {
-  техника: "text-blue-600 bg-blue-50 border-blue-200",
-  тактика: "text-amber-600 bg-amber-50 border-amber-200",
-  физика: "text-emerald-600 bg-emerald-50 border-emerald-200",
-  менталка: "text-purple-600 bg-purple-50 border-purple-200",
+// Tag color palette — soft, distinguishable, accessible on white
+const TAG_COLORS: Record<string, { dot: string; bg: string; text: string; border: string }> = {
+  техника: { dot: "bg-blue-500", bg: "bg-blue-50", text: "text-blue-700", border: "border-blue-100" },
+  тактика: { dot: "bg-amber-500", bg: "bg-amber-50", text: "text-amber-700", border: "border-amber-100" },
+  физика: { dot: "bg-emerald-500", bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-100" },
+  менталка: { dot: "bg-purple-500", bg: "bg-purple-50", text: "text-purple-700", border: "border-purple-100" },
 };
 
-const STATUS_COLORS: Record<string, string> = {
-  approved: "text-emerald-700 bg-emerald-50 border-emerald-200",
-  draft: "text-amber-600 bg-amber-50 border-amber-200",
-  rejected: "text-red-600 bg-red-50 border-red-200",
-};
-const STATUS_LABELS: Record<string, string> = {
-  approved: "Approved",
-  draft: "Draft",
-  rejected: "Rejected",
+const STATUS_META: Record<string, { dot: string; text: string; bg: string; label: string }> = {
+  approved: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50", label: "Approved" },
+  draft: { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50", label: "Draft" },
+  rejected: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50", label: "Rejected" },
 };
 
 interface Student {
@@ -48,12 +43,27 @@ export function LibraryCardItem({
   const [editOpen, setEditOpen] = useState(false);
   const [applyOpen, setApplyOpen] = useState(false);
   const [collectionsOpen, setCollectionsOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Close popover on outside click
+  useEffect(() => {
+    if (!collectionsOpen) return;
+    function onDown(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setCollectionsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [collectionsOpen]);
 
   const mainTag = template.tags?.[0];
   const sideTag = template.tags?.[1];
-  const tagColor = mainTag
-    ? TAG_COLORS[mainTag] ?? "text-on-surface-variant bg-surface-elevated border-border-dim"
-    : "";
+  const tagStyle = mainTag ? TAG_COLORS[mainTag] : undefined;
+  const statusStyle = STATUS_META[template.trainer_status];
+
+  const tid = template.template_id ?? template.id;
+  const inAnyCollection = collections.some((c) => c.template_ids.includes(tid));
 
   const pseudoCard: InsightCard = {
     id: template.id,
@@ -78,119 +88,142 @@ export function LibraryCardItem({
     template_id: template.template_id,
   };
 
-  const tid = template.template_id ?? template.id;
-
   return (
     <>
-      <div className="group flex flex-col rounded-2xl bg-white border border-gray-200/80 hover:border-gray-300 transition-all duration-150 hover:shadow-[0_8px_32px_rgba(0,0,0,0.45)] overflow-hidden">
-        {/* Card body */}
+      <article
+        className="group relative flex flex-col rounded-2xl bg-white border border-gray-200 shadow-sm hover:shadow-xl hover:-translate-y-0.5 hover:border-gray-300 transition-all duration-200 overflow-hidden"
+      >
+        {/* ── Card body ── */}
         <div className="flex-1 p-5 space-y-3">
-          {/* Tags row */}
-          <div className="flex items-center gap-1.5 flex-wrap">
-            {mainTag && (
-              <span className={`text-[10px] font-black uppercase tracking-widest border rounded-full px-2 py-0.5 ${tagColor}`}>
-                {mainTag}
+          {/* Top row: tag + status */}
+          <div className="flex items-center gap-2">
+            {mainTag && tagStyle && (
+              <span
+                className={`inline-flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2.5 py-1 ${tagStyle.bg} ${tagStyle.text} border ${tagStyle.border}`}
+              >
+                <span className={`w-1.5 h-1.5 rounded-full ${tagStyle.dot}`} />
+                <span className="capitalize">{mainTag}</span>
               </span>
             )}
             {sideTag && (
-              <span className="text-[10px] font-black uppercase tracking-widest border border-gray-200 rounded-full px-2 py-0.5 text-gray-500 bg-gray-50">
+              <span className="inline-flex items-center text-[11px] font-medium text-gray-500 rounded-full px-2 py-1 bg-gray-50 border border-gray-100 capitalize">
                 {sideTag}
               </span>
             )}
-            <span className={`ml-auto text-[10px] font-black uppercase tracking-widest border rounded-full px-2 py-0.5 ${STATUS_COLORS[template.trainer_status]}`}>
-              {STATUS_LABELS[template.trainer_status]}
-            </span>
+            {statusStyle && (
+              <span
+                className={`ml-auto inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider rounded-full px-2 py-0.5 ${statusStyle.bg} ${statusStyle.text}`}
+              >
+                <span className={`w-1.5 h-1.5 rounded-full ${statusStyle.dot}`} />
+                {statusStyle.label}
+              </span>
+            )}
           </div>
 
           {/* Title */}
-          <p className="text-sm font-bold text-gray-900 leading-snug">
+          <h3 className="text-[15px] font-bold text-gray-900 leading-snug line-clamp-2">
             {template.title ?? "—"}
-          </p>
+          </h3>
 
-          {/* Body preview */}
+          {/* Body */}
           {template.body && (
-            <p className="text-xs text-gray-500 leading-relaxed line-clamp-3">
+            <p className="text-[13px] text-gray-500 leading-relaxed line-clamp-3">
               {template.body}
             </p>
           )}
 
           {/* Quote */}
           {template.quote && (
-            <p className="text-[11px] text-gray-400 italic border-l-2 border-gray-200 pl-3 line-clamp-2">
+            <blockquote className="text-[12px] text-gray-600 italic border-l-2 border-gray-200 pl-3 line-clamp-2 leading-relaxed">
               «{template.quote}»
-            </p>
+            </blockquote>
           )}
         </div>
 
-        {/* Stats + actions footer */}
-        <div className="border-t border-gray-100 bg-gray-50 px-5 py-3 flex items-center gap-4">
+        {/* ── Footer ── */}
+        <div className="border-t border-gray-100 bg-gray-50 px-4 py-2.5 flex items-center gap-3">
           {/* Stats */}
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            <span className="flex items-center gap-1 text-[11px] text-gray-400">
-              <span className="material-symbols-outlined text-[14px]">group</span>
-              {template.student_count}
+          <div className="flex items-center gap-3 flex-1 min-w-0 text-[12px] text-gray-500">
+            <span className="inline-flex items-center gap-1" title="Учеников">
+              <span className="material-symbols-outlined text-[15px] text-gray-400">group</span>
+              <span className="font-medium tabular-nums">{template.student_count}</span>
             </span>
             {template.taken_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-emerald-600">
-                <span className="material-symbols-outlined text-[14px]">check_circle</span>
-                {template.taken_count}
+              <span className="inline-flex items-center gap-1 text-emerald-600" title="Принято">
+                <span className="material-symbols-outlined text-[15px]">check</span>
+                <span className="font-medium tabular-nums">{template.taken_count}</span>
               </span>
             )}
             {template.skipped_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-gray-400">
-                <span className="material-symbols-outlined text-[14px]">skip_next</span>
-                {template.skipped_count}
+              <span className="inline-flex items-center gap-1" title="Пропущено">
+                <span className="material-symbols-outlined text-[15px] text-gray-400">arrow_forward</span>
+                <span className="font-medium tabular-nums">{template.skipped_count}</span>
               </span>
             )}
             {template.pending_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-amber-500">
-                <span className="material-symbols-outlined text-[14px]">schedule</span>
-                {template.pending_count}
+              <span className="inline-flex items-center gap-1 text-amber-600" title="Ожидает">
+                <span className="material-symbols-outlined text-[15px]">schedule</span>
+                <span className="font-medium tabular-nums">{template.pending_count}</span>
               </span>
             )}
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-0.5">
             {collections.length > 0 && (
-              <div className="relative">
+              <div className="relative" ref={popoverRef}>
                 <button
+                  type="button"
                   onClick={() => setCollectionsOpen((v) => !v)}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                  className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors ${
+                    inAnyCollection
+                      ? "text-gray-700 bg-gray-100 hover:bg-gray-200"
+                      : "text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+                  }`}
                   aria-label="Добавить в коллекцию"
+                  aria-expanded={collectionsOpen}
                 >
-                  <span className="material-symbols-outlined text-[16px]">bookmark_border</span>
+                  <span className={`material-symbols-outlined text-[17px] ${inAnyCollection ? "fill-icon" : ""}`}>
+                    bookmark
+                  </span>
                 </button>
                 {collectionsOpen && (
-                  <div className="absolute bottom-10 right-0 z-20 w-56 rounded-2xl bg-white border border-gray-200 shadow-2xl p-2 space-y-1">
-                    <p className="text-[10px] font-black uppercase tracking-widest text-gray-400 px-2 py-1">
+                  <div className="absolute bottom-10 right-0 z-30 w-60 rounded-xl bg-white border border-gray-200 shadow-2xl p-1.5">
+                    <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 px-2.5 py-1.5">
                       Коллекции
                     </p>
-                    {collections.map((col) => {
-                      const inCollection = col.template_ids.includes(tid);
-                      return (
-                        <button
-                          key={col.id}
-                          onClick={() => {
-                            inCollection
-                              ? onRemoveFromCollection(col.id, tid)
-                              : onAddToCollection(col.id, tid);
-                            setCollectionsOpen(false);
-                          }}
-                          className="w-full flex items-center gap-2 px-2 py-2 rounded-xl hover:bg-gray-50 text-left min-h-[36px]"
-                        >
-                          <span className={`material-symbols-outlined text-[16px] ${inCollection ? "text-primary fill-icon" : "text-gray-400"}`}>
-                            bookmark
-                          </span>
-                          <span className="text-sm text-gray-800 truncate">{col.name}</span>
-                        </button>
-                      );
-                    })}
+                    <div className="max-h-64 overflow-y-auto">
+                      {collections.map((col) => {
+                        const inCollection = col.template_ids.includes(tid);
+                        return (
+                          <button
+                            key={col.id}
+                            type="button"
+                            onClick={() => {
+                              if (inCollection) onRemoveFromCollection(col.id, tid);
+                              else onAddToCollection(col.id, tid);
+                              setCollectionsOpen(false);
+                            }}
+                            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-lg hover:bg-gray-50 text-left transition-colors"
+                          >
+                            <span
+                              className={`material-symbols-outlined text-[16px] ${
+                                inCollection ? "text-gray-900 fill-icon" : "text-gray-300"
+                              }`}
+                            >
+                              {inCollection ? "check_circle" : "radio_button_unchecked"}
+                            </span>
+                            <span className="text-[13px] text-gray-800 truncate flex-1">{col.name}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
               </div>
             )}
             <button
+              type="button"
               onClick={() => setEditOpen(true)}
               className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
               aria-label="Редактировать"
@@ -198,16 +231,17 @@ export function LibraryCardItem({
               <span className="material-symbols-outlined text-[16px]">edit</span>
             </button>
             <button
+              type="button"
               onClick={() => setApplyOpen(true)}
-              className="flex items-center gap-1.5 px-3 h-8 rounded-lg kinetic-gradient text-on-primary text-[11px] font-black uppercase tracking-wide"
-              aria-label="Применить к студенту"
+              className="ml-1 inline-flex items-center gap-1 h-8 px-3 rounded-lg kinetic-gradient text-on-primary text-[12px] font-bold hover:shadow-md transition-all duration-200"
+              aria-label="Применить к ученику"
             >
-              <span className="material-symbols-outlined text-[14px]">add</span>
-              Дать
+              Assign
+              <span className="material-symbols-outlined text-[15px]">arrow_forward</span>
             </button>
           </div>
         </div>
-      </div>
+      </article>
 
       {editOpen && <EditAiCardModal card={pseudoCard} onClose={() => setEditOpen(false)} />}
       {applyOpen && (

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -7,16 +7,16 @@ import { ApplyCardSheet } from "./ApplyCardSheet";
 import type { InsightCard } from "@/lib/types";
 
 const TAG_COLORS: Record<string, string> = {
-  техника: "text-blue-400 bg-blue-500/10 border-blue-500/20",
-  тактика: "text-amber-400 bg-amber-500/10 border-amber-500/20",
-  физика: "text-emerald-400 bg-emerald-500/10 border-emerald-500/20",
-  менталка: "text-purple-400 bg-purple-500/10 border-purple-500/20",
+  техника: "text-blue-600 bg-blue-50 border-blue-200",
+  тактика: "text-amber-600 bg-amber-50 border-amber-200",
+  физика: "text-emerald-600 bg-emerald-50 border-emerald-200",
+  менталка: "text-purple-600 bg-purple-50 border-purple-200",
 };
 
 const STATUS_COLORS: Record<string, string> = {
-  approved: "text-primary bg-primary/10 border-primary/20",
-  draft: "text-amber-400 bg-amber-500/10 border-amber-500/20",
-  rejected: "text-red-400 bg-red-500/10 border-red-500/20",
+  approved: "text-emerald-700 bg-emerald-50 border-emerald-200",
+  draft: "text-amber-600 bg-amber-50 border-amber-200",
+  rejected: "text-red-600 bg-red-50 border-red-200",
 };
 const STATUS_LABELS: Record<string, string> = {
   approved: "Approved",
@@ -82,7 +82,7 @@ export function LibraryCardItem({
 
   return (
     <>
-      <div className="group flex flex-col rounded-2xl bg-surface-card border border-border-dim hover:border-border transition-all duration-150 hover:shadow-[0_4px_24px_rgba(0,0,0,0.4)] overflow-hidden">
+      <div className="group flex flex-col rounded-2xl bg-white border border-gray-200/80 hover:border-gray-300 transition-all duration-150 hover:shadow-[0_8px_32px_rgba(0,0,0,0.45)] overflow-hidden">
         {/* Card body */}
         <div className="flex-1 p-5 space-y-3">
           {/* Tags row */}
@@ -93,7 +93,7 @@ export function LibraryCardItem({
               </span>
             )}
             {sideTag && (
-              <span className="text-[10px] font-black uppercase tracking-widest border border-border-dim rounded-full px-2 py-0.5 text-on-surface-variant bg-surface-elevated">
+              <span className="text-[10px] font-black uppercase tracking-widest border border-gray-200 rounded-full px-2 py-0.5 text-gray-500 bg-gray-50">
                 {sideTag}
               </span>
             )}
@@ -103,47 +103,47 @@ export function LibraryCardItem({
           </div>
 
           {/* Title */}
-          <p className="text-sm font-bold text-on-surface leading-snug">
+          <p className="text-sm font-bold text-gray-900 leading-snug">
             {template.title ?? "—"}
           </p>
 
           {/* Body preview */}
           {template.body && (
-            <p className="text-xs text-on-surface-variant leading-relaxed line-clamp-3">
+            <p className="text-xs text-gray-500 leading-relaxed line-clamp-3">
               {template.body}
             </p>
           )}
 
           {/* Quote */}
           {template.quote && (
-            <p className="text-[11px] text-on-surface-variant italic border-l-2 border-primary/30 pl-3 line-clamp-2">
+            <p className="text-[11px] text-gray-400 italic border-l-2 border-gray-200 pl-3 line-clamp-2">
               «{template.quote}»
             </p>
           )}
         </div>
 
         {/* Stats + actions footer */}
-        <div className="border-t border-border-dim px-5 py-3 flex items-center gap-4">
+        <div className="border-t border-gray-100 bg-gray-50 px-5 py-3 flex items-center gap-4">
           {/* Stats */}
           <div className="flex items-center gap-3 flex-1 min-w-0">
-            <span className="flex items-center gap-1 text-[11px] text-on-surface-variant">
+            <span className="flex items-center gap-1 text-[11px] text-gray-400">
               <span className="material-symbols-outlined text-[14px]">group</span>
               {template.student_count}
             </span>
             {template.taken_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-primary">
+              <span className="flex items-center gap-1 text-[11px] text-emerald-600">
                 <span className="material-symbols-outlined text-[14px]">check_circle</span>
                 {template.taken_count}
               </span>
             )}
             {template.skipped_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-on-surface-variant">
+              <span className="flex items-center gap-1 text-[11px] text-gray-400">
                 <span className="material-symbols-outlined text-[14px]">skip_next</span>
                 {template.skipped_count}
               </span>
             )}
             {template.pending_count > 0 && (
-              <span className="flex items-center gap-1 text-[11px] text-amber-400">
+              <span className="flex items-center gap-1 text-[11px] text-amber-500">
                 <span className="material-symbols-outlined text-[14px]">schedule</span>
                 {template.pending_count}
               </span>
@@ -156,14 +156,14 @@ export function LibraryCardItem({
               <div className="relative">
                 <button
                   onClick={() => setCollectionsOpen((v) => !v)}
-                  className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated transition-colors"
+                  className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
                   aria-label="Добавить в коллекцию"
                 >
                   <span className="material-symbols-outlined text-[16px]">bookmark_border</span>
                 </button>
                 {collectionsOpen && (
-                  <div className="absolute bottom-10 right-0 z-20 w-56 rounded-2xl bg-surface-elevated border border-border shadow-2xl p-2 space-y-1">
-                    <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant px-2 py-1">
+                  <div className="absolute bottom-10 right-0 z-20 w-56 rounded-2xl bg-white border border-gray-200 shadow-2xl p-2 space-y-1">
+                    <p className="text-[10px] font-black uppercase tracking-widest text-gray-400 px-2 py-1">
                       Коллекции
                     </p>
                     {collections.map((col) => {
@@ -177,12 +177,12 @@ export function LibraryCardItem({
                               : onAddToCollection(col.id, tid);
                             setCollectionsOpen(false);
                           }}
-                          className="w-full flex items-center gap-2 px-2 py-2 rounded-xl hover:bg-surface-card text-left min-h-[36px]"
+                          className="w-full flex items-center gap-2 px-2 py-2 rounded-xl hover:bg-gray-50 text-left min-h-[36px]"
                         >
-                          <span className={`material-symbols-outlined text-[16px] ${inCollection ? "text-primary fill-icon" : "text-on-surface-variant"}`}>
+                          <span className={`material-symbols-outlined text-[16px] ${inCollection ? "text-primary fill-icon" : "text-gray-400"}`}>
                             bookmark
                           </span>
-                          <span className="text-sm text-on-surface truncate">{col.name}</span>
+                          <span className="text-sm text-gray-800 truncate">{col.name}</span>
                         </button>
                       );
                     })}
@@ -192,7 +192,7 @@ export function LibraryCardItem({
             )}
             <button
               onClick={() => setEditOpen(true)}
-              className="w-8 h-8 flex items-center justify-center rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-elevated transition-colors"
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
               aria-label="Редактировать"
             >
               <span className="material-symbols-outlined text-[16px]">edit</span>

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import type { CardTemplate, InsightCollection } from "@/lib/types";
+import { EditAiCardModal } from "@/components/insights/EditAiCardModal";
+import { ApplyCardSheet } from "./ApplyCardSheet";
+import type { InsightCard } from "@/lib/types";
+
+const TAG_COLORS: Record<string, string> = {
+  техника: "text-blue-400 bg-blue-500/10",
+  тактика: "text-amber-400 bg-amber-500/10",
+  физика: "text-green-400 bg-green-500/10",
+  менталка: "text-purple-400 bg-purple-500/10",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  approved: "Approved",
+  draft: "Draft",
+  rejected: "Rejected",
+};
+const STATUS_COLORS: Record<string, string> = {
+  approved: "text-green-400 bg-green-500/10",
+  draft: "text-amber-400 bg-amber-500/10",
+  rejected: "text-red-400 bg-red-500/10",
+};
+
+interface Student {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+interface Props {
+  template: CardTemplate & { student_ids: string[] };
+  students: Student[];
+  collections: (InsightCollection & { template_ids: string[] })[];
+  onAddToCollection: (collectionId: string, templateId: string) => void;
+  onRemoveFromCollection: (collectionId: string, templateId: string) => void;
+}
+
+export function LibraryCardItem({
+  template,
+  students,
+  collections,
+  onAddToCollection,
+  onRemoveFromCollection,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [applyOpen, setApplyOpen] = useState(false);
+  const [collectionsOpen, setCollectionsOpen] = useState(false);
+
+  const mainTag = template.tags?.[0];
+  const sideTag = template.tags?.[1];
+  const tagColor = mainTag ? TAG_COLORS[mainTag] ?? "text-on-surface-variant bg-surface-elevated" : "";
+
+  const pseudoCard: InsightCard = {
+    id: template.id,
+    session_id: "",
+    student_id: "",
+    trainer_id: "",
+    problem_id: null,
+    category_id: null,
+    front_text: template.title ?? "",
+    context_text: template.body,
+    title: template.title,
+    body: template.body,
+    quote: template.quote,
+    tags: template.tags,
+    source: "ai-paste",
+    trainer_status: template.trainer_status,
+    student_decision: null,
+    student_edited_text: null,
+    position: 0,
+    created_at: template.created_at,
+    decided_at: null,
+    template_id: template.template_id,
+  };
+
+  return (
+    <>
+      <div className="rounded-2xl bg-surface-card border border-border-dim overflow-hidden">
+        {/* Header row */}
+        <button
+          className="w-full flex items-start gap-3 p-4 text-left"
+          onClick={() => setExpanded((v) => !v)}
+        >
+          <div className="flex-1 min-w-0 space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              {mainTag && (
+                <span className={`text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 ${tagColor}`}>
+                  {mainTag}
+                </span>
+              )}
+              {sideTag && (
+                <span className="text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 text-on-surface-variant bg-surface-elevated">
+                  {sideTag}
+                </span>
+              )}
+              <span className={`text-[10px] font-black uppercase tracking-widest rounded-full px-2 py-0.5 ${STATUS_COLORS[template.trainer_status]}`}>
+                {STATUS_LABELS[template.trainer_status]}
+              </span>
+            </div>
+            <p className="text-sm font-bold text-on-surface line-clamp-2">
+              {template.title ?? template.body ?? "—"}
+            </p>
+            {/* Stats */}
+            <p className="text-[11px] text-on-surface-variant">
+              <span className="mr-2">👤 {template.student_count}</span>
+              <span className="mr-2">✅ {template.taken_count}</span>
+              {template.skipped_count > 0 && <span className="mr-2">⏭ {template.skipped_count}</span>}
+              {template.pending_count > 0 && <span>⏳ {template.pending_count}</span>}
+            </p>
+          </div>
+          <span className="material-symbols-outlined text-on-surface-variant text-base mt-0.5 flex-shrink-0">
+            {expanded ? "expand_less" : "expand_more"}
+          </span>
+        </button>
+
+        {/* Expanded content */}
+        {expanded && (
+          <div className="px-4 pb-4 space-y-3 border-t border-border-dim">
+            {template.body && (
+              <p className="text-sm text-on-surface pt-3">{template.body}</p>
+            )}
+            {template.quote && (
+              <p className="text-xs text-on-surface-variant italic border-l-2 border-primary/40 pl-3">
+                «{template.quote}»
+              </p>
+            )}
+
+            {/* Action buttons */}
+            <div className="flex gap-2 pt-1 flex-wrap">
+              <button
+                onClick={() => setEditOpen(true)}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-on-surface text-xs font-bold min-h-[44px] border border-border-dim"
+              >
+                <span className="material-symbols-outlined text-sm">edit</span>
+                Редактировать
+              </button>
+              <button
+                onClick={() => setApplyOpen(true)}
+                className="flex items-center gap-1.5 px-3 py-2 rounded-xl kinetic-gradient text-on-primary text-xs font-bold min-h-[44px]"
+              >
+                <span className="material-symbols-outlined text-sm">person_add</span>
+                Применить
+              </button>
+              {collections.length > 0 && (
+                <button
+                  onClick={() => setCollectionsOpen((v) => !v)}
+                  className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-on-surface-variant text-xs font-bold min-h-[44px] border border-border-dim"
+                >
+                  <span className="material-symbols-outlined text-sm">bookmark</span>
+                  В коллекцию
+                </button>
+              )}
+            </div>
+
+            {/* Collections picker */}
+            {collectionsOpen && (
+              <div className="space-y-1.5 pt-1">
+                <p className="text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+                  Коллекции
+                </p>
+                {collections.map((col) => {
+                  const inCollection = col.template_ids.includes(template.template_id ?? template.id);
+                  return (
+                    <button
+                      key={col.id}
+                      onClick={() =>
+                        inCollection
+                          ? onRemoveFromCollection(col.id, template.template_id ?? template.id)
+                          : onAddToCollection(col.id, template.template_id ?? template.id)
+                      }
+                      className="w-full flex items-center gap-2 rounded-xl bg-surface-elevated px-3 py-2.5 text-sm min-h-[44px]"
+                    >
+                      <span className={`material-symbols-outlined text-base ${inCollection ? "text-primary" : "text-on-surface-variant"}`}>
+                        {inCollection ? "bookmark" : "bookmark_border"}
+                      </span>
+                      <span className="font-medium text-on-surface">{col.name}</span>
+                      {inCollection && (
+                        <span className="ml-auto text-[10px] text-primary font-black uppercase">Добавлено</span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {editOpen && (
+        <EditAiCardModal card={pseudoCard} onClose={() => setEditOpen(false)} />
+      )}
+      {applyOpen && (
+        <ApplyCardSheet
+          templateId={template.template_id ?? template.id}
+          templateTitle={template.title}
+          students={students}
+          onClose={() => setApplyOpen(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -88,114 +88,104 @@ export function LibraryCardItem({
 
   return (
     <>
-      <article
-        className="group relative flex flex-col rounded-2xl bg-white border border-gray-200 shadow-sm hover:shadow-xl hover:-translate-y-0.5 hover:border-gray-300 transition-all duration-200 overflow-hidden"
-      >
-        {/* ── Card body ── */}
-        <div className="flex-1 p-5 space-y-3">
-          {/* Top row: tag + status */}
-          <div className="flex items-center gap-2">
-            {mainTag && tagStyle && (
-              <span
-                className={`inline-flex items-center text-[11px] font-semibold rounded-md px-2 py-0.5 ${tagStyle.bg} ${tagStyle.text} border ${tagStyle.border} capitalize`}
-              >
-                {mainTag}
-              </span>
-            )}
-            {statusStyle && (
-              <span className={`ml-auto text-[11px] font-semibold ${statusStyle.text}`}>
-                {statusStyle.label}
-              </span>
-            )}
+      <article className="group relative flex flex-col rounded-2xl bg-white border border-gray-100 hover:border-gray-200 hover:shadow-lg transition-all duration-200 overflow-hidden min-h-[240px]">
+        {/* ── Top: tag + menu ── */}
+        <div className="flex items-start justify-between px-5 pt-5 pb-2">
+          <div className="flex-1 min-w-0 pr-2">
+            <p className="text-[11px] font-medium text-gray-400 mb-1.5 capitalize">
+              {mainTag ?? statusStyle?.label ?? "—"}
+            </p>
+            <h3 className="text-[16px] font-bold text-gray-900 leading-snug line-clamp-2">
+              {template.title ?? "—"}
+            </h3>
           </div>
 
-          {/* Title */}
-          <h3 className="text-[15px] font-bold text-gray-900 leading-snug line-clamp-3">
-            {template.title ?? "—"}
-          </h3>
-        </div>
+          {/* "..." menu */}
+          <div className="relative" ref={popoverRef}>
+            <button
+              type="button"
+              onClick={() => setCollectionsOpen((v) => !v)}
+              className="w-7 h-7 flex items-center justify-center rounded-lg text-gray-300 hover:text-gray-600 hover:bg-gray-100 transition-colors shrink-0"
+              aria-label="Действия с карточкой"
+              aria-expanded={collectionsOpen}
+            >
+              <span className="material-symbols-outlined text-[18px]">more_horiz</span>
+            </button>
 
-        {/* ── Footer ── */}
-        <div className="border-t border-gray-100 bg-gray-50 px-4 py-2.5 flex items-center gap-3">
-          {/* Student count */}
-          <div className="flex items-center flex-1 min-w-0 text-[12px] text-gray-400">
-            {template.student_count > 0 && (
-              <span className="tabular-nums">{template.student_count} {template.student_count === 1 ? "ученик" : "учеников"}</span>
-            )}
-          </div>
-
-          {/* Action buttons */}
-          <div className="flex items-center gap-0.5">
-            {collections.length > 0 && (
-              <div className="relative" ref={popoverRef}>
-                <button
-                  type="button"
-                  onClick={() => setCollectionsOpen((v) => !v)}
-                  className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors ${
-                    inAnyCollection
-                      ? "text-gray-700 bg-gray-100 hover:bg-gray-200"
-                      : "text-gray-400 hover:text-gray-700 hover:bg-gray-100"
-                  }`}
-                  aria-label="Добавить в коллекцию"
-                  aria-expanded={collectionsOpen}
-                >
-                  <span className={`material-symbols-outlined text-[17px] ${inAnyCollection ? "fill-icon" : ""}`}>
-                    bookmark
-                  </span>
-                </button>
-                {collectionsOpen && (
-                  <div className="absolute bottom-10 right-0 z-30 w-60 rounded-xl bg-white border border-gray-200 shadow-2xl p-1.5">
-                    <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 px-2.5 py-1.5">
-                      Коллекции
-                    </p>
-                    <div className="max-h-64 overflow-y-auto">
-                      {collections.map((col) => {
-                        const inCollection = col.template_ids.includes(tid);
-                        return (
-                          <button
-                            key={col.id}
-                            type="button"
-                            onClick={() => {
-                              if (inCollection) onRemoveFromCollection(col.id, tid);
-                              else onAddToCollection(col.id, tid);
-                              setCollectionsOpen(false);
-                            }}
-                            className="w-full flex items-center gap-2 px-2.5 py-2 rounded-lg hover:bg-gray-50 text-left transition-colors"
+            {collectionsOpen && (
+              <div className="absolute top-8 right-0 z-30 w-60 rounded-2xl bg-white border border-gray-200 shadow-2xl p-1.5">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 px-2.5 py-1.5">
+                  Коллекции
+                </p>
+                {collections.length === 0 ? (
+                  <p className="text-[12px] text-gray-400 px-2.5 py-2">Нет коллекций</p>
+                ) : (
+                  <div className="max-h-64 overflow-y-auto">
+                    {collections.map((col) => {
+                      const inCollection = col.template_ids.includes(tid);
+                      return (
+                        <button
+                          key={col.id}
+                          type="button"
+                          onClick={() => {
+                            if (inCollection) onRemoveFromCollection(col.id, tid);
+                            else onAddToCollection(col.id, tid);
+                            setCollectionsOpen(false);
+                          }}
+                          className="w-full flex items-center gap-2 px-2.5 py-2 rounded-xl hover:bg-gray-50 text-left transition-colors"
+                        >
+                          <span
+                            className={`material-symbols-outlined text-[16px] ${
+                              inCollection ? "text-gray-900 fill-icon" : "text-gray-300"
+                            }`}
                           >
-                            <span
-                              className={`material-symbols-outlined text-[16px] ${
-                                inCollection ? "text-gray-900 fill-icon" : "text-gray-300"
-                              }`}
-                            >
-                              {inCollection ? "check_circle" : "radio_button_unchecked"}
-                            </span>
-                            <span className="text-[13px] text-gray-800 truncate flex-1">{col.name}</span>
-                          </button>
-                        );
-                      })}
-                    </div>
+                            {inCollection ? "check_circle" : "radio_button_unchecked"}
+                          </span>
+                          <span className="text-[13px] text-gray-800 truncate flex-1">{col.name}</span>
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>
             )}
-            <button
-              type="button"
-              onClick={() => setEditOpen(true)}
-              className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-              aria-label="Редактировать"
-            >
-              <span className="material-symbols-outlined text-[16px]">edit</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => setApplyOpen(true)}
-              className="ml-1 inline-flex items-center gap-1 h-8 px-3 rounded-lg kinetic-gradient text-on-primary text-[12px] font-bold hover:shadow-md transition-all duration-200"
-              aria-label="Применить к ученику"
-            >
-              Assign
-              <span className="material-symbols-outlined text-[15px]">arrow_forward</span>
-            </button>
           </div>
+        </div>
+
+        {/* ── Body content ── */}
+        <div className="flex-1 px-5 pb-4">
+          {template.body ? (
+            <p className="text-[13px] text-gray-400 leading-relaxed line-clamp-4">
+              {template.body}
+            </p>
+          ) : (
+            <p className="text-[13px] text-gray-200 italic">Нет описания...</p>
+          )}
+        </div>
+
+        {/* ── Footer ── */}
+        <div className="px-5 pb-5 flex items-end justify-between">
+          {/* Left: assign */}
+          <button
+            type="button"
+            onClick={() => setApplyOpen(true)}
+            className="text-[12px] font-semibold text-gray-400 hover:text-gray-700 transition-colors"
+            aria-label="Применить к ученику"
+          >
+            {template.student_count > 0
+              ? `${template.student_count} ${template.student_count === 1 ? "ученик" : "учеников"}`
+              : "Assign..."}
+          </button>
+
+          {/* Right: dark circle edit button */}
+          <button
+            type="button"
+            onClick={() => setEditOpen(true)}
+            className="w-10 h-10 rounded-full bg-gray-900 flex items-center justify-center hover:bg-gray-700 active:scale-95 transition-all"
+            aria-label="Редактировать"
+          >
+            <span className="material-symbols-outlined text-white text-[18px]">edit</span>
+          </button>
         </div>
       </article>
 

--- a/src/components/trainer/LibraryCardItem.tsx
+++ b/src/components/trainer/LibraryCardItem.tsx
@@ -5,18 +5,17 @@ import type { CardTemplate, InsightCollection, InsightCard } from "@/lib/types";
 import { EditAiCardModal } from "@/components/insights/EditAiCardModal";
 import { ApplyCardSheet } from "./ApplyCardSheet";
 
-// Tag color palette — soft, distinguishable, accessible on white
-const TAG_COLORS: Record<string, { dot: string; bg: string; text: string; border: string }> = {
-  техника: { dot: "bg-blue-500", bg: "bg-blue-50", text: "text-blue-700", border: "border-blue-100" },
-  тактика: { dot: "bg-amber-500", bg: "bg-amber-50", text: "text-amber-700", border: "border-amber-100" },
-  физика: { dot: "bg-emerald-500", bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-100" },
-  менталка: { dot: "bg-purple-500", bg: "bg-purple-50", text: "text-purple-700", border: "border-purple-100" },
+const TAG_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  техника: { bg: "bg-blue-50", text: "text-blue-700", border: "border-blue-100" },
+  тактика: { bg: "bg-amber-50", text: "text-amber-700", border: "border-amber-100" },
+  физика: { bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-100" },
+  менталка: { bg: "bg-purple-50", text: "text-purple-700", border: "border-purple-100" },
 };
 
-const STATUS_META: Record<string, { dot: string; text: string; bg: string; label: string }> = {
-  approved: { dot: "bg-emerald-500", text: "text-emerald-700", bg: "bg-emerald-50", label: "Approved" },
-  draft: { dot: "bg-amber-500", text: "text-amber-700", bg: "bg-amber-50", label: "Draft" },
-  rejected: { dot: "bg-red-500", text: "text-red-700", bg: "bg-red-50", label: "Rejected" },
+const STATUS_META: Record<string, { text: string; label: string }> = {
+  approved: { text: "text-emerald-600", label: "Approved" },
+  draft: { text: "text-amber-600", label: "Draft" },
+  rejected: { text: "text-red-500", label: "Rejected" },
 };
 
 interface Student {
@@ -58,7 +57,6 @@ export function LibraryCardItem({
   }, [collectionsOpen]);
 
   const mainTag = template.tags?.[0];
-  const sideTag = template.tags?.[1];
   const tagStyle = mainTag ? TAG_COLORS[mainTag] : undefined;
   const statusStyle = STATUS_META[template.trainer_status];
 
@@ -99,72 +97,30 @@ export function LibraryCardItem({
           <div className="flex items-center gap-2">
             {mainTag && tagStyle && (
               <span
-                className={`inline-flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2.5 py-1 ${tagStyle.bg} ${tagStyle.text} border ${tagStyle.border}`}
+                className={`inline-flex items-center text-[11px] font-semibold rounded-md px-2 py-0.5 ${tagStyle.bg} ${tagStyle.text} border ${tagStyle.border} capitalize`}
               >
-                <span className={`w-1.5 h-1.5 rounded-full ${tagStyle.dot}`} />
-                <span className="capitalize">{mainTag}</span>
-              </span>
-            )}
-            {sideTag && (
-              <span className="inline-flex items-center text-[11px] font-medium text-gray-500 rounded-full px-2 py-1 bg-gray-50 border border-gray-100 capitalize">
-                {sideTag}
+                {mainTag}
               </span>
             )}
             {statusStyle && (
-              <span
-                className={`ml-auto inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider rounded-full px-2 py-0.5 ${statusStyle.bg} ${statusStyle.text}`}
-              >
-                <span className={`w-1.5 h-1.5 rounded-full ${statusStyle.dot}`} />
+              <span className={`ml-auto text-[11px] font-semibold ${statusStyle.text}`}>
                 {statusStyle.label}
               </span>
             )}
           </div>
 
           {/* Title */}
-          <h3 className="text-[15px] font-bold text-gray-900 leading-snug line-clamp-2">
+          <h3 className="text-[15px] font-bold text-gray-900 leading-snug line-clamp-3">
             {template.title ?? "—"}
           </h3>
-
-          {/* Body */}
-          {template.body && (
-            <p className="text-[13px] text-gray-500 leading-relaxed line-clamp-3">
-              {template.body}
-            </p>
-          )}
-
-          {/* Quote */}
-          {template.quote && (
-            <blockquote className="text-[12px] text-gray-600 italic border-l-2 border-gray-200 pl-3 line-clamp-2 leading-relaxed">
-              «{template.quote}»
-            </blockquote>
-          )}
         </div>
 
         {/* ── Footer ── */}
         <div className="border-t border-gray-100 bg-gray-50 px-4 py-2.5 flex items-center gap-3">
-          {/* Stats */}
-          <div className="flex items-center gap-3 flex-1 min-w-0 text-[12px] text-gray-500">
-            <span className="inline-flex items-center gap-1" title="Учеников">
-              <span className="material-symbols-outlined text-[15px] text-gray-400">group</span>
-              <span className="font-medium tabular-nums">{template.student_count}</span>
-            </span>
-            {template.taken_count > 0 && (
-              <span className="inline-flex items-center gap-1 text-emerald-600" title="Принято">
-                <span className="material-symbols-outlined text-[15px]">check</span>
-                <span className="font-medium tabular-nums">{template.taken_count}</span>
-              </span>
-            )}
-            {template.skipped_count > 0 && (
-              <span className="inline-flex items-center gap-1" title="Пропущено">
-                <span className="material-symbols-outlined text-[15px] text-gray-400">arrow_forward</span>
-                <span className="font-medium tabular-nums">{template.skipped_count}</span>
-              </span>
-            )}
-            {template.pending_count > 0 && (
-              <span className="inline-flex items-center gap-1 text-amber-600" title="Ожидает">
-                <span className="material-symbols-outlined text-[15px]">schedule</span>
-                <span className="font-medium tabular-nums">{template.pending_count}</span>
-              </span>
+          {/* Student count */}
+          <div className="flex items-center flex-1 min-w-0 text-[12px] text-gray-400">
+            {template.student_count > 0 && (
+              <span className="tabular-nums">{template.student_count} {template.student_count === 1 ? "ученик" : "учеников"}</span>
             )}
           </div>
 

--- a/src/lib/actions/aiInsights.ts
+++ b/src/lib/actions/aiInsights.ts
@@ -36,6 +36,34 @@ export async function pasteInsightsFromClaude(
     return { error: error.message };
   }
 
+  // Assign template_id to newly created cards.
+  // Reuse existing template_id if a card with the same title+body already exists,
+  // otherwise generate a new one. This ensures cards pasted across multiple students
+  // automatically share the same template_id.
+  const { data: newCards } = await supabase
+    .from("insight_cards")
+    .select("id, title, body")
+    .eq("session_id", sessionId)
+    .is("template_id", null);
+
+  for (const card of newCards ?? []) {
+    let tid: string;
+    if (card.title && card.body) {
+      const { data: existing } = await supabase
+        .from("insight_cards")
+        .select("template_id")
+        .eq("title", card.title)
+        .eq("body", card.body)
+        .not("template_id", "is", null)
+        .limit(1)
+        .maybeSingle();
+      tid = existing?.template_id ?? crypto.randomUUID();
+    } else {
+      tid = crypto.randomUUID();
+    }
+    await supabase.from("insight_cards").update({ template_id: tid }).eq("id", card.id);
+  }
+
   revalidatePath(`/sessions/${sessionId}`);
   return { success: true, count: (data as number) ?? parsed.cards.length };
 }
@@ -48,13 +76,17 @@ async function requireTrainerOwnsCard(cardId: string) {
 
   const { data: card } = await supabase
     .from("insight_cards")
-    .select("id, session_id, trainer_id")
+    .select("id, session_id, trainer_id, template_id")
     .eq("id", cardId)
     .single();
 
   if (!card || card.trainer_id !== user.id) return null;
 
-  return { supabase, sessionId: card.session_id as string };
+  return {
+    supabase,
+    sessionId: card.session_id as string,
+    templateId: card.template_id as string | null,
+  };
 }
 
 export async function approveInsightCard(
@@ -63,11 +95,11 @@ export async function approveInsightCard(
   const ctx = await requireTrainerOwnsCard(cardId);
   if (!ctx) return { error: "Forbidden" };
 
-  const { supabase, sessionId } = ctx;
-  const { error } = await supabase
-    .from("insight_cards")
-    .update({ trainer_status: "approved" })
-    .eq("id", cardId);
+  const { supabase, sessionId, templateId } = ctx;
+  const filter = templateId
+    ? supabase.from("insight_cards").update({ trainer_status: "approved" }).eq("template_id", templateId)
+    : supabase.from("insight_cards").update({ trainer_status: "approved" }).eq("id", cardId);
+  const { error } = await filter;
 
   if (error) return { error: error.message };
 
@@ -81,11 +113,11 @@ export async function rejectInsightCard(
   const ctx = await requireTrainerOwnsCard(cardId);
   if (!ctx) return { error: "Forbidden" };
 
-  const { supabase, sessionId } = ctx;
-  const { error } = await supabase
-    .from("insight_cards")
-    .update({ trainer_status: "rejected" })
-    .eq("id", cardId);
+  const { supabase, sessionId, templateId } = ctx;
+  const filter = templateId
+    ? supabase.from("insight_cards").update({ trainer_status: "rejected" }).eq("template_id", templateId)
+    : supabase.from("insight_cards").update({ trainer_status: "rejected" }).eq("id", cardId);
+  const { error } = await filter;
 
   if (error) return { error: error.message };
 
@@ -132,17 +164,19 @@ export async function updateAiInsightCard(
 
   const tags = patch.side ? [patch.tag, patch.side] : [patch.tag];
 
-  const { supabase, sessionId } = ctx;
-  const { error } = await supabase
-    .from("insight_cards")
-    .update({
-      title: patch.title.trim(),
-      body: patch.body.trim(),
-      tags,
-      front_text: patch.title.trim(),
-      context_text: patch.body.trim(),
-    })
-    .eq("id", cardId);
+  const { supabase, sessionId, templateId } = ctx;
+  const contentPatch = {
+    title: patch.title.trim(),
+    body: patch.body.trim(),
+    tags,
+    front_text: patch.title.trim(),
+    context_text: patch.body.trim(),
+  };
+
+  const filter = templateId
+    ? supabase.from("insight_cards").update(contentPatch).eq("template_id", templateId)
+    : supabase.from("insight_cards").update(contentPatch).eq("id", cardId);
+  const { error } = await filter;
 
   if (error) return { error: error.message };
 

--- a/src/lib/actions/insightCards.ts
+++ b/src/lib/actions/insightCards.ts
@@ -124,16 +124,29 @@ export async function updateInsightCard(
   }
   if (patch.tags !== undefined) update.tags = patch.tags;
 
-  const { data, error } = await supabase
+  const { data: card, error: fetchErr } = await supabase
     .from("insight_cards")
-    .update(update)
+    .select("session_id, template_id")
     .eq("id", cardId)
-    .select("session_id")
     .single();
 
-  if (error) return { success: false, error: error.message };
+  if (fetchErr || !card) return { success: false, error: fetchErr?.message ?? "Card not found" };
 
-  revalidatePath(`/trainer/sessions/${data.session_id}/insights`);
+  if (card.template_id) {
+    const { error } = await supabase
+      .from("insight_cards")
+      .update(update)
+      .eq("template_id", card.template_id);
+    if (error) return { success: false, error: error.message };
+  } else {
+    const { error } = await supabase
+      .from("insight_cards")
+      .update(update)
+      .eq("id", cardId);
+    if (error) return { success: false, error: error.message };
+  }
+
+  revalidatePath(`/trainer/sessions/${card.session_id}/insights`);
   return { success: true };
 }
 
@@ -143,18 +156,32 @@ export async function setTrainerCardStatus(
 ): Promise<Result> {
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
+  const { supabase } = auth;
 
-  const { data, error } = await auth.supabase
+  const { data: card, error: fetchErr } = await supabase
     .from("insight_cards")
-    .update({ trainer_status: status })
+    .select("session_id, template_id")
     .eq("id", cardId)
-    .select("session_id")
     .single();
 
-  if (error) return { success: false, error: error.message };
+  if (fetchErr || !card) return { success: false, error: fetchErr?.message ?? "Card not found" };
 
-  revalidatePath(`/trainer/sessions/${data.session_id}/insights`);
-  revalidatePath(`/sessions/${data.session_id}`);
+  if (card.template_id) {
+    const { error } = await supabase
+      .from("insight_cards")
+      .update({ trainer_status: status })
+      .eq("template_id", card.template_id);
+    if (error) return { success: false, error: error.message };
+  } else {
+    const { error } = await supabase
+      .from("insight_cards")
+      .update({ trainer_status: status })
+      .eq("id", cardId);
+    if (error) return { success: false, error: error.message };
+  }
+
+  revalidatePath(`/trainer/sessions/${card.session_id}/insights`);
+  revalidatePath(`/sessions/${card.session_id}`);
   return { success: true };
 }
 

--- a/src/lib/actions/insightCards.ts
+++ b/src/lib/actions/insightCards.ts
@@ -9,6 +9,14 @@ import type {
   InsightStudentDecision,
 } from "@/lib/types";
 
+export interface StudentSessionOption {
+  id: string;
+  session_number: number;
+  trainer_notes: string | null;
+  scheduled_at: string | null;
+  created_at: string;
+}
+
 type Result<T = void> =
   | (T extends void ? { success: true } : { success: true } & T)
   | { success: false; error: string };
@@ -326,4 +334,167 @@ export async function getVaultCards(
     return [];
   }
   return (data ?? []) as unknown as InsightCardWithRelations[];
+}
+
+export async function getStudentSessions(
+  studentId: string
+): Promise<StudentSessionOption[]> {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return [];
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("sessions")
+    .select("id, session_number, trainer_notes, scheduled_at, created_at, goals!inner(user_id)")
+    .eq("goals.user_id", studentId)
+    .order("scheduled_at", { ascending: false, nullsFirst: false });
+
+  return ((data ?? []) as unknown as (StudentSessionOption & { goals: { user_id: string } })[]).map(
+    ({ goals: _g, ...s }) => s
+  );
+}
+
+export async function applyTemplateToStudent(
+  templateId: string,
+  sessionId: string
+): Promise<Result<{ id: string }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+  const { supabase, userId } = auth;
+
+  // Get representative card for this template
+  const { data: template, error: tErr } = await supabase
+    .from("insight_cards")
+    .select("*")
+    .eq("template_id", templateId)
+    .limit(1)
+    .single();
+  if (tErr || !template) return { success: false, error: "Template not found" };
+
+  // Get student from session
+  const { data: session, error: sErr } = await supabase
+    .from("sessions")
+    .select("id, goals!inner(user_id)")
+    .eq("id", sessionId)
+    .single();
+  if (sErr || !session) return { success: false, error: "Session not found" };
+
+  const studentId = (session as unknown as { goals: { user_id: string } }).goals.user_id;
+
+  // Check card not already applied to this student
+  const { count } = await supabase
+    .from("insight_cards")
+    .select("id", { count: "exact", head: true })
+    .eq("template_id", templateId)
+    .eq("student_id", studentId);
+  if (count && count > 0) return { success: false, error: "Карточка уже есть у этого ученика" };
+
+  const { data: lastCard } = await supabase
+    .from("insight_cards")
+    .select("position")
+    .eq("session_id", sessionId)
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const { data: newCard, error: insertErr } = await supabase
+    .from("insight_cards")
+    .insert({
+      session_id: sessionId,
+      student_id: studentId,
+      trainer_id: userId,
+      template_id: templateId,
+      title: template.title,
+      body: template.body,
+      quote: template.quote,
+      tags: template.tags,
+      front_text: template.front_text,
+      context_text: template.context_text,
+      problem_id: template.problem_id,
+      category_id: template.category_id,
+      source: "ai-paste",
+      trainer_status: "approved",
+      position: (lastCard?.position ?? 0) + 1,
+    })
+    .select("id")
+    .single();
+
+  if (insertErr || !newCard) return { success: false, error: insertErr?.message ?? "Failed" };
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true, id: newCard.id };
+}
+
+export async function createCollection(name: string): Promise<Result<{ id: string }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+  const { supabase, userId } = auth;
+
+  const { data, error } = await supabase
+    .from("insight_collections")
+    .insert({ trainer_id: userId, name: name.trim() })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  revalidatePath("/trainer/cards");
+  return { success: true, id: data.id };
+}
+
+export async function addCardToCollection(
+  collectionId: string,
+  templateId: string
+): Promise<Result> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { error } = await auth.supabase
+    .from("insight_collection_cards")
+    .upsert({ collection_id: collectionId, template_id: templateId, position: 0 });
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/trainer/cards");
+  return { success: true };
+}
+
+export async function removeCardFromCollection(
+  collectionId: string,
+  templateId: string
+): Promise<Result> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+
+  const { error } = await auth.supabase
+    .from("insight_collection_cards")
+    .delete()
+    .eq("collection_id", collectionId)
+    .eq("template_id", templateId);
+
+  if (error) return { success: false, error: error.message };
+  revalidatePath("/trainer/cards");
+  return { success: true };
+}
+
+export async function applyCollectionToStudent(
+  collectionId: string,
+  sessionId: string
+): Promise<Result<{ applied: number }>> {
+  const auth = await requireTrainer();
+  if (!auth.ok) return { success: false, error: auth.error };
+  const { supabase, userId } = auth;
+
+  const { data: items } = await supabase
+    .from("insight_collection_cards")
+    .select("template_id")
+    .eq("collection_id", collectionId)
+    .order("position");
+
+  let applied = 0;
+  for (const item of items ?? []) {
+    const result = await applyTemplateToStudent(item.template_id, sessionId);
+    if (result.success) applied++;
+  }
+
+  revalidatePath(`/sessions/${sessionId}`);
+  return { success: true, applied };
 }

--- a/src/lib/i18n/dict.ts
+++ b/src/lib/i18n/dict.ts
@@ -33,6 +33,7 @@ const ru = {
   "nav.home": "Главная",
   "nav.insights": "Инсайты",
   "nav.matches": "Матчи",
+  "nav.cards": "Карточки",
   "nav.logout": "Выйти",
 
   // Dashboard
@@ -190,6 +191,7 @@ const en: Record<keyof typeof ru, string> = {
   "nav.home": "Home",
   "nav.insights": "Insights",
   "nav.matches": "Matches",
+  "nav.cards": "Cards",
   "nav.logout": "Sign out",
 
   "dashboard.welcome": "Welcome,",

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -173,6 +173,29 @@ export interface MasterPlanSection {
   items: MasterPlanItem[];
 }
 
+export interface CardTemplate {
+  id: string;
+  template_id: string | null;
+  title: string | null;
+  body: string | null;
+  quote: string | null;
+  tags: string[] | null;
+  trainer_status: InsightTrainerStatus;
+  created_at: string;
+  student_count: number;
+  taken_count: number;
+  skipped_count: number;
+  pending_count: number;
+}
+
+export interface InsightCollection {
+  id: string;
+  trainer_id: string;
+  name: string;
+  created_at: string;
+  card_count?: number;
+}
+
 export interface MasterPlan {
   id: string;
   student_id: string;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -92,6 +92,7 @@ export interface InsightCard {
   position: number;
   created_at: string;
   decided_at: string | null;
+  template_id: string | null;
 }
 
 export interface InsightCardWithRelations extends InsightCard {

--- a/supabase/migrations/015_insight_cards_template_id.sql
+++ b/supabase/migrations/015_insight_cards_template_id.sql
@@ -1,0 +1,25 @@
+ALTER TABLE public.insight_cards
+  ADD COLUMN IF NOT EXISTS template_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_insight_cards_template_id
+  ON public.insight_cards (template_id)
+  WHERE template_id IS NOT NULL;
+
+-- Backfill: assign the same template_id to all cards sharing (title, body).
+-- Uses a CTE to generate one stable UUID per unique pair before joining back.
+WITH unique_pairs AS (
+  SELECT DISTINCT ON (title, body) title, body
+  FROM insight_cards
+  WHERE title IS NOT NULL AND body IS NOT NULL AND template_id IS NULL
+  ORDER BY title, body
+),
+with_ids AS (
+  SELECT title, body, gen_random_uuid() AS tid
+  FROM unique_pairs
+)
+UPDATE insight_cards
+SET template_id = with_ids.tid
+FROM with_ids
+WHERE insight_cards.title = with_ids.title
+  AND insight_cards.body = with_ids.body
+  AND insight_cards.template_id IS NULL;

--- a/supabase/migrations/016_insight_collections.sql
+++ b/supabase/migrations/016_insight_collections.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS public.insight_collections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trainer_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS public.insight_collection_cards (
+  collection_id UUID NOT NULL REFERENCES public.insight_collections(id) ON DELETE CASCADE,
+  template_id UUID NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (collection_id, template_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_insight_collections_trainer
+  ON public.insight_collections (trainer_id);
+
+CREATE INDEX IF NOT EXISTS idx_collection_cards_collection
+  ON public.insight_collection_cards (collection_id);


### PR DESCRIPTION
## Summary

- New page `/trainer/cards` — единая библиотека всех инсайт-карточек тренера
- Новый таб «Карточки» в BottomNav (только для тренера), иконка `auto_stories`
- Дедупликация по `template_id` — каждый шаблон показывается один раз
- Миграция 016: таблицы `insight_collections` + `insight_collection_cards`

## Что умеет библиотека

**Карточки:**
- Поиск по заголовку и описанию
- Фильтр по тегу (техника / тактика / физика / менталка)
- Фильтр по статусу (approved / draft / rejected)
- Фильтр по ученику (только карточки конкретного ученика)
- Статистика: 👤 N учеников · ✅ N взяли · ⏭ N пропустили · ⏳ N не решили
- Редактирование через EditAiCardModal (пропагейтится всем студентам)
- «Применить к студенту» — выбрать ученика + сессию, добавить карточку

**Коллекции:**
- Создать коллекцию с именем
- Добавить/убрать карточку из коллекции (через «В коллекцию» в карточке)
- «Применить коллекцию» — сразу добавить все карточки коллекции студенту

**Layout:**
- Мобиль: sticky поиск + чипы + список карточек
- Десктоп (`md:`): боковая панель фильтров + двухколоночная сетка карточек

## Test plan

- [ ] Открыть `/trainer/cards` — видны все уникальные карточки с правильной статистикой
- [ ] Поиск, фильтры по тегу/статусу/ученику работают
- [ ] Редактировать карточку → у всех студентов обновился текст
- [ ] «Применить» карточку к ученику/сессии → карточка появилась в сессии
- [ ] Создать коллекцию, добавить карточки, применить студенту
- [ ] На мобиле (390px) — удобно, тач-зоны ≥ 44px
- [ ] На десктопе — двухколоночный layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)