### PR TITLE
feat(api): /api/v1 audio-endpoints — upload-url, transcribe, status (#185)

### DIFF
--- a/src/app/api/v1/sessions/[id]/audio/upload-url/route.ts
+++ b/src/app/api/v1/sessions/[id]/audio/upload-url/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
+import { requestAudioUploadUrlCore } from "@/lib/core/audio";
+
+/**
+ * POST /api/v1/sessions/{id}/audio/upload-url
+ * Body: { ext?: string }  (default "m4a")
+ *
+ * Returns a Supabase signed upload URL for the session's audio. The native
+ * client PUTs the recording directly to that URL, then calls .../transcribe.
+ * Trainer-only; ownership of the session is enforced.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainerOwnsSession(id);
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let ext = "m4a";
+  try {
+    const body = await request.json();
+    if (body?.ext) ext = String(body.ext);
+  } catch {
+    // Body is optional — default ext is fine.
+  }
+
+  const result = await requestAudioUploadUrlCore(ctx.supabase, id, ext);
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+  return NextResponse.json(result);
+}

--- a/src/app/api/v1/sessions/[id]/transcribe/route.ts
+++ b/src/app/api/v1/sessions/[id]/transcribe/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
+import { transcribeSessionCore } from "@/lib/core/audio";
+
+// STT (download + Groq Whisper) runs inline and can take a while for long
+// recordings — allow up to the platform max.
+export const maxDuration = 300;
+
+/**
+ * POST /api/v1/sessions/{id}/transcribe
+ * Body: { storagePath: string }  (from the upload-url step)
+ *
+ * Runs the existing Groq STT pipeline: downloads the uploaded audio,
+ * transcribes it, stores the transcript, and removes the audio file.
+ * Trainer-only; ownership enforced.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainerOwnsSession(id);
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let storagePath: string | undefined;
+  try {
+    ({ storagePath } = await request.json());
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!storagePath) {
+    return NextResponse.json({ error: "Missing storagePath" }, { status: 400 });
+  }
+
+  const result = await transcribeSessionCore(ctx.supabase, id, storagePath);
+  if (!result.success) {
+    // Transcript row is marked 'failed' by the core; surface the reason.
+    return NextResponse.json({ error: result.error ?? "transcription_failed" }, { status: 502 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/sessions/[id]/transcript/status/route.ts
+++ b/src/app/api/v1/sessions/[id]/transcript/status/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
+import { getTranscriptStatusCore } from "@/lib/core/audio";
+
+/**
+ * GET /api/v1/sessions/{id}/transcript/status
+ *
+ * Returns { status, error_message, analysis_status, analysis_error } so the
+ * native client can poll the transcription → analysis progress.
+ * Trainer-only; ownership enforced. 404 if no transcript row yet.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainerOwnsSession(id);
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const status = await getTranscriptStatusCore(ctx.supabase, id);
+  if (!status) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  return NextResponse.json(status);
+}


### PR DESCRIPTION
Closes #185

## Что сделано
Три REST-эндпоинта поверх ядра `src/lib/core/audio.ts` (A1), bearer-авторизация + `requireTrainerOwnsSession`:
- `POST /api/v1/sessions/[id]/audio/upload-url` — signed upload URL (тело `{ext?}`).
- `POST /api/v1/sessions/[id]/transcribe` — запуск Groq STT (`maxDuration=300`), тело `{storagePath}`.
- `GET  /api/v1/sessions/[id]/transcript/status` — статусы расшифровки/анализа.

Коды: 401 (нет сессии) / 403 (не владелец) / 400 (тело) / 404 (нет транскрипта) / 502 (STT-сбой).

## Code review (правило №3)
Пройдено субагентом `code-reviewer`: вердикт ship-ready, блокеров нет. Опц. замечания относятся к ядру A1 (двойной getSession, идемпотентность transcribe) — вне scope A4, зафиксированы.

## Проверка
tsc=0 · eslint=0 · 216 тестов прошли.

## Отклонения от плана
- «Увеличить TTL signed URL»: Supabase `createSignedUploadUrl` даёт токен с фиксированным TTL 2 часа (в JS SDK не настраивается) — этого достаточно для длинной заливки, отдельного кода не требуется.