### PR TITLE
feat: клиентская компрессия аудио + invite flow через Google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "priceless-poincare",
       "version": "0.1.0",
       "dependencies": {
+        "@breezystack/lamejs": "^1.2.7",
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
         "firebase": "^12.12.1",
@@ -281,6 +282,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@breezystack/lamejs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz",
+      "integrity": "sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==",
+      "license": "LGPL-3.0"
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -8044,6 +8051,7 @@
       "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@breezystack/lamejs": "^1.2.7",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
     "firebase": "^12.12.1",

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
-import { createSession } from "@/lib/auth/session";
+import { createSession, claimSession } from "@/lib/auth/session";
 
 export async function POST(request: Request) {
   try {
-    const { idToken } = await request.json();
+    const { idToken, claimToken } = await request.json();
     if (!idToken) return NextResponse.json({ error: "Missing idToken" }, { status: 400 });
 
-    const user = await createSession(idToken);
+    const user = claimToken
+      ? await claimSession(idToken, claimToken)
+      : await createSession(idToken);
     return NextResponse.json({ ok: true, user });
   } catch (err) {
     console.error("Session creation failed:", err);

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 
@@ -54,21 +55,7 @@ export default async function InvitePage({ params }: PageProps) {
     );
   }
 
-  return (
-    <main className="mx-auto max-w-md p-8 text-center">
-      <h1 className="text-2xl font-semibold mb-2">
-        Привет{state.fullName ? `, ${state.fullName}` : ""}!
-      </h1>
-      <p className="text-neutral-600 mb-6">
-        Ваш тренер уже создал для вас профиль в Nivel. Войдите через Гречку,
-        чтобы привязать его к вашему аккаунту.
-      </p>
-      <a
-        href={`/api/auth/grechka?claim=${encodeURIComponent(state.token)}`}
-        className="inline-block rounded-md bg-black text-white px-6 py-3 font-medium"
-      >
-        Войти через Гречку
-      </a>
-    </main>
-  );
+  const qs = new URLSearchParams({ claim: state.token });
+  if (state.fullName) qs.set("name", state.fullName);
+  redirect(`/login?${qs.toString()}`);
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 
+export const dynamic = "force-dynamic";
+
 type PageProps = {
   params: Promise<{ token: string }>;
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,6 +19,8 @@ const ERROR_MESSAGES: Record<string, string> = {
 function LoginContent() {
   const searchParams = useSearchParams();
   const urlError = searchParams.get("error");
+  const claimToken = searchParams.get("claim");
+  const inviteName = searchParams.get("name");
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -32,10 +34,13 @@ function LoginContent() {
       const result = await signInWithPopup(auth, provider);
       const idToken = await result.user.getIdToken();
 
+      const body: Record<string, string> = { idToken };
+      if (claimToken) body.claimToken = claimToken;
+
       const res = await fetch("/api/auth/session", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ idToken }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) throw new Error("Session creation failed");
@@ -48,6 +53,10 @@ function LoginContent() {
   };
 
   const displayError = error ?? (urlError ? (ERROR_MESSAGES[urlError] ?? urlError) : null);
+
+  const grechkaAction = claimToken
+    ? `/api/auth/grechka?claim=${encodeURIComponent(claimToken)}`
+    : "/api/auth/grechka";
 
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6">
@@ -62,16 +71,26 @@ function LoginContent() {
           </p>
         </div>
 
+        {/* Invite welcome banner */}
+        {claimToken && (
+          <div className="rounded-2xl bg-surface-card p-4 text-sm space-y-1">
+            {inviteName && (
+              <p className="font-bold text-on-surface">Привет, {inviteName}!</p>
+            )}
+            <p className="text-on-surface-variant">
+              Ваш тренер уже создал для вас профиль. Войдите, чтобы привязать его к своему аккаунту.
+            </p>
+          </div>
+        )}
+
         <div className="space-y-4">
           {/* Grechka Sign In */}
-          <form action="/api/auth/grechka" method="GET">
-            <button
-              type="submit"
-              className="w-full flex items-center justify-center gap-3 bg-primary text-black font-semibold py-4 px-6 rounded-2xl hover:opacity-90 transition-opacity active:scale-[0.98]"
-            >
-              Войти через Гречку
-            </button>
-          </form>
+          <a
+            href={grechkaAction}
+            className="w-full flex items-center justify-center gap-3 bg-primary text-black font-semibold py-4 px-6 rounded-2xl hover:opacity-90 transition-opacity active:scale-[0.98]"
+          >
+            Войти через Гречку
+          </a>
 
           {/* Google Sign In */}
           <button

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,7 +20,6 @@ function LoginContent() {
   const searchParams = useSearchParams();
   const urlError = searchParams.get("error");
   const claimToken = searchParams.get("claim");
-  const inviteName = searchParams.get("name");
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -70,18 +69,6 @@ function LoginContent() {
             Падел-платформа для тренеров и игроков
           </p>
         </div>
-
-        {/* Invite welcome banner */}
-        {claimToken && (
-          <div className="rounded-2xl bg-surface-card p-4 text-sm space-y-1">
-            {inviteName && (
-              <p className="font-bold text-on-surface">Привет, {inviteName}!</p>
-            )}
-            <p className="text-on-surface-variant">
-              Ваш тренер уже создал для вас профиль. Войдите, чтобы привязать его к своему аккаунту.
-            </p>
-          </div>
-        )}
 
         <div className="space-y-4">
           {/* Grechka Sign In */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { getFirebaseAuth } from "@/lib/firebase/client";
@@ -19,7 +19,17 @@ const ERROR_MESSAGES: Record<string, string> = {
 function LoginContent() {
   const searchParams = useSearchParams();
   const urlError = searchParams.get("error");
-  const claimToken = searchParams.get("claim");
+
+  // Читаем claim из URL один раз и сразу убираем из адресной строки
+  const claimRef = useRef(searchParams.get("claim"));
+  const claimToken = claimRef.current;
+  useEffect(() => {
+    if (claimToken) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("claim");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, [claimToken]);
 
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);

--- a/src/app/sessions/[id]/page.tsx
+++ b/src/app/sessions/[id]/page.tsx
@@ -1,3 +1,5 @@
+export const maxDuration = 300;
+
 import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";

--- a/src/components/sessions/AudioUploader.tsx
+++ b/src/components/sessions/AudioUploader.tsx
@@ -3,7 +3,62 @@
 import { useRef, useState } from "react";
 import { requestAudioUploadUrl, transcribeSession } from "@/lib/actions/audio";
 
-type UploadState = "idle" | "uploading" | "processing" | "done" | "error";
+type UploadState = "idle" | "compressing" | "uploading" | "processing" | "done" | "error";
+
+const AUDIO_EXTS = new Set(["m4a", "mp3", "wav", "ogg", "webm", "mp4", "aac", "opus"]);
+
+async function compressAudio(file: File): Promise<File> {
+  const { Mp3Encoder } = await import("@breezystack/lamejs");
+
+  const arrayBuffer = await file.arrayBuffer();
+  const audioCtx = new AudioContext();
+  let decoded: AudioBuffer;
+  try {
+    decoded = await audioCtx.decodeAudioData(arrayBuffer);
+  } finally {
+    await audioCtx.close();
+  }
+
+  const targetRate = 16000;
+  let offlineCtx: OfflineAudioContext;
+  try {
+    offlineCtx = new OfflineAudioContext(
+      1,
+      Math.ceil(decoded.duration * targetRate),
+      targetRate
+    );
+  } catch {
+    // Safari < 14.5 не поддерживает произвольный sampleRate
+    offlineCtx = new OfflineAudioContext(
+      1,
+      Math.ceil(decoded.duration * decoded.sampleRate),
+      decoded.sampleRate
+    );
+  }
+  const src = offlineCtx.createBufferSource();
+  src.buffer = decoded;
+  src.connect(offlineCtx.destination);
+  src.start();
+  const rendered = await offlineCtx.startRendering();
+
+  const pcm = rendered.getChannelData(0);
+  const int16 = new Int16Array(pcm.length);
+  for (let i = 0; i < pcm.length; i++) {
+    int16[i] = Math.max(-32768, Math.min(32767, pcm[i] * 32767));
+  }
+
+  const encoder = new Mp3Encoder(1, rendered.sampleRate, 16);
+  const blockSize = 1152;
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < int16.length; i += blockSize) {
+    const buf = encoder.encodeBuffer(int16.subarray(i, i + blockSize));
+    if (buf.length > 0) chunks.push(new Uint8Array(buf));
+  }
+  const tail = encoder.flush();
+  if (tail.length > 0) chunks.push(new Uint8Array(tail));
+
+  return new File(chunks.map((c) => c.buffer as ArrayBuffer), "audio.mp3", { type: "audio/mpeg" });
+}
 
 export function AudioUploader({ sessionId }: { sessionId: string }) {
   const [state, setState] = useState<UploadState>("idle");
@@ -12,23 +67,36 @@ export function AudioUploader({ sessionId }: { sessionId: string }) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   async function handleFile(file: File) {
-    if (!file.type.startsWith("audio/")) {
+    const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+    if (!file.type.startsWith("audio/") && !AUDIO_EXTS.has(ext)) {
       setErrorMsg("Только аудио-файлы (m4a, mp3, wav…)");
       setState("error");
       return;
     }
-    if (file.size > 100 * 1024 * 1024) {
-      setErrorMsg("Файл слишком большой — максимум 100 MB");
+    if (file.size > 150 * 1024 * 1024) {
+      setErrorMsg("Файл слишком большой — максимум 150 MB (~90 мин). Сожмите аудио перед загрузкой.");
       setState("error");
       return;
+    }
+
+    let uploadFile = file;
+    if (file.size > 20 * 1024 * 1024) {
+      setState("compressing");
+      try {
+        uploadFile = await compressAudio(file);
+      } catch (err: unknown) {
+        setState("error");
+        setErrorMsg(err instanceof Error ? err.message : "Ошибка при сжатии аудио");
+        return;
+      }
     }
 
     setState("uploading");
     setProgress(0);
     setErrorMsg("");
 
-    const ext = file.name.split(".").pop()?.toLowerCase() ?? "m4a";
-    const urlResult = await requestAudioUploadUrl(sessionId, ext);
+    const uploadExt = uploadFile.name.split(".").pop()?.toLowerCase() ?? "mp3";
+    const urlResult = await requestAudioUploadUrl(sessionId, uploadExt);
     if ("error" in urlResult) {
       setState("error");
       setErrorMsg(urlResult.error);
@@ -41,7 +109,7 @@ export function AudioUploader({ sessionId }: { sessionId: string }) {
       await new Promise<void>((resolve, reject) => {
         const xhr = new XMLHttpRequest();
         xhr.open("PUT", uploadUrl);
-        xhr.setRequestHeader("Content-Type", file.type);
+        xhr.setRequestHeader("Content-Type", uploadFile.type);
         xhr.upload.onprogress = (e) => {
           if (e.lengthComputable) setProgress(Math.round((e.loaded / e.total) * 100));
         };
@@ -50,7 +118,7 @@ export function AudioUploader({ sessionId }: { sessionId: string }) {
           else reject(new Error(`Upload failed (${xhr.status})`));
         };
         xhr.onerror = () => reject(new Error("Сетевая ошибка при загрузке"));
-        xhr.send(file);
+        xhr.send(uploadFile);
       });
     } catch (err: unknown) {
       setState("error");
@@ -88,7 +156,7 @@ export function AudioUploader({ sessionId }: { sessionId: string }) {
     );
   }
 
-  const isActive = state === "uploading" || state === "processing";
+  const isActive = state === "compressing" || state === "uploading" || state === "processing";
 
   return (
     <div className="space-y-3">
@@ -121,9 +189,16 @@ export function AudioUploader({ sessionId }: { sessionId: string }) {
             </span>
             <p className="text-sm font-bold text-on-surface">Загрузить аудио</p>
             <p className="text-xs text-on-surface-variant mt-1">
-              Перетащите файл или нажмите · m4a, mp3, wav · до 100 MB
+              Перетащите файл или нажмите · m4a, mp3, wav · до 150 MB · большие файлы сжимаются автоматически
             </p>
           </>
+        )}
+
+        {state === "compressing" && (
+          <div className="space-y-2">
+            <p className="text-sm font-bold text-on-surface">Сжимаем аудио…</p>
+            <p className="text-xs text-on-surface-variant">Займёт несколько секунд, не закрывайте вкладку</p>
+          </div>
         )}
 
         {state === "uploading" && (

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -1,5 +1,7 @@
 "use server";
 
+export const maxDuration = 300;
+
 import { postprocessTranscript } from "@/lib/stt/postprocess";
 import { revalidatePath } from "next/cache";
 import { randomUUID } from "crypto";

--- a/src/lib/actions/audio.ts
+++ b/src/lib/actions/audio.ts
@@ -1,7 +1,5 @@
 "use server";
 
-export const maxDuration = 300;
-
 import { postprocessTranscript } from "@/lib/stt/postprocess";
 import { revalidatePath } from "next/cache";
 import { randomUUID } from "crypto";

--- a/src/lib/stt/groq.ts
+++ b/src/lib/stt/groq.ts
@@ -8,7 +8,7 @@ function requireGroqKey(): string {
 
 const GROQ_API_KEY = requireGroqKey();
 
-const GROQ_TIMEOUT_MS = 120_000;
+const GROQ_TIMEOUT_MS = 280_000;
 
 export async function transcribeAudio(
   audioBuffer: Buffer,


### PR DESCRIPTION
## Что сделано

### Клиентская компрессия аудио
- `AudioUploader`: файлы >20 MB сжимаются в браузере до MP3 16 kbps mono через Web Audio API + `@breezystack/lamejs` — 1 час аудио → ~7 MB, укладывается в лимит Groq 25 MB
- Лимит файла: 100 MB → 150 MB (~90 мин)
- Состояние `"compressing"` в UI с подсказкой не закрывать вкладку
- Фикс MIME-проверки для iOS Safari (fallback на расширение файла)
- Groq таймаут: 120 s → 280 s
- `maxDuration = 300` на странице сессии для Vercel

### Invite flow
- `/invite/[token]` редиректит на `/login?claim=TOKEN` вместо отдельной страницы
- Login page передаёт `claim` в обе кнопки входа (Гречка и Google)
- Google sign-in на invite flow вызывает `claimSession()` — привязывает аккаунт
- `/api/auth/session` принимает опциональный `claimToken`
- `claim` убирается из URL через `history.replaceState` сразу после чтения
- `force-dynamic` на invite странице — всегда свежий статус токена из БД

### Инфраструктура
- Добавлены env vars для Preview окружения на Vercel (Firebase, SESSION_SECRET, Supabase)

## Проверить
- Загрузить аудио >20 MB → должно появиться "Сжимаем аудио…", файл загружается меньшего размера
- Открыть invite-ссылку → редирект на `/login`, claim пропадает из URL после загрузки
- Войти через Google по invite-ссылке → аккаунт привязывается, редирект на `/dashboard`