### PR TITLE
feat(telegram): таймзона напоминаний — Europe/Madrid

### DIFF
--- a/src/lib/telegram/notify.ts
+++ b/src/lib/telegram/notify.ts
@@ -71,11 +71,10 @@ export async function notifySessionReminder(
     if (chatId === null) return "no_link";
     const word = plural(hoursBefore, "час", "часа", "часов");
     const date = new Date(scheduledAt);
-    // TODO: brать таймзону из профиля юзера, пока хардкод под основную аудиторию.
     const time = date.toLocaleTimeString("ru-RU", {
       hour: "2-digit",
       minute: "2-digit",
-      timeZone: "Europe/Moscow",
+      timeZone: "Europe/Madrid",
     });
     const text = `⏰ Через ${hoursBefore} ${word} тренировка (в ${time}).`;
     const keyboard: InlineKeyboard = {


### PR DESCRIPTION
Closes #175

Меняем хардкод `Europe/Moscow` → `Europe/Madrid` в `notifySessionReminder`. Игроки в Барселоне. Убран TODO про per-user TZ — решение by design.

## Test plan

- [ ] Создать сессию с `scheduled_at = now() + 2h`, дёрнуть cron вручную → в пуше время совпадает с барселонским.

🤖 Generated with [Claude Code](https://claude.com/claude-code)