### PR TITLE
fix(migrations): миграция 020 на Supabase Vault

### DIFF
--- a/supabase/migrations/020_session_reminders_cron.sql
+++ b/supabase/migrations/020_session_reminders_cron.sql
@@ -1,8 +1,9 @@
 -- Schedules a cron job to ping the session-reminders endpoint every 15 minutes.
--- Prerequisites: set both GUCs before applying, then reconnect:
---   ALTER DATABASE postgres SET app.cron_secret = '<same value as Vercel CRON_SECRET>';
---   ALTER DATABASE postgres SET app.nivel_url   = 'https://nivel-five.vercel.app';
--- Reconnect (new SQL session) so cron.schedule reads the fresh GUCs.
+-- Prerequisites: two secrets in Supabase Vault before applying this migration:
+--   select vault.create_secret('<base url>',   'nivel_url',         'Base URL of Nivel app');
+--   select vault.create_secret('<cron secret>', 'nivel_cron_secret', 'Bearer token for /api/cron/* endpoints');
+-- Supabase managed Postgres does not allow `ALTER DATABASE SET app.*` for arbitrary GUCs,
+-- so we read from Vault instead.
 
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
@@ -21,8 +22,11 @@ select cron.schedule(
   '*/15 * * * *',
   $$
   select net.http_get(
-    url := current_setting('app.nivel_url') || '/api/cron/session-reminders',
-    headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.cron_secret'))
+    url := (select decrypted_secret from vault.decrypted_secrets where name = 'nivel_url') || '/api/cron/session-reminders',
+    headers := jsonb_build_object(
+      'Authorization',
+      'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'nivel_cron_secret')
+    )
   );
   $$
 );


### PR DESCRIPTION
## Summary

Файл миграции `020_session_reminders_cron.sql` обновлён, чтобы соответствовать тому что реально применено в prod.

## Почему

Supabase managed Postgres не разрешает `ALTER DATABASE SET` для произвольных `app.*` параметров — выдаёт `permission denied to set parameter`. Поэтому подход с GUC из исходной миграции не работает на managed Supabase.

Перешёл на Supabase Vault. Секреты лежат там зашифрованными, миграция читает их через `vault.decrypted_secrets`:

```sql
url := (select decrypted_secret from vault.decrypted_secrets where name = 'nivel_url') || '/api/cron/session-reminders',
```

## Что сделано в prod

- В Vault уже созданы оба секрета (`nivel_url`, `nivel_cron_secret`).
- Cron job `session-reminders` уже зашедулен — `select * from cron.job where jobname = 'session-reminders'` показывает `active=true`.

## Test plan

- [ ] Через ≤15 минут после деплоя: `select * from net._http_response order by id desc limit 5;` — status_code = 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)