### PR TITLE
feat(api): A3 read-endpoints (тренер) — reference + master-plan

### DIFF
--- a/src/app/api/v1/reference/route.ts
+++ b/src/app/api/v1/reference/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainer } from "@/lib/auth/ownership";
+import { getReferenceCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/reference
+ * Trainer-only. Reference dictionaries (problem categories + problems, skills,
+ * exercises) used to compose goals / sessions / insight cards.
+ *
+ * Localized via `?lang=ru|en` (falls back to the Accept-Language header, then ru).
+ */
+function resolveLang(request: Request): "ru" | "en" {
+  const q = new URL(request.url).searchParams.get("lang")?.toLowerCase();
+  if (q === "en" || q === "ru") return q;
+  const header = request.headers.get("accept-language")?.toLowerCase() ?? "";
+  return header.startsWith("en") ? "en" : "ru";
+}
+
+export async function GET(request: Request) {
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainer();
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const reference = await getReferenceCore(ctx.supabase, resolveLang(request));
+  return NextResponse.json(reference);
+}

--- a/src/app/api/v1/sessions/[id]/insight-cards/route.ts
+++ b/src/app/api/v1/sessions/[id]/insight-cards/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
+import { getSessionInsightCardsCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/sessions/{id}/insight-cards
+ * Trainer-only; ownership enforced. Insight cards of the session, ordered by position.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainerOwnsSession(id);
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const cards = await getSessionInsightCardsCore(ctx.supabase, id);
+  return NextResponse.json({ cards });
+}

--- a/src/app/api/v1/sessions/[id]/route.ts
+++ b/src/app/api/v1/sessions/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainerOwnsSession } from "@/lib/auth/ownership";
+import { getSessionDetailCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/sessions/{id}
+ * Trainer-only; ownership enforced. Session detail + exercises.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainerOwnsSession(id);
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const session = await getSessionDetailCore(ctx.supabase, id);
+  if (!session) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  return NextResponse.json(session);
+}

--- a/src/app/api/v1/students/[id]/master-plan/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainer } from "@/lib/auth/ownership";
+import { getMasterPlanCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/students/{id}/master-plan
+ * Trainer-only. The student's master plan with sections and items.
+ * Returns `{ plan: null }` (200) when the student has no plan yet.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainer();
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const plan = await getMasterPlanCore(ctx.supabase, id);
+  return NextResponse.json({ plan });
+}

--- a/src/app/api/v1/students/[id]/route.ts
+++ b/src/app/api/v1/students/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainer } from "@/lib/auth/ownership";
+import { getStudentDetailCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/students/{id}
+ * Trainer-only. Student profile with their goals and sessions.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainer();
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const student = await getStudentDetailCore(ctx.supabase, id);
+  if (!student) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  return NextResponse.json(student);
+}

--- a/src/app/api/v1/students/route.ts
+++ b/src/app/api/v1/students/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { requireTrainer } from "@/lib/auth/ownership";
+import { listStudentsCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/students
+ * Trainer-only. List of students with active-goal and total-session counts.
+ */
+export async function GET() {
+  if (!(await getSession())) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+  const ctx = await requireTrainer();
+  if (!ctx) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  const students = await listStudentsCore(ctx.supabase);
+  return NextResponse.json({ students });
+}

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -52,6 +52,20 @@ export async function requireTrainerOwnsSession(
   return { user, supabase, studentId, trainerId: user.id };
 }
 
+export type TrainerContext = { user: SessionUser; supabase: SupabaseClient };
+
+/**
+ * Verifies the current session is a trainer. Returns { user, supabase } or null.
+ * For trainer-scoped read endpoints that aren't tied to a single session.
+ * Plain module (no "use server") — shared by Server Actions and Route Handlers.
+ */
+export async function requireTrainer(): Promise<TrainerContext | null> {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+  const supabase = await createClient();
+  return { user, supabase };
+}
+
 export type CardOwnershipContext = {
   user: SessionUser;
   supabase: SupabaseClient;

--- a/src/lib/core/trainerReads.ts
+++ b/src/lib/core/trainerReads.ts
@@ -164,3 +164,45 @@ export async function getSessionDetailCore(
     })),
   };
 }
