### PR TITLE
fix(sessions): instant card edit update + preserve reorder after refresh

### DIFF
--- a/src/components/insights/ApprovedCardsReorderable.tsx
+++ b/src/components/insights/ApprovedCardsReorderable.tsx
@@ -48,7 +48,18 @@ export function ApprovedCardsReorderable({ sessionId, cards }: Props) {
             </button>
           </div>
           <div className="flex-1 min-w-0">
-            <ApprovedInsightCard card={card} />
+            <ApprovedInsightCard
+              card={card}
+              onSaved={(patch) => {
+                setOrder((prev) =>
+                  prev.map((c) =>
+                    c.id === card.id
+                      ? { ...c, title: patch.title, body: patch.body, front_text: patch.title, context_text: patch.body, tags: patch.tags }
+                      : c
+                  )
+                );
+              }}
+            />
           </div>
         </div>
       ))}

--- a/src/components/insights/ApprovedInsightCard.tsx
+++ b/src/components/insights/ApprovedInsightCard.tsx
@@ -9,9 +9,10 @@ import type { InsightCard } from "@/lib/types";
 
 interface Props {
   card: InsightCard;
+  onSaved?: (patch: { title: string; body: string; tags: string[] }) => void;
 }
 
-export function ApprovedInsightCard({ card }: Props) {
+export function ApprovedInsightCard({ card, onSaved }: Props) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -27,9 +28,11 @@ export function ApprovedInsightCard({ card }: Props) {
     };
   }, [open]);
 
-  const displayText = card.title || card.front_text;
-  const displayBody = card.body || card.context_text;
-  const tag = card.tags?.[0] ?? null;
+  const [localPatch, setLocalPatch] = useState<{ title: string; body: string; tags: string[] } | null>(null);
+
+  const displayText = localPatch?.title ?? card.title ?? card.front_text;
+  const displayBody = localPatch?.body ?? card.body ?? card.context_text;
+  const tag = (localPatch?.tags ?? card.tags)?.[0] ?? null;
 
   function handleDelete() {
     startTransition(async () => {
@@ -174,7 +177,14 @@ export function ApprovedInsightCard({ card }: Props) {
       {sheet}
 
       {editing && (
-        <EditAiCardModal card={card} onClose={() => setEditing(false)} />
+        <EditAiCardModal
+          card={card}
+          onClose={() => setEditing(false)}
+          onSaved={(patch) => {
+            setLocalPatch(patch);
+            onSaved?.(patch);
+          }}
+        />
       )}
     </>
   );

--- a/src/components/insights/EditAiCardModal.tsx
+++ b/src/components/insights/EditAiCardModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { updateAiInsightCard } from "@/lib/actions/aiInsights";
 import type { InsightCard } from "@/lib/types";
 
@@ -11,10 +10,10 @@ const SIDES = ["защита", "атака"] as const;
 interface Props {
   card: InsightCard;
   onClose: () => void;
+  onSaved?: (patch: { title: string; body: string; tags: string[] }) => void;
 }
 
-export function EditAiCardModal({ card, onClose }: Props) {
-  const router = useRouter();
+export function EditAiCardModal({ card, onClose, onSaved }: Props) {
   const [title, setTitle] = useState(card.title || card.front_text);
   const [body, setBody] = useState(card.body || card.context_text || "");
   const [tag, setTag] = useState<string>(card.tags?.[0] ?? "техника");
@@ -43,7 +42,8 @@ export function EditAiCardModal({ card, onClose }: Props) {
       if ("error" in result) {
         setError(result.error);
       } else {
-        router.refresh();
+        const tags = [tag, side];
+        onSaved?.({ title: title.trim(), body: body.trim(), tags });
         onClose();
       }
     });

--- a/src/lib/actions/insightCards.ts
+++ b/src/lib/actions/insightCards.ts
@@ -227,15 +227,13 @@ export async function reorderInsightCards(
   const { data: existing, error: fetchErr } = await supabase
     .from("insight_cards")
     .select("id")
-    .eq("session_id", sessionId);
+    .eq("session_id", sessionId)
+    .in("id", orderedIds);
 
   if (fetchErr) return { success: false, error: fetchErr.message };
 
   const existingIds = new Set((existing ?? []).map((c) => c.id));
-  if (
-    orderedIds.length !== existingIds.size ||
-    !orderedIds.every((id) => existingIds.has(id))
-  ) {
+  if (!orderedIds.every((id) => existingIds.has(id))) {
     return { success: false, error: "Card list is out of sync" };
   }
 


### PR DESCRIPTION
## Что сделано

- **Редактирование без обновления страницы** — `EditAiCardModal` вызывает `onSaved(patch)` вместо `router.refresh()`; карточка обновляется мгновенно через локальный стейт
- **Порядок сохраняется после обновления** — `reorderInsightCards` раньше брал все карточки сессии (включая черновики) и сравнивал их количество с переданным списком approved-карточек; проверка всегда падала если были черновики, позиции никогда не сохранялись; теперь запрос фильтруется `.in("id", orderedIds)`