### PR TITLE
feat(dashboard): NEW/+1 badges for updated goals and skills

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -201,6 +201,22 @@ body {
   animation: insight-tap-ring 0.85s ease-out 0s 1 both;
 }
 
+/* ─── Progress delta +1 badge pop-in ─── */
+@keyframes delta-badge-pop {
+  0%   { transform: scale(0);    opacity: 0; }
+  55%  { transform: scale(1.18); opacity: 1; }
+  78%  { transform: scale(0.94); }
+  100% { transform: scale(1);    opacity: 1; }
+}
+.delta-badge-pop {
+  animation: delta-badge-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 0.2s both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .delta-badge-pop {
+    animation: none;
+  }
+}
+
 /* ─── Vault flip card ─── */
 .vault-card {
   perspective: 1000px;

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -9,6 +9,8 @@ import InlineSessionCreator from "@/components/dashboard/edit/InlineSessionCreat
 import InlineProfileHeader from "@/components/dashboard/edit/InlineProfileHeader";
 import MasterPlanEditor from "@/components/masterPlan/MasterPlanEditor";
 import PlaytomicConnectBlock from "@/components/playtomic/PlaytomicConnectBlock";
+import SkillProgressSection from "@/components/dashboard/SkillProgressSection";
+import MarkSeenEffect from "@/components/dashboard/MarkSeenEffect";
 
 export interface DashboardViewEditable {
   studentId: string;
@@ -50,6 +52,9 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
 
   return (
     <div className="space-y-6">
+      {/* Mark dashboard data as seen — real student viewing their own dashboard only */}
+      {!isTrainer && !previewMode && <MarkSeenEffect userId={profile.id} />}
+
       {/* Header */}
       {isTrainer ? (
         <InlineProfileHeader profile={profile} />
@@ -280,49 +285,61 @@ export default function DashboardView({ data, locale, editable, previewMode }: P
               </p>
             ) : (
               <div className="flex gap-3 overflow-x-auto pb-1 -mx-5 px-5" style={{ scrollbarWidth: "none" }}>
-                {goals.map((goal) => (
-                  <div key={goal.id} className="flex-shrink-0 w-52 bg-surface-card rounded-2xl p-4" style={{ borderTop: "2px solid #cafd00" }}>
-                    <div className="flex items-center gap-1.5 mb-2">
-                      <span className="w-2 h-2 rounded-full bg-primary" />
-                      <span className="text-[10px] font-black uppercase tracking-widest text-primary">
-                        {t(locale, "dashboard.goal")}
-                      </span>
+                {goals.map((goal) => {
+                  const isNewGoal = goal.is_new;
+                  return (
+                    <div key={goal.id} className="flex-shrink-0 w-52 bg-surface-card rounded-2xl p-4" style={{ borderTop: "2px solid #cafd00" }}>
+                      <div className="flex items-center gap-1.5 mb-2">
+                        <span className="w-2 h-2 rounded-full bg-primary" />
+                        <span className="text-[10px] font-black uppercase tracking-widest text-primary">
+                          {t(locale, "dashboard.goal")}
+                        </span>
+                        {isNewGoal && (
+                          <span
+                            className="ml-auto inline-flex items-center px-1.5 py-0.5 rounded-md text-[9px] font-black tracking-widest leading-none"
+                            style={{ backgroundColor: "#cafd00", color: "#0a0a0a", transform: "rotate(2deg)" }}
+                          >
+                            NEW
+                          </span>
+                        )}
+                      </div>
+                      {goal.problems.length > 0
+                        ? goal.problems.map((p) => (
+                            <p key={p.id} className="text-sm font-semibold leading-snug text-on-surface mb-1">
+                              {p.name.length > 50 ? p.name.slice(0, 50) + "..." : p.name}
+                            </p>
+                          ))
+                        : goal.custom_problem
+                        ? <p className="text-sm font-semibold leading-snug text-on-surface mb-1">{goal.custom_problem}</p>
+                        : null}
                     </div>
-                    {goal.problems.length > 0
-                      ? goal.problems.map((p) => (
-                          <p key={p.id} className="text-sm font-semibold leading-snug text-on-surface mb-1">
-                            {p.name.length > 50 ? p.name.slice(0, 50) + "..." : p.name}
-                          </p>
-                        ))
-                      : goal.custom_problem
-                      ? <p className="text-sm font-semibold leading-snug text-on-surface mb-1">{goal.custom_problem}</p>
-                      : null}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </section>
 
           {/* Skills */}
-          {skillProgress.length > 0 && (
-            <section className="bg-surface-high rounded-3xl p-6">
-              <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant mb-5">
-                {t(locale, "dashboard.skillProgression")}
-              </h3>
-              <div className="space-y-5">
-                {skillProgress.map((sp, i) => (
-                  <ProgressBar
-                    key={sp.skill_id}
-                    label={sp.skill_name}
-                    value={sp.points_in_level}
-                    max={10}
-                    variant={i % 2 === 0 ? "secondary" : "primary"}
-                    sublabel={`${sp.points_in_level}/10 · Lv.${sp.level}`}
-                  />
-                ))}
-              </div>
-            </section>
-          )}
+          {skillProgress.length > 0 && (() => {
+            const deltas: Record<number, number> = {};
+            const newIds: number[] = [];
+            for (const sp of skillProgress) {
+              if (sp.points_seen === null) {
+                newIds.push(sp.skill_id);
+              } else {
+                const delta = Math.max(0, sp.points - sp.points_seen);
+                if (delta > 0) deltas[sp.skill_id] = delta;
+              }
+            }
+            return (
+              <SkillProgressSection
+                skills={skillProgress}
+                deltas={deltas}
+                newIds={newIds}
+                label={t(locale, "dashboard.skillProgression")}
+              />
+            );
+          })()}
 
           {/* Sessions list */}
           <section>

--- a/src/components/dashboard/MarkSeenEffect.tsx
+++ b/src/components/dashboard/MarkSeenEffect.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { markDashboardSeen } from "@/lib/actions/dashboard";
+
+interface Props {
+  userId: string;
+}
+
+/**
+ * Fire-and-forget: after the student has had the dashboard open for 3s,
+ * mark skill points and goals as "seen" so NEW badges / deltas reset
+ * on the next visit. Renders nothing.
+ */
+export default function MarkSeenEffect({ userId }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      void markDashboardSeen(userId);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [userId]);
+
+  return null;
+}

--- a/src/components/dashboard/SkillProgressSection.tsx
+++ b/src/components/dashboard/SkillProgressSection.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import ProgressBar from "@/components/ui/ProgressBar";
+
+interface Skill {
+  skill_id: number;
+  skill_name: string;
+  points_in_level: number;
+  level: number;
+}
+
+interface Props {
+  skills: Skill[];
+  deltas: Record<number, number>;
+  newIds: number[];
+  label: string;
+}
+
+export default function SkillProgressSection({ skills, deltas, newIds, label }: Props) {
+  const [showAll, setShowAll] = useState(false);
+
+  const updated = skills.filter((s) => deltas[s.skill_id] || newIds.includes(s.skill_id));
+  const rest = skills.filter((s) => !deltas[s.skill_id] && !newIds.includes(s.skill_id));
+
+  return (
+    <section className="bg-surface-high rounded-3xl p-6">
+      <h3 className="text-xs font-black uppercase tracking-[0.2em] text-on-surface-variant mb-5">
+        {label}
+      </h3>
+
+      {/* Updated skills — always visible */}
+      <div className="space-y-5">
+        {updated.map((sp, i) => (
+          <ProgressBar
+            key={sp.skill_id}
+            label={sp.skill_name}
+            value={sp.points_in_level}
+            max={10}
+            variant={i % 2 === 0 ? "secondary" : "primary"}
+            sublabel={`${sp.points_in_level}/10 · Lv.${sp.level}`}
+            delta={deltas[sp.skill_id]}
+            isNew={newIds.includes(sp.skill_id)}
+          />
+        ))}
+      </div>
+
+      {/* Rest — collapsible via grid 0fr → 1fr trick for smooth height */}
+      {rest.length > 0 && (
+        <div
+          className="grid transition-[grid-template-rows] duration-300 ease-out"
+          style={{ gridTemplateRows: showAll ? "1fr" : "0fr" }}
+        >
+          <div className="overflow-hidden min-h-0">
+            {/* Divider between updated and earlier skills */}
+            {updated.length > 0 && (
+              <div className="flex items-center gap-3 pt-5">
+                <span className="h-px flex-1 bg-surface-elevated" />
+                <span className="text-[9px] font-black uppercase tracking-[0.2em] text-on-surface-variant">
+                  Ранее
+                </span>
+                <span className="h-px flex-1 bg-surface-elevated" />
+              </div>
+            )}
+            <div className="space-y-5 pt-5">
+              {rest.map((sp, i) => (
+                <ProgressBar
+                  key={sp.skill_id}
+                  label={sp.skill_name}
+                  value={sp.points_in_level}
+                  max={10}
+                  variant={i % 2 === 0 ? "secondary" : "primary"}
+                  sublabel={`${sp.points_in_level}/10 · Lv.${sp.level}`}
+                  delta={deltas[sp.skill_id]}
+                  isNew={newIds.includes(sp.skill_id)}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {rest.length > 0 && !showAll && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="mt-5 w-full flex items-center justify-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-on-surface-variant"
+        >
+          <span className="material-symbols-outlined text-sm">expand_more</span>
+          Все скиллы ({rest.length})
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -4,6 +4,8 @@ interface ProgressBarProps {
   variant?: "primary" | "secondary" | "orange";
   label: string;
   sublabel?: string;
+  delta?: number;
+  isNew?: boolean;
 }
 
 export default function ProgressBar({
@@ -12,8 +14,12 @@ export default function ProgressBar({
   variant = "primary",
   label,
   sublabel,
+  delta,
+  isNew,
 }: ProgressBarProps) {
   const percentage = Math.min(100, Math.max(0, (value / max) * 100));
+  const prevPercentage = delta ? Math.min(100, Math.max(0, ((value - delta) / max) * 100)) : percentage;
+  const hasDelta = !!(delta && delta > 0);
 
   const barClasses: Record<string, string> = {
     primary: "kinetic-gradient bar-glow-primary",
@@ -33,23 +39,53 @@ export default function ProgressBar({
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-xs font-black uppercase tracking-wider text-on-surface">
           {label}
+          {isNew && !hasDelta && (
+            <span
+              className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-md text-[9px] font-black tracking-widest leading-none"
+              style={{ backgroundColor: "#cafd00", color: "#0a0a0a" }}
+            >
+              NEW
+            </span>
+          )}
         </span>
-        {sublabel && (
-          <span className={`text-xs font-bold ${sublabelClasses[variant]}`}>
-            {sublabel}
-          </span>
-        )}
+        <div className="flex items-center gap-1.5">
+          {sublabel && (
+            <span className={`text-xs font-bold ${sublabelClasses[variant]}`}>
+              {sublabel}
+            </span>
+          )}
+          {hasDelta && (
+            <span
+              className="delta-badge-pop inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-black leading-none"
+              style={{ backgroundColor: "#cafd00", color: "#0a0a0a" }}
+            >
+              +{delta}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Bar */}
-      <div className="h-1.5 w-full rounded-full bg-surface-elevated">
+      <div className="h-1.5 w-full rounded-full bg-surface-elevated relative overflow-hidden">
+        {/* Dimmed delta — full reach (0 → percentage), reduced opacity.
+            The track clip handles rounding; the solid base on top draws over
+            the "old" portion, so the seam is exactly the base's right edge. */}
+        {hasDelta && (
+          <div
+            className={`absolute inset-y-0 left-0 h-full transition-all duration-500 ${barClasses[variant]}`}
+            style={{
+              width: `${percentage}%`,
+              opacity: 0.35,
+            }}
+          />
+        )}
+        {/* Solid base — "old" progress, drawn on top of the dimmed layer.
+            No per-side radius needed: it stops mid-bar with a clean straight
+            edge, and the track's overflow-hidden rounds the outer ends. */}
         <div
-          className={`h-full rounded-full transition-all duration-500 ${barClasses[variant]}`}
+          className={`absolute inset-y-0 left-0 h-full transition-all duration-500 ${barClasses[variant]}`}
           style={{
-            width: `${percentage}%`,
-            ...(variant === "orange"
-              ? { boxShadow: "0 0 8px rgba(255, 149, 0, 0.5)" }
-              : {}),
+            width: `${hasDelta ? prevPercentage : percentage}%`,
           }}
         />
       </div>

--- a/src/lib/actions/dashboard.ts
+++ b/src/lib/actions/dashboard.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Marks dashboard data as "seen" for the given user:
+ * - Sets skill_progress.points_seen = points for every skill (so deltas reset to 0).
+ * - Sets goals.seen_at = now() for every goal where seen_at IS NULL (so NEW badge clears).
+ *
+ * Only the student themselves may mark their own data.
+ */
+export async function markDashboardSeen(
+  userId: string
+): Promise<{ success: true } | { success: false; error: string }> {
+  try {
+    const user = await getSession();
+    if (!user) return { success: false, error: "Not authenticated" };
+    if (user.id !== userId) return { success: false, error: "Forbidden" };
+
+    const supabase = await createClient();
+
+    // 1) Snapshot current skill points into points_seen.
+    const { data: skills, error: skillsFetchError } = await supabase
+      .from("skill_progress")
+      .select("id, points")
+      .eq("user_id", userId);
+
+    if (skillsFetchError) {
+      return { success: false, error: skillsFetchError.message };
+    }
+
+    // Only update rows where points_seen would actually change is unnecessary —
+    // a per-row update keeps points_seen in sync with the current points value.
+    for (const sp of skills ?? []) {
+      const { error: updError } = await supabase
+        .from("skill_progress")
+        .update({ points_seen: sp.points })
+        .eq("id", sp.id);
+      if (updError) {
+        return { success: false, error: updError.message };
+      }
+    }
+
+    // 2) Stamp seen_at on goals the student hasn't seen yet.
+    const { error: goalsError } = await supabase
+      .from("goals")
+      .update({ seen_at: new Date().toISOString() })
+      .eq("user_id", userId)
+      .is("seen_at", null);
+
+    if (goalsError) {
+      return { success: false, error: goalsError.message };
+    }
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/src/lib/dashboard/data.ts
+++ b/src/lib/dashboard/data.ts
@@ -16,12 +16,14 @@ export interface DashboardGoal {
   problems: { id: number; name: string; category_name: string }[];
   total_sessions: number;
   completed_sessions: number;
+  is_new: boolean;
 }
 
 export interface DashboardSkill {
   skill_id: number;
   skill_name: string;
   points: number;
+  points_seen: number | null;
   level: number;
   points_in_level: number;
 }
@@ -195,6 +197,7 @@ export async function loadDashboardData(
       problems,
       total_sessions: totalByGoal.get(id) ?? 0,
       completed_sessions: completedByGoal.get(id) ?? 0,
+      is_new: goal.seen_at == null,
     };
   });
 
@@ -207,6 +210,7 @@ export async function loadDashboardData(
         skill_id: sp.skill_id as number,
         skill_name: (skill?.[nameCol] as string) || "",
         points,
+        points_seen: (sp.points_seen as number | null) ?? null,
         level,
         points_in_level,
       };


### PR DESCRIPTION
## Что сделано

Система отображения обновлений для ученика — бейджи NEW и +1 когда тренер добавил цель, скилл или балл.

## База данных
- `skill_progress`: добавлены `updated_at` (авто-триггер при изменении `points`) и `points_seen` (снапшот на момент просмотра)
- `goals`: добавлено `seen_at` (null = никогда не видел = NEW)

## Логика
- `markDashboardSeen()` — server action, снапшотит `points_seen = points` и ставит `seen_at` на все новые цели. Вызывается через `MarkSeenEffect` с задержкой 3 сек после открытия дашборда учеником
- `DashboardView` вычисляет `delta` и `isNew` из реальных полей БД (не mock)

## UI
- `ProgressBar`: слоистый подход — сначала тусклый бар на всю длину, поверх сплошной «старый» прогресс. Граница прямая, без скруглённых артефактов
- Бейдж `+1`: CSS-only pop-in анимация (`scale 0→1.18→0.94→1`), `prefers-reduced-motion` учтён
- `SkillProgressSection`: обновлённые скиллы сверху, остальные скрыты под кнопкой «Все скиллы» с плавным раскрытием через grid `0fr→1fr`
- Разделитель «Ранее» между обновлёнными и старыми скиллами
- Бейдж NEW на целях и скиллах — зелёный (`#cafd00`), без обрезания