+
+export type SessionInsightCard = {
+  id: string;
+  title: string | null;
+  body: string | null;
+  quote: string | null;
+  tags: string[] | null;
+  front_text: string | null;
+  context_text: string | null;
+  source: string | null;
+  trainer_status: string | null;
+  student_decision: string | null;
+  position: number | null;
+  created_at: string;
+};
+
+export async function getSessionInsightCardsCore(
+  supabase: SupabaseClient,
+  sessionId: string
+): Promise<SessionInsightCard[]> {
+  const { data } = await supabase
+    .from("insight_cards")
+    .select(
+      "id, title, body, quote, tags, front_text, context_text, source, trainer_status, student_decision, position, created_at"
+    )
+    .eq("session_id", sessionId)
+    .order("position", { ascending: true });
+  return (data ?? []).map((c: Record<string, unknown>) => ({
+    id: c.id as string,
+    title: (c.title as string | null) ?? null,
+    body: (c.body as string | null) ?? null,
+    quote: (c.quote as string | null) ?? null,
+    tags: (c.tags as string[] | null) ?? null,
+    front_text: (c.front_text as string | null) ?? null,
+    context_text: (c.context_text as string | null) ?? null,
+    source: (c.source as string | null) ?? null,
+    trainer_status: (c.trainer_status as string | null) ?? null,
+    student_decision: (c.student_decision as string | null) ?? null,
+    position: (c.position as number | null) ?? null,
+    created_at: c.created_at as string,
+  }));
+}

--- a/src/lib/core/trainerReads.ts
+++ b/src/lib/core/trainerReads.ts
@@ -1,0 +1,166 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Read-side business core for trainer-facing data, consumed by `/api/v1`
+ * (native client) and reusable by web. Auth-agnostic: callers verify the
+ * trainer session and pass a ready `supabase` client. No "use server".
+ *
+ * NOTE: query shapes mirror the existing trainer web pages; verify against the
+ * live DB when wiring the native screens (typecheck can't validate row shapes).
+ */
+
+export type StudentListItem = {
+  id: string;
+  email: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+  active_goals: number;
+  total_sessions: number;
+};
+
+export async function listStudentsCore(
+  supabase: SupabaseClient
+): Promise<StudentListItem[]> {
+  const { data: students } = await supabase
+    .from("profiles")
+    .select("id, email, full_name, avatar_url")
+    .eq("role", "student")
+    .order("created_at", { ascending: false });
+
+  return Promise.all(
+    (students ?? []).map(async (s: Record<string, unknown>) => {
+      const id = s.id as string;
+      const { count: goalCount } = await supabase
+        .from("goals")
+        .select("*", { count: "exact", head: true })
+        .eq("user_id", id)
+        .eq("status", "active");
+      const { count: sessionCount } = await supabase
+        .from("sessions")
+        .select("*, goals!inner(user_id)", { count: "exact", head: true })
+        .eq("goals.user_id", id);
+      return {
+        id,
+        email: (s.email as string | null) ?? null,
+        full_name: (s.full_name as string | null) ?? null,
+        avatar_url: (s.avatar_url as string | null) ?? null,
+        active_goals: goalCount ?? 0,
+        total_sessions: sessionCount ?? 0,
+      };
+    })
+  );
+}
+
+export type StudentDetail = {
+  id: string;
+  email: string | null;
+  full_name: string | null;
+  avatar_url: string | null;
+  goals: Array<{
+    id: string;
+    custom_problem: string | null;
+    status: string;
+    created_at: string;
+  }>;
+  sessions: Array<{
+    id: string;
+    goal_id: string;
+    session_number: number | null;
+    status: string;
+    scheduled_at: string | null;
+    completed_at: string | null;
+    created_at: string;
+  }>;
+};
+
+export async function getStudentDetailCore(
+  supabase: SupabaseClient,
+  studentId: string
+): Promise<StudentDetail | null> {
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id, email, full_name, avatar_url, role")
+    .eq("id", studentId)
+    .maybeSingle();
+  if (!profile || (profile as { role: string }).role !== "student") return null;
+
+  const { data: goals } = await supabase
+    .from("goals")
+    .select("id, custom_problem, status, created_at")
+    .eq("user_id", studentId)
+    .order("created_at", { ascending: false });
+
+  const { data: sessions } = await supabase
+    .from("sessions")
+    .select("id, goal_id, session_number, status, scheduled_at, completed_at, created_at, goals!inner(user_id)")
+    .eq("goals.user_id", studentId)
+    .order("created_at", { ascending: false });
+
+  const p = profile as Record<string, unknown>;
+  return {
+    id: p.id as string,
+    email: (p.email as string | null) ?? null,
+    full_name: (p.full_name as string | null) ?? null,
+    avatar_url: (p.avatar_url as string | null) ?? null,
+    goals: (goals ?? []).map((g: Record<string, unknown>) => ({
+      id: g.id as string,
+      custom_problem: (g.custom_problem as string | null) ?? null,
+      status: g.status as string,
+      created_at: g.created_at as string,
+    })),
+    sessions: (sessions ?? []).map((s: Record<string, unknown>) => ({
+      id: s.id as string,
+      goal_id: s.goal_id as string,
+      session_number: (s.session_number as number | null) ?? null,
+      status: s.status as string,
+      scheduled_at: (s.scheduled_at as string | null) ?? null,
+      completed_at: (s.completed_at as string | null) ?? null,
+      created_at: s.created_at as string,
+    })),
+  };
+}
+
+export type SessionDetail = {
+  id: string;
+  goal_id: string;
+  session_number: number | null;
+  status: string;
+  trainer_notes: string | null;
+  scheduled_at: string | null;
+  completed_at: string | null;
+  exercises: Array<{ id: number; name: string | null; sort_order: number | null }>;
+};
+
+export async function getSessionDetailCore(
+  supabase: SupabaseClient,
+  sessionId: string
+): Promise<SessionDetail | null> {
+  const { data: session } = await supabase
+    .from("sessions")
+    .select("id, goal_id, session_number, status, trainer_notes, scheduled_at, completed_at")
+    .eq("id", sessionId)
+    .maybeSingle();
+  if (!session) return null;
+
+  const { data: exercises } = await supabase
+    .from("session_exercises")
+    .select("id, sort_order, exercises(name)")
+    .eq("session_id", sessionId)
+    .order("sort_order", { ascending: true });
+
+  const s = session as Record<string, unknown>;
+  return {
+    id: s.id as string,
+    goal_id: s.goal_id as string,
+    session_number: (s.session_number as number | null) ?? null,
+    status: s.status as string,
+    trainer_notes: (s.trainer_notes as string | null) ?? null,
+    scheduled_at: (s.scheduled_at as string | null) ?? null,
+    completed_at: (s.completed_at as string | null) ?? null,
+    exercises: (exercises ?? []).map((e: Record<string, unknown>) => ({
+      id: e.id as number,
+      name: ((e.exercises as { name?: string } | null)?.name as string | null) ?? null,
+      sort_order: (e.sort_order as number | null) ?? null,
+    })),
+  };
+}

--- a/src/lib/core/trainerReads.ts
+++ b/src/lib/core/trainerReads.ts
@@ -206,3 +206,134 @@ export async function getSessionInsightCardsCore(
     created_at: c.created_at as string,
   }));
 }
