### PR TITLE
fix(dashboard): show session time in browser local timezone

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -356,7 +356,7 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
                         {session.session_number}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="font-semibold text-sm">
+                        <p className="font-semibold text-sm" suppressHydrationWarning>
                           {(() => {
                             const d = new Date(session.scheduled_at ?? session.created_at);
                             const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long" }).format(d);
@@ -364,7 +364,7 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
                             return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${time}`;
                           })()}
                         </p>
-                        <p className="text-[11px] text-on-surface-variant">
+                        <p className="text-[11px] text-on-surface-variant" suppressHydrationWarning>
                           {new Date(session.scheduled_at ?? session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long" })}
                           {session.status === "completed" && ` · ${t(locale, "common.completed")}`}
                         </p>


### PR DESCRIPTION
## Проблема
Сессия создана в 11:00 по местному времени (UTC+2), но отображалась как 09:00.

Supabase хранит время правильно — 09:00 UTC. Проблема в отображении: Next.js SSR рендерит `DashboardView` на сервере Vercel (UTC), форматирует время как 09:00. React обнаруживает расхождение при гидрации и оставляет серверное значение вместо локального.

## Фикс
`suppressHydrationWarning` на элементах с временем и датой — браузер перерисовывает их в локальном timezone после гидрации.