### PR TITLE
feat(telegram): пуш тренеру когда ученик завершил разбор сессии

### DIFF
--- a/src/lib/actions/sessions.ts
+++ b/src/lib/actions/sessions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
-import { notifyNewInsights } from "@/lib/telegram/notify";
+import { notifyNewInsights, notifyStudentCompletedReview } from "@/lib/telegram/notify";
 
 export async function createSession(
   goalId: string,
@@ -207,11 +207,52 @@ export async function maybeCompleteSession(
     return { completed: false };
   }
 
-  await supabase
+  // Атомарная транзиция planned → completed. При гонке/повторном вызове
+  // .select() вернёт [] для всех проигравших — пуш тренеру отправится ровно один раз.
+  const { data: updatedRows } = await supabase
     .from("sessions")
     .update({ status: "completed", completed_at: new Date().toISOString() })
-    .eq("id", sessionId);
+    .eq("id", sessionId)
+    .eq("status", "planned")
+    .select("id, session_number, goal_id");
 
+  const transitionedToCompleted = (updatedRows?.length ?? 0) > 0;
+
+  if (transitionedToCompleted) {
+    const updated = updatedRows![0];
+    // Assumption: одна сессия = один тренер. Проверено перед стартом задачи:
+    //   select count(*) from (select session_id, count(distinct trainer_id) c
+    //   from insight_cards group by session_id) t where t.c > 1; -- 0 строк.
+    // Если в будущем co-coaching — пересмотреть источник.
+    const { data: cardRow } = await supabase
+      .from("insight_cards")
+      .select("trainer_id")
+      .eq("session_id", sessionId)
+      .limit(1)
+      .maybeSingle();
+    const { data: studentRow } = await supabase
+      .from("goals")
+      .select("profiles!inner(full_name)")
+      .eq("id", updated.goal_id)
+      .single();
+
+    const trainerId = cardRow?.trainer_id as string | undefined;
+    const profilesField =
+      (studentRow as { profiles?: { full_name?: string | null } | { full_name?: string | null }[] | null } | null)
+        ?.profiles;
+    const rawName = Array.isArray(profilesField)
+      ? profilesField[0]?.full_name
+      : profilesField?.full_name;
+    const name = rawName?.trim() || "Ученик";
+
+    if (trainerId) {
+      await notifyStudentCompletedReview(trainerId, sessionId, name, updated.session_number);
+    }
+  }
+
+  // К этой точке мы дошли через ранние проверки (планируется + ревью завершено + decisions есть).
+  // Если update не сработал — значит параллельный вызов уже перевёл в completed. В любом случае
+  // сессия сейчас в completed → возвращаем true, сохраняя семантику оригинала.
   return { completed: true };
 }
 

--- a/src/lib/telegram/notify.ts
+++ b/src/lib/telegram/notify.ts
@@ -94,3 +94,30 @@ export async function notifySessionReminder(
     return "failed";
   }
 }
+
+export async function notifyStudentCompletedReview(
+  trainerProfileId: string,
+  sessionId: string,
+  studentName: string,
+  sessionNumber: number
+): Promise<NotifyResult> {
+  try {
+    const chatId = await getActiveChat(trainerProfileId);
+    if (chatId === null) return "no_link";
+    const text = `✅ ${studentName} завершил разбор тренировки #${sessionNumber}.`;
+    const keyboard: InlineKeyboard = {
+      inline_keyboard: [
+        [{ text: "Посмотреть", url: `${APP_URL}/trainer/sessions/${sessionId}/insights` }],
+      ],
+    };
+    const res = await sendMessage(chatId, text, { reply_markup: keyboard });
+    if (res.forbidden) {
+      await deactivateLink(trainerProfileId);
+      return "no_link";
+    }
+    return res.ok ? "sent" : "failed";
+  } catch (e) {
+    console.error("[tg] notifyStudentCompletedReview failed", e);
+    return "failed";
+  }
+}


### PR DESCRIPTION
Closes #176

## Что внутри

- `notifyStudentCompletedReview(trainerProfileId, sessionId, studentName, sessionNumber)` в `src/lib/telegram/notify.ts` — паттерн один-в-один как `notifyNewInsights`: `getActiveChat` → текст + кнопка → 403 деактивирует ссылку → возвращает `NotifyResult`.
- `maybeCompleteSession` (`src/lib/actions/sessions.ts:180`) теперь делает атомарный UPDATE с `.eq("status", "planned").select()`. Только победитель гонки получает строку и вызывает notify — гарантирует ровно один пуш на сессию.
- `trainer_id` берётся из любой карточки сессии (assumption: одна сессия = один тренер, проверено SQL: `select count(*) from (select session_id, count(distinct trainer_id) c from insight_cards group by session_id) t where t.c > 1; -- 0 строк`). Если в будущем co-coaching — пересмотреть.
- `studentName` через JOIN `goals → profiles.full_name` с fallback `"Ученик"` если null/пусто.
- Возврат функции изменён на `{ completed: true }` после атомарного блока (race-loser тоже видит completed). Callers (`setTrainerReviewCompleted`, `submitStudentDecision`) возвращаемое значение не использовали.

## Семантика и edge-cases

| Сценарий | Поведение |
|---|---|
| Ученик swipe'нул всю approved-карту (первый раз) | UPDATE wins → пуш тренеру |
| Параллельные swipe в двух вкладках | Один wins → один пуш, остальные тихо `completed=true` |
| Откатить student_decision, вернуть | status уже `completed` → UPDATE не сработает → пуш не дублируется |
| Тренер без активной TG-связки | `notifyStudentCompletedReview` тихо вернёт `"no_link"`, не блокирует |
| Сессия без approved-карточек | Ранняя проверка `pending > 0` падает; до UPDATE не доходим |
| `full_name` пустой/null | Пуш с `"Ученик завершил разбор тренировки #N."` |

## Test plan

- [ ] На тестовом ученике swipe'нуть все карточки → тренер получает пуш `✅ <имя> завершил разбор тренировки #N` с кнопкой «Посмотреть»
- [ ] Кнопка ведёт на `/trainer/sessions/<id>/insights`
- [ ] Откатить `student_decision` в null SQL'ом и вернуть → пуш не дублируется
- [ ] Race: открыть две вкладки swipe-экрана, swipe'нуть последнюю карту в обеих → один пуш
- [ ] Сессия без TG-связки тренера → тихо, без ошибок в логах

🤖 Generated with [Claude Code](https://claude.com/claude-code)