### PR TITLE
feat(telegram): уведомления ученикам через бота

### DIFF
--- a/scripts/setup-telegram-webhook.mjs
+++ b/scripts/setup-telegram-webhook.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Usage:
+//   TELEGRAM_BOT_TOKEN=... TELEGRAM_WEBHOOK_SECRET=... \
+//   [TELEGRAM_WEBHOOK_URL=https://your.app/api/telegram/webhook] \
+//   node scripts/setup-telegram-webhook.mjs
+
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+const url = process.env.TELEGRAM_WEBHOOK_URL ?? "https://nivel-five.vercel.app/api/telegram/webhook";
+
+if (!token || !secret) {
+  console.error("Need TELEGRAM_BOT_TOKEN and TELEGRAM_WEBHOOK_SECRET in env.");
+  process.exit(1);
+}
+
+const res = await fetch(`https://api.telegram.org/bot${token}/setWebhook`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url,
+    secret_token: secret,
+    allowed_updates: ["message"],
+    drop_pending_updates: true,
+  }),
+});
+
+const body = await res.text();
+console.log("HTTP", res.status);
+console.log(body);
+if (!res.ok) process.exit(1);

--- a/src/app/api/cron/session-reminders/route.ts
+++ b/src/app/api/cron/session-reminders/route.ts
@@ -1,0 +1,53 @@
+import { createClient } from "@/lib/supabase/server";
+import { notifySessionReminder } from "@/lib/telegram/notify";
+
+export const dynamic = "force-dynamic";
+
+const HOURS_BEFORE = 2;
+const WINDOW_MIN = 15;
+
+type Row = {
+  id: string;
+  scheduled_at: string;
+  goals: { user_id: string } | null;
+};
+
+export async function GET(req: Request): Promise<Response> {
+  const expected = process.env.CRON_SECRET;
+  if (!expected || req.headers.get("authorization") !== `Bearer ${expected}`) {
+    return new Response("unauthorized", { status: 401 });
+  }
+
+  const now = Date.now();
+  const targetMin = new Date(now + (HOURS_BEFORE * 60 - WINDOW_MIN) * 60_000).toISOString();
+  const targetMax = new Date(now + (HOURS_BEFORE * 60 + WINDOW_MIN) * 60_000).toISOString();
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("sessions")
+    .select("id, scheduled_at, goals!inner(user_id)")
+    .eq("status", "planned")
+    .is("reminder_sent_at", null)
+    .gte("scheduled_at", targetMin)
+    .lte("scheduled_at", targetMax);
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as unknown as Row[];
+  let processed = 0;
+
+  for (const s of rows) {
+    const studentId = s.goals?.user_id;
+    if (!studentId || !s.scheduled_at) continue;
+    await notifySessionReminder(studentId, s.id, s.scheduled_at, HOURS_BEFORE);
+    await supabase
+      .from("sessions")
+      .update({ reminder_sent_at: new Date().toISOString() })
+      .eq("id", s.id);
+    processed++;
+  }
+
+  return Response.json({ processed, scanned: rows.length });
+}

