### PR TITLE
fix(sessions): store and display trainer-entered time exactly as typed

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -167,7 +167,7 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
                     {allItems.map((item) => {
                       if (item.kind === "session") {
                         const dateStr = item.scheduled_at
-                          ? new Date(item.scheduled_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit" })
+                          ? new Date(item.scheduled_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit", timeZone: "UTC" })
                           : null;
                         return (
                           <Link
@@ -356,16 +356,16 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
                         {session.session_number}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="font-semibold text-sm" suppressHydrationWarning>
+                        <p className="font-semibold text-sm">
                           {(() => {
                             const d = new Date(session.scheduled_at ?? session.created_at);
-                            const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long" }).format(d);
-                            const time = new Intl.DateTimeFormat(dateLocale, { hour: "2-digit", minute: "2-digit", hour12: false }).format(d);
+                            const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long", timeZone: "UTC" }).format(d);
+                            const time = new Intl.DateTimeFormat(dateLocale, { hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC" }).format(d);
                             return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${time}`;
                           })()}
                         </p>
-                        <p className="text-[11px] text-on-surface-variant" suppressHydrationWarning>
-                          {new Date(session.scheduled_at ?? session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long" })}
+                        <p className="text-[11px] text-on-surface-variant">
+                          {new Date(session.scheduled_at ?? session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", timeZone: "UTC" })}
                           {session.status === "completed" && ` · ${t(locale, "common.completed")}`}
                         </p>
                       </div>

--- a/src/components/dashboard/edit/InlineSessionCreator.tsx
+++ b/src/components/dashboard/edit/InlineSessionCreator.tsx
@@ -26,7 +26,8 @@ export default function InlineSessionCreator({ studentId, goals }: Props) {
       return;
     }
     startTransition(async () => {
-      const iso = date ? new Date(date).toISOString() : null;
+      // datetime-local has no timezone — append Z to treat the entered time as UTC literally
+      const iso = date ? `${date}:00.000Z` : null;
       const res = await createSessionForStudent(studentId, goalId, {
         scheduledAt: iso,
         completedAt: completed ? iso ?? new Date().toISOString() : null,


### PR DESCRIPTION
## Проблема
Тренер вводил 11:00 → браузер конвертировал в UTC (09:00 при UTC+2) → сохранялось и показывалось 09:00.

## Фикс
- **Сохранение**: `datetime-local` возвращает `"2026-05-19T11:00"` без timezone. Вместо `new Date(date).toISOString()` (которое применяет локальный offset браузера) теперь дописываем `Z` напрямую → `"2026-05-19T11:00:00.000Z"`. Число 11 хранится как есть.
- **Отображение**: `Intl.DateTimeFormat` и `toLocaleDateString` везде получают `timeZone: "UTC"` → показывают ровно то UTC-значение, что хранится в базе.

Результат: тренер ввёл 11:00 → в базе 11:00 UTC → на экране 11:00 у всех.