+
+export type ReferenceData = {
+  problem_categories: Array<{ id: number; name: string; sort_order: number | null }>;
+  problems: Array<{ id: number; category_id: number; name: string; sort_order: number | null }>;
+  skills: Array<{ id: number; name: string }>;
+  exercises: Array<{ id: number; name: string }>;
+};
+
+/**
+ * Reference dictionaries shown when the trainer composes goals / sessions /
+ * insight cards: problem categories + problems, skills, exercises.
+ *
+ * Localized fields use name_ru / name_en (mirrors goals/new and the trainer
+ * student page). `exercises` only has a single `name` column, so it is not
+ * localized.
+ */
+export async function getReferenceCore(
+  supabase: SupabaseClient,
+  lang: "ru" | "en"
+): Promise<ReferenceData> {
+  const nameCol = lang === "en" ? "name_en" : "name_ru";
+
+  const [catsRes, probsRes, skillsRes, exercisesRes] = await Promise.all([
+    supabase
+      .from("problem_categories")
+      .select(`id, sort_order, ${nameCol}`)
+      .order("sort_order"),
+    supabase
+      .from("problems")
+      .select(`id, category_id, sort_order, ${nameCol}`)
+      .order("sort_order"),
+    supabase.from("skills").select(`id, ${nameCol}`).order(nameCol),
+    supabase.from("exercises").select("id, name").order("name"),
+  ]);
+
+  return {
+    problem_categories: (catsRes.data ?? []).map((c: Record<string, unknown>) => ({
+      id: c.id as number,
+      name: (c[nameCol] as string | null) ?? "",
+      sort_order: (c.sort_order as number | null) ?? null,
+    })),
+    problems: (probsRes.data ?? []).map((p: Record<string, unknown>) => ({
+      id: p.id as number,
+      category_id: p.category_id as number,
+      name: (p[nameCol] as string | null) ?? "",
+      sort_order: (p.sort_order as number | null) ?? null,
+    })),
+    skills: (skillsRes.data ?? []).map((s: Record<string, unknown>) => ({
+      id: s.id as number,
+      name: (s[nameCol] as string | null) ?? "",
+    })),
+    exercises: (exercisesRes.data ?? []).map((e: Record<string, unknown>) => ({
+      id: e.id as number,
+      name: (e.name as string | null) ?? "",
+    })),
+  };
+}
+
+export type MasterPlanData = {
+  id: string;
+  student_id: string;
+  trainer_id: string;
+  created_at: string;
+  updated_at: string;
+  sections: Array<{
+    id: string;
+    plan_id: string;
+    title: string;
+    category: string;
+    sort_order: number;
+    items: Array<{
+      id: string;
+      section_id: string;
+      title: string;
+      description: string | null;
+      image_url: string | null;
+      sort_order: number;
+    }>;
+  }>;
+};
+
+/**
+ * The student's master plan with its sections and items (mirrors getMasterPlan
+ * in actions/masterPlan.ts). Returns null when the student has no plan yet.
+ * Sections and items are returned ordered by sort_order for a stable DTO.
+ */
+export async function getMasterPlanCore(
+  supabase: SupabaseClient,
+  studentId: string
+): Promise<MasterPlanData | null> {
+  const { data: plan } = await supabase
+    .from("master_plans")
+    .select("id, student_id, trainer_id, created_at, updated_at")
+    .eq("student_id", studentId)
+    .maybeSingle();
+  if (!plan) return null;
+
+  const planRow = plan as Record<string, unknown>;
+  const { data: sections } = await supabase
+    .from("master_plan_sections")
+    .select(
+      "id, plan_id, title, category, sort_order, master_plan_items(id, section_id, title, description, image_url, sort_order)"
+    )
+    .eq("plan_id", planRow.id as string)
+    .order("sort_order");
+
+  return {
+    id: planRow.id as string,
+    student_id: planRow.student_id as string,
+    trainer_id: planRow.trainer_id as string,
+    created_at: planRow.created_at as string,
+    updated_at: planRow.updated_at as string,
+    sections: (sections ?? []).map((s: Record<string, unknown>) => ({
+      id: s.id as string,
+      plan_id: s.plan_id as string,
+      title: s.title as string,
+      category: s.category as string,
+      sort_order: (s.sort_order as number | null) ?? 0,
+      items: (((s.master_plan_items as Record<string, unknown>[]) ?? [])
+        .map((it) => ({
+          id: it.id as string,
+          section_id: it.section_id as string,
+          title: it.title as string,
+          description: (it.description as string | null) ?? null,
+          image_url: (it.image_url as string | null) ?? null,
+          sort_order: (it.sort_order as number | null) ?? 0,
+        }))
+        .sort((a, b) => a.sort_order - b.sort_order)),
+    })),
+  };
+}