--- a/src/app/api/cron/session-reminders/route.ts
+++ b/src/app/api/cron/session-reminders/route.ts
@@ -37,11 +37,19 @@ export async function GET(req: Request): Promise<Response> {
 
   const rows = (data ?? []) as unknown as Row[];
   let processed = 0;
+  let failed = 0;
 
   for (const s of rows) {
-    const studentId = s.goals?.user_id;
+    const goalsField = s.goals as unknown as { user_id: string } | { user_id: string }[] | null;
+    const studentId = Array.isArray(goalsField) ? goalsField[0]?.user_id : goalsField?.user_id;
     if (!studentId || !s.scheduled_at) continue;
-    await notifySessionReminder(studentId, s.id, s.scheduled_at, HOURS_BEFORE);
+
+    const result = await notifySessionReminder(studentId, s.id, s.scheduled_at, HOURS_BEFORE);
+    if (result === "failed") {
+      // Не помечаем reminder_sent_at — следующий тик попробует ещё раз.
+      failed++;
+      continue;
+    }
     await supabase
       .from("sessions")
       .update({ reminder_sent_at: new Date().toISOString() })
@@ -49,5 +57,5 @@ export async function GET(req: Request): Promise<Response> {
     processed++;
   }
 
-  return Response.json({ processed, scanned: rows.length });
+  return Response.json({ processed, failed, scanned: rows.length });
 }

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -27,9 +27,14 @@ const OK = new Response("ok", { status: 200 });
 
 export async function POST(req: Request): Promise<Response> {
   const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  if (!secret) {
+    // Fail loudly: missing env is a deploy bug, not a Telegram-side issue.
+    console.error("[tg] TELEGRAM_WEBHOOK_SECRET is not set — webhook is misconfigured");
+    return new Response("misconfigured", { status: 500 });
+  }
   const headerSecret = req.headers.get("x-telegram-bot-api-secret-token");
-  if (!secret || headerSecret !== secret) {
-    // Silently 200 so Telegram doesn't retry on misconfigured webhooks.
+  if (headerSecret !== secret) {
+    // Silently 200 so legitimate Telegram retries don't pile up if a real request gets here.
     return OK;
   }
 

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -1,0 +1,117 @@
+import { createClient } from "@/lib/supabase/server";
+import { sendMessage } from "@/lib/telegram/client";
+import { consumeLinkToken } from "@/lib/telegram/tokens";
+
+export const dynamic = "force-dynamic";
+
+type TelegramUser = {
+  id: number;
+  username?: string;
+};
+
+type TelegramChat = {
+  id: number;
+};
+
+type TelegramMessage = {
+  text?: string;
+  from?: TelegramUser;
+  chat: TelegramChat;
+};
+
+type TelegramUpdate = {
+  message?: TelegramMessage;
+};
+
+const OK = new Response("ok", { status: 200 });
+
+export async function POST(req: Request): Promise<Response> {
+  const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+  const headerSecret = req.headers.get("x-telegram-bot-api-secret-token");
+  if (!secret || headerSecret !== secret) {
+    // Silently 200 so Telegram doesn't retry on misconfigured webhooks.
+    return OK;
+  }
+
+  let update: TelegramUpdate;
+  try {
+    update = (await req.json()) as TelegramUpdate;
+  } catch {
+    return OK;
+  }
+
+  const message = update.message;
+  if (!message || !message.text) return OK;
+
+  const text = message.text.trim();
+  const chatId = message.chat.id;
+
+  if (text === "/start") {
+    await sendMessage(
+      chatId,
+      "Привет. Чтобы связать аккаунт, открой раздел настроек в Nivel и нажми «Подключить Telegram»."
+    );
+    return OK;
+  }
+
+  if (text.startsWith("/start ")) {
+    const token = text.slice("/start ".length).trim();
+    if (!token) return OK;
+    await handleStartWithToken(token, message, chatId);
+    return OK;
+  }
+
+  return OK;
+}
+
+async function handleStartWithToken(
+  token: string,
+  message: TelegramMessage,
+  chatId: number
+): Promise<void> {
+  try {
+    const consumed = await consumeLinkToken(token);
+    if (!consumed) {
+      await sendMessage(
+        chatId,
+        "Ссылка устарела или уже использована. Открой настройки Nivel и попробуй ещё раз."
+      );
+      return;
+    }
+
+    const supabase = await createClient();
+    const { error } = await supabase
+      .from("telegram_links")
+      .upsert(
+        {
+          profile_id: consumed.profileId,
+          telegram_chat_id: chatId,
+          telegram_user_id: message.from?.id ?? null,
+          username: message.from?.username ?? null,
+          linked_at: new Date().toISOString(),
+          is_active: true,
+        },
+        { onConflict: "profile_id" }
+      );
+
+    if (error) {
+      if (error.code === "23505") {
+        await sendMessage(
+          chatId,
+          "Этот Telegram уже привязан к другому аккаунту Nivel. Сначала отключи его в том аккаунте."
+        );
+        return;
+      }
+      console.error("[tg] upsert link failed", error);
+      await sendMessage(chatId, "Не удалось подключить. Попробуй позже.");
+      return;
+    }
+
+    await sendMessage(
+      chatId,
+      "✅ Подключено к Nivel. Будем писать про новые разборы и тренировки."
+    );
+  } catch (e) {
+    console.error("[tg] handleStartWithToken failed", e);
+  }
+}

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -12,6 +12,7 @@ import PlaytomicConnectBlock from "@/components/playtomic/PlaytomicConnectBlock"
 import SkillProgressSection from "@/components/dashboard/SkillProgressSection";
 import MarkSeenEffect from "@/components/dashboard/MarkSeenEffect";
 import InlineSkillAdder from "@/components/dashboard/edit/InlineSkillAdder";
+import TelegramLinkCard from "@/components/telegram/TelegramLinkCard";
 
 export interface DashboardViewEditable {
   studentId: string;
@@ -73,6 +74,9 @@ export default function DashboardView({ data, locale, editable, previewMode, all
       {!isTrainer && !previewMode && (
         <PlaytomicConnectBlock currentUserId={profile.playtomic_user_id ?? null} />
       )}
+
+      {/* Telegram link — student only */}
+      {!isTrainer && !previewMode && <TelegramLinkCard />}
 
       {/* Empty state — student only */}
       {isEmpty && !isTrainer ? (

--- a/src/components/telegram/TelegramLinkCard.tsx
+++ b/src/components/telegram/TelegramLinkCard.tsx
@@ -1,0 +1,19 @@
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import TelegramLinkCardClient from "./TelegramLinkCardClient";
+
+export default async function TelegramLinkCard() {
+  const user = await getSession();
+  if (!user) return null;
+
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("telegram_links")
+    .select("is_active, username")
+    .eq("profile_id", user.id)
+    .maybeSingle();
+
+  const linked = !!data?.is_active;
+
+  return <TelegramLinkCardClient linked={linked} username={data?.username ?? null} />;
+}

--- a/src/components/telegram/TelegramLinkCardClient.tsx
+++ b/src/components/telegram/TelegramLinkCardClient.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { startTelegramLink, unlinkTelegram } from "@/lib/actions/telegram";
+
+type Props = {
+  linked: boolean;
+  username: string | null;
+};
+
+export default function TelegramLinkCardClient({ linked, username }: Props) {
+  const router = useRouter();
+  const [pending, startT] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onConnect = () => {
+    setError(null);
+    startT(async () => {
+      const res = await startTelegramLink();
+      if (!res.success) {
+        setError(res.error);
+        return;
+      }
+      window.open(res.url, "_blank", "noopener");
+    });
+  };
+
+  const onUnlink = () => {
+    setError(null);
+    startT(async () => {
+      const res = await unlinkTelegram();
+      if (!res.success) {
+        setError(res.error ?? "Не удалось отключить");
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  if (linked) {
+    return (
+      <div className="rounded-2xl bg-surface-container p-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-xl">✅</span>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold truncate">Telegram подключён</p>
+            {username && (
+              <p className="text-xs text-on-surface-variant truncate">@{username}</p>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onUnlink}
+          disabled={pending}
+          className="min-h-11 px-3 text-sm text-on-surface-variant disabled:opacity-50"
+        >
+          Отключить
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-surface-container p-4 space-y-3">
+      <div>
+        <p className="text-sm font-semibold">Подключи Telegram</p>
+        <p className="text-xs text-on-surface-variant mt-0.5">
+          Бот напишет, когда тренер пришлёт новые разборы и за 2 часа до тренировки.
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onConnect}
+          disabled={pending}
+          className="flex-1 min-h-11 rounded-xl bg-primary text-on-primary text-sm font-semibold disabled:opacity-50"
+        >
+          {pending ? "Открываю…" : "Подключить Telegram"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.refresh()}
+          disabled={pending}
+          className="min-h-11 px-3 text-sm text-on-surface-variant disabled:opacity-50"
+          aria-label="Обновить статус"
+          title="Обновить статус"
+        >
+          ↻
+        </button>
+      </div>
+      {error && <p className="text-xs text-error">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/telegram/TelegramLinkCardClient.tsx
+++ b/src/components/telegram/TelegramLinkCardClient.tsx
@@ -69,6 +69,9 @@ export default function TelegramLinkCardClient({ linked, username }: Props) {
         <p className="text-xs text-on-surface-variant mt-0.5">
           Бот напишет, когда тренер пришлёт новые разборы и за 2 часа до тренировки.
         </p>
+        <p className="text-[10px] text-on-surface-variant/70 mt-1">
+          Ссылка одноразовая и действует 15 минут — не пересылай её другим.
+        </p>
       </div>
       <div className="flex items-center gap-2">
         <button

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -226,21 +226,38 @@ export async function setTrainerReviewCompleted(
     return { success: false, error: "Only trainers can finish review" };
   }
 
-  const { data: prev } = await supabase
-    .from("sessions")
-    .select("trainer_review_completed, goal_id, goals!inner(user_id)")
-    .eq("id", sessionId)
-    .single();
+  let transitionedToTrue = false;
 
-  const { error } = await supabase
-    .from("sessions")
-    .update({ trainer_review_completed: completed })
-    .eq("id", sessionId);
+  if (completed === true) {
+    // Atomic guard: only the request that flips false → true wins this update.
+    // Concurrent double-clicks see zero affected rows on the loser.
+    const { data: updatedRows, error } = await supabase
+      .from("sessions")
+      .update({ trainer_review_completed: true })
+      .eq("id", sessionId)
+      .eq("trainer_review_completed", false)
+      .select("id");
 
-  if (error) return { success: false, error: error.message };
+    if (error) return { success: false, error: error.message };
+    transitionedToTrue = (updatedRows?.length ?? 0) > 0;
+  } else {
+    const { error } = await supabase
+      .from("sessions")
+      .update({ trainer_review_completed: false })
+      .eq("id", sessionId);
+    if (error) return { success: false, error: error.message };
+  }
 
-  if (completed === true && prev?.trainer_review_completed !== true) {
-    const studentId = (prev as { goals?: { user_id?: string } | null } | null)?.goals?.user_id;
+  if (transitionedToTrue) {
+    const { data: ctx } = await supabase
+      .from("sessions")
+      .select("goals!inner(user_id)")
+      .eq("id", sessionId)
+      .single();
+
+    const goalsField = (ctx as { goals?: { user_id?: string } | { user_id?: string }[] | null } | null)?.goals;
+    const studentId = Array.isArray(goalsField) ? goalsField[0]?.user_id : goalsField?.user_id;
+
     if (studentId) {
       const { count } = await supabase
         .from("insight_cards")

--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
+import { notifyNewInsights } from "@/lib/telegram/notify";
 
 export async function createSession(
   goalId: string,
@@ -225,12 +226,32 @@ export async function setTrainerReviewCompleted(
     return { success: false, error: "Only trainers can finish review" };
   }
 
+  const { data: prev } = await supabase
+    .from("sessions")
+    .select("trainer_review_completed, goal_id, goals!inner(user_id)")
+    .eq("id", sessionId)
+    .single();
+
   const { error } = await supabase
     .from("sessions")
     .update({ trainer_review_completed: completed })
     .eq("id", sessionId);
 
   if (error) return { success: false, error: error.message };
+
+  if (completed === true && prev?.trainer_review_completed !== true) {
+    const studentId = (prev as { goals?: { user_id?: string } | null } | null)?.goals?.user_id;
+    if (studentId) {
+      const { count } = await supabase
+        .from("insight_cards")
+        .select("id", { count: "exact", head: true })
+        .eq("session_id", sessionId)
+        .eq("trainer_status", "approved");
+      if ((count ?? 0) > 0) {
+        await notifyNewInsights(studentId, sessionId, count ?? 0);
+      }
+    }
+  }
 
   await maybeCompleteSession(sessionId);
 

--- a/src/lib/actions/telegram.ts
+++ b/src/lib/actions/telegram.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+import { createLinkToken } from "@/lib/telegram/tokens";
+
+export type StartLinkResult =
+  | { success: true; url: string }
+  | { success: false; error: string };
+
+export async function startTelegramLink(): Promise<StartLinkResult> {
+  const user = await getSession();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const botUsername = process.env.TELEGRAM_BOT_USERNAME;
+  if (!botUsername) {
+    return { success: false, error: "TELEGRAM_BOT_USERNAME is not set" };
+  }
+
+  try {
+    const token = await createLinkToken(user.id);
+    return { success: true, url: `https://t.me/${botUsername}?start=${token}` };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Failed to create token" };
+  }
+}
+
+export async function unlinkTelegram(): Promise<{ success: boolean; error?: string }> {
+  const user = await getSession();
+  if (!user) return { success: false, error: "Not authenticated" };
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("telegram_links")
+    .update({ is_active: false })
+    .eq("profile_id", user.id);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}

--- a/src/lib/telegram/client.ts
+++ b/src/lib/telegram/client.ts
@@ -1,0 +1,36 @@
+const API_BASE = "https://api.telegram.org";
+
+export type InlineKeyboard = {
+  inline_keyboard: { text: string; url: string }[][];
+};
+
+export type SendMessageOptions = {
+  parse_mode?: "HTML" | "MarkdownV2";
+  reply_markup?: InlineKeyboard;
+  disable_web_page_preview?: boolean;
+};
+
+export type SendResult = {
+  ok: boolean;
+  status: number;
+  forbidden: boolean;
+};
+
+export async function sendMessage(
+  chatId: number | string,
+  text: string,
+  options: SendMessageOptions = {}
+): Promise<SendResult> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error("[tg] TELEGRAM_BOT_TOKEN is not set");
+    return { ok: false, status: 0, forbidden: false };
+  }
+  const res = await fetch(`${API_BASE}/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, ...options }),
+    cache: "no-store",
+  });
+  return { ok: res.ok, status: res.status, forbidden: res.status === 403 };
+}

--- a/src/lib/telegram/notify.ts
+++ b/src/lib/telegram/notify.ts
@@ -19,14 +19,17 @@ async function deactivateLink(profileId: string): Promise<void> {
     .eq("profile_id", profileId);
 }
 
+export type NotifyResult = "sent" | "no_link" | "failed";
+
 async function getActiveChat(profileId: string): Promise<number | null> {
   const supabase = await createClient();
   const { data } = await supabase
     .from("telegram_links")
-    .select("telegram_chat_id, is_active")
+    .select("telegram_chat_id")
     .eq("profile_id", profileId)
+    .eq("is_active", true)
     .maybeSingle();
-  if (!data || !data.is_active) return null;
+  if (!data) return null;
   return Number(data.telegram_chat_id);
 }
 
@@ -34,10 +37,10 @@ export async function notifyNewInsights(
   profileId: string,
   sessionId: string,
   count: number
-): Promise<void> {
+): Promise<NotifyResult> {
   try {
     const chatId = await getActiveChat(profileId);
-    if (chatId === null) return;
+    if (chatId === null) return "no_link";
     const word = plural(count, "новый разбор", "новых разбора", "новых разборов");
     const text = `🎾 Тренер прислал ${count} ${word} с тренировки.`;
     const keyboard: InlineKeyboard = {
@@ -46,9 +49,14 @@ export async function notifyNewInsights(
       ],
     };
     const res = await sendMessage(chatId, text, { reply_markup: keyboard });
-    if (res.forbidden) await deactivateLink(profileId);
+    if (res.forbidden) {
+      await deactivateLink(profileId);
+      return "no_link";
+    }
+    return res.ok ? "sent" : "failed";
   } catch (e) {
     console.error("[tg] notifyNewInsights failed", e);
+    return "failed";
   }
 }
 
@@ -57,12 +65,13 @@ export async function notifySessionReminder(
   sessionId: string,
   scheduledAt: string,
   hoursBefore: number
-): Promise<void> {
+): Promise<NotifyResult> {
   try {
     const chatId = await getActiveChat(profileId);
-    if (chatId === null) return;
+    if (chatId === null) return "no_link";
     const word = plural(hoursBefore, "час", "часа", "часов");
     const date = new Date(scheduledAt);
+    // TODO: brать таймзону из профиля юзера, пока хардкод под основную аудиторию.
     const time = date.toLocaleTimeString("ru-RU", {
       hour: "2-digit",
       minute: "2-digit",
@@ -75,8 +84,13 @@ export async function notifySessionReminder(
       ],
     };
     const res = await sendMessage(chatId, text, { reply_markup: keyboard });
-    if (res.forbidden) await deactivateLink(profileId);
+    if (res.forbidden) {
+      await deactivateLink(profileId);
+      return "no_link";
+    }
+    return res.ok ? "sent" : "failed";
   } catch (e) {
     console.error("[tg] notifySessionReminder failed", e);
+    return "failed";
   }
 }

--- a/src/lib/telegram/notify.ts
+++ b/src/lib/telegram/notify.ts
@@ -1,0 +1,82 @@
+import { createClient } from "@/lib/supabase/server";
+import { sendMessage, type InlineKeyboard } from "./client";
+
+const APP_URL = process.env.NEXT_PUBLIC_NIVEL_URL ?? "https://nivel-five.vercel.app";
+
+function plural(n: number, one: string, few: string, many: string): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod10 === 1 && mod100 !== 11) return one;
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return few;
+  return many;
+}
+
+async function deactivateLink(profileId: string): Promise<void> {
+  const supabase = await createClient();
+  await supabase
+    .from("telegram_links")
+    .update({ is_active: false })
+    .eq("profile_id", profileId);
+}
+
+async function getActiveChat(profileId: string): Promise<number | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("telegram_links")
+    .select("telegram_chat_id, is_active")
+    .eq("profile_id", profileId)
+    .maybeSingle();
+  if (!data || !data.is_active) return null;
+  return Number(data.telegram_chat_id);
+}
+
+export async function notifyNewInsights(
+  profileId: string,
+  sessionId: string,
+  count: number
+): Promise<void> {
+  try {
+    const chatId = await getActiveChat(profileId);
+    if (chatId === null) return;
+    const word = plural(count, "новый разбор", "новых разбора", "новых разборов");
+    const text = `🎾 Тренер прислал ${count} ${word} с тренировки.`;
+    const keyboard: InlineKeyboard = {
+      inline_keyboard: [
+        [{ text: "Открыть в Nivel", url: `${APP_URL}/sessions/${sessionId}/insights` }],
+      ],
+    };
+    const res = await sendMessage(chatId, text, { reply_markup: keyboard });
+    if (res.forbidden) await deactivateLink(profileId);
+  } catch (e) {
+    console.error("[tg] notifyNewInsights failed", e);
+  }
+}
+
+export async function notifySessionReminder(
+  profileId: string,
+  sessionId: string,
+  scheduledAt: string,
+  hoursBefore: number
+): Promise<void> {
+  try {
+    const chatId = await getActiveChat(profileId);
+    if (chatId === null) return;
+    const word = plural(hoursBefore, "час", "часа", "часов");
+    const date = new Date(scheduledAt);
+    const time = date.toLocaleTimeString("ru-RU", {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "Europe/Moscow",
+    });
+    const text = `⏰ Через ${hoursBefore} ${word} тренировка (в ${time}).`;
+    const keyboard: InlineKeyboard = {
+      inline_keyboard: [
+        [{ text: "Открыть в Nivel", url: `${APP_URL}/sessions/${sessionId}` }],
+      ],
+    };
+    const res = await sendMessage(chatId, text, { reply_markup: keyboard });
+    if (res.forbidden) await deactivateLink(profileId);
+  } catch (e) {
+    console.error("[tg] notifySessionReminder failed", e);
+  }
+}

--- a/src/lib/telegram/tokens.ts
+++ b/src/lib/telegram/tokens.ts
@@ -28,6 +28,10 @@ export async function consumeLinkToken(
     .gt("expires_at", new Date().toISOString())
     .select("profile_id")
     .maybeSingle();
-  if (error || !data) return null;
+  if (error) {
+    console.error("[tg] consumeLinkToken db error", error);
+    return null;
+  }
+  if (!data) return null;
   return { profileId: data.profile_id as string };
 }

--- a/src/lib/telegram/tokens.ts
+++ b/src/lib/telegram/tokens.ts
@@ -1,0 +1,33 @@
+import { randomBytes } from "node:crypto";
+import { createClient } from "@/lib/supabase/server";
+
+const TOKEN_TTL_MIN = 15;
+
+export async function createLinkToken(profileId: string): Promise<string> {
+  const supabase = await createClient();
+  const token = randomBytes(24).toString("base64url");
+  const expiresAt = new Date(Date.now() + TOKEN_TTL_MIN * 60_000).toISOString();
+  const { error } = await supabase.from("telegram_link_tokens").insert({
+    token,
+    profile_id: profileId,
+    expires_at: expiresAt,
+  });
+  if (error) throw new Error(`createLinkToken failed: ${error.message}`);
+  return token;
+}
+
+export async function consumeLinkToken(
+  token: string
+): Promise<{ profileId: string } | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("telegram_link_tokens")
+    .update({ used_at: new Date().toISOString() })
+    .eq("token", token)
+    .is("used_at", null)
+    .gt("expires_at", new Date().toISOString())
+    .select("profile_id")
+    .maybeSingle();
+  if (error || !data) return null;
+  return { profileId: data.profile_id as string };
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -64,8 +64,19 @@ export interface Session {
   student_insight: string | null;
   status: "planned" | "completed";
   trainer_review_completed: boolean;
+  scheduled_at: string | null;
+  reminder_sent_at: string | null;
   completed_at: string | null;
   created_at: string;
+}
+
+export interface TelegramLink {
+  profile_id: string;
+  telegram_chat_id: number;
+  telegram_user_id: number | null;
+  username: string | null;
+  linked_at: string;
+  is_active: boolean;
 }
 
 export type InsightCardSource = "manual" | "ai" | "ai-paste";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,8 @@ export async function proxy(request: NextRequest) {
   const isPublic =
     pathname === "/login" ||
     pathname.startsWith("/api/auth/") ||
+    pathname.startsWith("/api/telegram/") ||
+    pathname.startsWith("/api/cron/") ||
     pathname.startsWith("/invite/");
 
   const session = request.cookies.get("__session")?.value;

--- a/supabase/migrations/018_telegram_links.sql
+++ b/supabase/migrations/018_telegram_links.sql
@@ -1,0 +1,25 @@
+-- Telegram chat linkage per profile.
+create table if not exists telegram_links (
+  profile_id uuid primary key references profiles(id) on delete cascade,
+  telegram_chat_id bigint not null,
+  telegram_user_id bigint,
+  username text,
+  linked_at timestamptz not null default now(),
+  is_active boolean not null default true
+);
+
+create unique index if not exists telegram_links_chat_id_uniq
+  on telegram_links (telegram_chat_id)
+  where is_active = true;
+
+-- One-time tokens for /start <token> deep-link flow.
+create table if not exists telegram_link_tokens (
+  token text primary key,
+  profile_id uuid not null references profiles(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  used_at timestamptz
+);
+
+create index if not exists telegram_link_tokens_profile_idx
+  on telegram_link_tokens (profile_id);

--- a/supabase/migrations/019_sessions_reminder_sent_at.sql
+++ b/supabase/migrations/019_sessions_reminder_sent_at.sql
@@ -1,0 +1,5 @@
+alter table sessions add column if not exists reminder_sent_at timestamptz;
+
+create index if not exists sessions_reminder_lookup_idx
+  on sessions (scheduled_at)
+  where status = 'planned' and reminder_sent_at is null;

--- a/supabase/migrations/020_session_reminders_cron.sql
+++ b/supabase/migrations/020_session_reminders_cron.sql
@@ -1,0 +1,27 @@
+-- Schedules a cron job to ping the session-reminders endpoint every 15 minutes.
+-- Prerequisite: app.cron_secret GUC must be set, e.g.
+--   ALTER DATABASE postgres SET app.cron_secret = '<same value as Vercel CRON_SECRET>';
+-- After running ALTER DATABASE, reconnect (a new SQL session) before applying this migration.
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+do $$
+declare j_id int;
+begin
+  select jobid into j_id from cron.job where jobname = 'session-reminders';
+  if j_id is not null then
+    perform cron.unschedule(j_id);
+  end if;
+end $$;
+
+select cron.schedule(
+  'session-reminders',
+  '*/15 * * * *',
+  $$
+  select net.http_get(
+    url := 'https://nivel-five.vercel.app/api/cron/session-reminders',
+    headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.cron_secret'))
+  );
+  $$
+);

--- a/supabase/migrations/020_session_reminders_cron.sql
+++ b/supabase/migrations/020_session_reminders_cron.sql
@@ -1,7 +1,8 @@
 -- Schedules a cron job to ping the session-reminders endpoint every 15 minutes.
--- Prerequisite: app.cron_secret GUC must be set, e.g.
+-- Prerequisites: set both GUCs before applying, then reconnect:
 --   ALTER DATABASE postgres SET app.cron_secret = '<same value as Vercel CRON_SECRET>';
--- After running ALTER DATABASE, reconnect (a new SQL session) before applying this migration.
+--   ALTER DATABASE postgres SET app.nivel_url   = 'https://nivel-five.vercel.app';
+-- Reconnect (new SQL session) so cron.schedule reads the fresh GUCs.
 
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
@@ -20,7 +21,7 @@ select cron.schedule(
   '*/15 * * * *',
   $$
   select net.http_get(
-    url := 'https://nivel-five.vercel.app/api/cron/session-reminders',
+    url := current_setting('app.nivel_url') || '/api/cron/session-reminders',
     headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.cron_secret'))
   );
   $$


### PR DESCRIPTION
## Summary

MVP-уведомления для учеников через Telegram-бота. Решает проблему iOS Web Push (нужна установка PWA на главный экран) тем что использует канал, который у всех уже стоит.

**Сценарии:**
- Когда тренер жмёт "Finish review" на сессии — ученик получает один пуш: «🎾 Тренер прислал N разборов» + кнопка на swipe-экран.
- За 2 часа до `sessions.scheduled_at` (planned) — пуш «⏰ Через 2 часа тренировка» + ссылка.

**Auth flow:** одноразовый токен (15 мин) → `t.me/<bot>?start=<token>` → webhook ловит `/start <token>` → атомарно валидирует → upsert в `telegram_links`.

**Cron:** `pg_cron + pg_net` в Supabase (Vercel Pro не нужен), тикает каждые 15 мин, дёргает `/api/cron/session-reminders` с `CRON_SECRET`.

## Что внутри

- Миграции `018` (telegram_links + telegram_link_tokens), `019` (sessions.reminder_sent_at + индекс). Применены через Management API.
- Миграция `020` (pg_cron schedule) — **применять руками после деплоя**, см. ниже.
- Webhook `src/app/api/telegram/webhook/route.ts` (проверка secret_token, 500 при отсутствии env, обработка только `/start [token]`).
- Cron `src/app/api/cron/session-reminders/route.ts` (Bearer CRON_SECRET, retry при failure через `reminder_sent_at IS NULL`).
- Lib `src/lib/telegram/{client,notify,tokens}.ts`. `notify*` возвращают `'sent' | 'no_link' | 'failed'`.
- Server actions `src/lib/actions/telegram.ts` + атомарная точка `notifyNewInsights` в `setTrainerReviewCompleted` (transition false→true через UPDATE с фильтром).
- UI `src/components/telegram/TelegramLinkCard*.tsx` на дашборде ученика.
- `scripts/setup-telegram-webhook.mjs` для setWebhook.

## Что нужно сделать руками после мержа

### 1. Env-переменные в Vercel (production + preview + development)

- `TELEGRAM_BOT_TOKEN` — токен от @BotFather
- `TELEGRAM_BOT_USERNAME` — имя бота без `@` (для построения `t.me/<bot>?start=...`)
- `TELEGRAM_WEBHOOK_SECRET` — `openssl rand -hex 32`
- `CRON_SECRET` — `openssl rand -hex 32`

### 2. Деплой в prod

### 3. Регистрация webhook (один раз)

```bash
TELEGRAM_BOT_TOKEN=... TELEGRAM_WEBHOOK_SECRET=... \
  node scripts/setup-telegram-webhook.mjs
```

### 4. Прописать оба GUC в Supabase

Открой SQL Editor в Supabase и выполни:

```sql
alter database postgres set app.cron_secret = '<тот же CRON_SECRET что в Vercel>';
alter database postgres set app.nivel_url   = 'https://nivel-five.vercel.app';
```

**Важно**: после `ALTER DATABASE` переоткрой SQL Editor — новые сессии читают свежие значения. Без этого следующий шаг провалится с ошибкой `unrecognized configuration parameter`.

### 5. Применить миграцию 020 (pg_cron schedule)

В новой SQL Editor сессии (после шага 4) выполни содержимое `supabase/migrations/020_session_reminders_cron.sql`, либо через Management API:

```bash
jq -Rs '{query:.}' < supabase/migrations/020_session_reminders_cron.sql | \
  curl -s -X POST \
  "https://api.supabase.com/v1/projects/gqcyaxxhvyvpzuhoysis/database/query" \
  -H "Authorization: Bearer \$SUPABASE_ACCESS_TOKEN" \
  -H "Content-Type: application/json" -d @-
```

### 6. Проверка cron

```sql
-- Job создан?
select jobid, schedule, jobname from cron.job where jobname = 'session-reminders';

-- Через ≤15 минут — пинги доходят?
select id, status_code, error_msg, created
from net._http_response
order by id desc
limit 5;
```

Должен быть `status_code = 200`. Если `401` — GUC `app.cron_secret` не совпадает с `CRON_SECRET` в Vercel. Если `connection refused` / `dns error` — проверь `app.nivel_url`.

## Test plan

- [ ] Открыть `/dashboard` под ученика — карточка «Подключить Telegram» видна, кнопка ≥44px, есть предупреждение про одноразовость ссылки
- [ ] Клик → открывается `t.me/<bot>?start=<token>` в новой вкладке
- [ ] Жмём Start в TG → приходит «✅ Подключено к Nivel»
- [ ] В Supabase: `select * from telegram_links` — есть запись с `is_active=true`
- [ ] Под тренером открыть сессию ученика, апрувнуть карточки, нажать "Finish review" → один пуш в TG с `Открыть в Nivel`
- [ ] Клик по кнопке → редирект в swipe-экран `/sessions/<id>/insights`
- [ ] Повторный клик "Finish review" (уже true) → пуш не приходит
- [ ] Двойной быстрый клик "Finish review" → только один пуш (атомарность)
- [ ] Создать сессию с `scheduled_at = now() + 2h`, дёрнуть `curl -H "Authorization: Bearer \$CRON_SECRET" .../api/cron/session-reminders` → пуш «Через 2 часа»; в БД `reminder_sent_at` заполнен
- [ ] Curl на cron без Authorization → 401
- [ ] Curl на webhook без `x-telegram-bot-api-secret-token` → 200, никаких записей в БД
- [ ] Curl на webhook на проде без переменной `TELEGRAM_WEBHOOK_SECRET` → 500 (защита от misconfig)
- [ ] Забанить бота → следующий пуш → `is_active=false` в `telegram_links`

## Открытые вопросы

- Тренер пока не получает пуши (карточка в UI ему тоже видна — может подключиться, но событий для него ещё нет).
- HOURS_BEFORE захардкожено = 2. Если надо менять — отдельный пер-юзер пресет.
- Язык фиксированный RU. Время сессии форматируется в Europe/Moscow (TODO в коде).
- Тестов нет. Race-condition в `setTrainerReviewCompleted` и атомарность `consumeLinkToken` стоит покрыть в фолоу-апе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)