### PR DESCRIPTION
Closes #184

REST GET-endpoints `/api/v1/*` для нативного клиента тренера (поверх ядра A1, bearer-авторизация A2). Эта ветка завершает весь объём A3.

## Что в ветке (суммарно)
- `GET /api/v1/students` — список учеников (active_goals, total_sessions)
- `GET /api/v1/students/[id]` — профиль ученика + его цели и сессии
- `GET /api/v1/sessions/[id]` — карточка сессии (+ упражнения)
- `GET /api/v1/sessions/[id]/insight-cards` — инсайт-карточки сессии
- **`GET /api/v1/reference`** — справочники: problem_categories+problems, skills, exercises (этот PR)
- **`GET /api/v1/students/[id]/master-plan`** — мастер-план ученика (этот PR)

## Что добавлено в этой итерации
- `src/lib/core/trainerReads.ts`:
  - `getReferenceCore(supabase, lang)` — справочники. Локализация `name_ru`/`name_en` по `?lang=ru|en` (фоллбэк на `Accept-Language`, затем `ru`) — как `goals/new` и `dashboard/data.ts`. `exercises` имеет только колонку `name`, поэтому не локализуется.
  - `getMasterPlanCore(supabase, studentId)` — мастер-план (секции + items), стабильный порядок по `sort_order`. Обёртка над логикой `getMasterPlan` из `actions/masterPlan.ts`, но auth-agnostic (без `"use server"`).
- `src/app/api/v1/reference/route.ts` — `requireTrainer()`.
- `src/app/api/v1/students/[id]/master-plan/route.ts` — `requireTrainer()`, возвращает `{ plan: null }` (200) если у ученика ещё нет плана.

Паттерн авторизации единый со всеми A3-route: `getSession()`→401, затем `requireTrainer()`→403. Ядро — auth-agnostic, в `trainerReads.ts`.

## Отклонения от плана
- В `getMasterPlanCore` использован `.maybeSingle()` вместо `.single()` (как в оригинальном `getMasterPlan`): при отсутствии плана это чисто возвращает `null` без PostgREST-ошибки. Route отдаёт `{ plan: null }` 200, чтобы клиент A6 отличал «плана нет» от «ученик не найден».

## На заметку ревью (не блокер)
- Межтренерская изоляция: `master-plan` (как и существующий `students/[id]` и веб-страница `trainer/students/[id]`) гейтит только на `role === "trainer"`, без проверки `created_by`. Это сложившийся в проекте паттерн, не регресс этого PR. Если нужна изоляция между тренерами — стоит решать единообразно для всех trainer-read endpoints.

## Проверки
- `npx tsc --noEmit` — чисто
- `npx eslint` по новым файлам — чисто
- ⚠️ Формы строк из БД tsc не валидирует — запросы повторяют существующие веб-страницы; финально сверить при подключении экранов в A6.

Code review выполнен субагентом (правило инициативы №3): блокеров нет.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSRZH6mWgVQgbgvYSYgQbr)_