### PR TITLE
feat(api): /api/v1 write-endpoints тренера (#186)

### DIFF
--- a/src/app/api/v1/cards/[id]/approve/route.ts
+++ b/src/app/api/v1/cards/[id]/approve/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { guardCard, badRequest } from "@/lib/api/respond";
+import { setAiCardTrainerStatusCore } from "@/lib/core/aiInsights";
+
+/**
+ * POST /api/v1/cards/{id}/approve
+ *
+ * Approves a draft insight card (propagates to template siblings). Trainer-only;
+ * ownership of the card enforced. Mirrors the web `approveInsightCard`.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardCard(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await setAiCardTrainerStatusCore(
+    guard.ctx.supabase,
+    id,
+    guard.ctx.templateId,
+    "approved"
+  );
+  if ("error" in result) return badRequest(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/cards/[id]/reject/route.ts
+++ b/src/app/api/v1/cards/[id]/reject/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { guardCard, badRequest } from "@/lib/api/respond";
+import { setAiCardTrainerStatusCore } from "@/lib/core/aiInsights";
+
+/**
+ * POST /api/v1/cards/{id}/reject
+ *
+ * Rejects a draft insight card (propagates to template siblings). Trainer-only;
+ * ownership of the card enforced. Mirrors the web `rejectInsightCard`.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardCard(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await setAiCardTrainerStatusCore(
+    guard.ctx.supabase,
+    id,
+    guard.ctx.templateId,
+    "rejected"
+  );
+  if ("error" in result) return badRequest(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/cards/[id]/route.ts
+++ b/src/app/api/v1/cards/[id]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { guardCard, parseJson, badRequest } from "@/lib/api/respond";
+import {
+  updateAiInsightCardCore,
+  deleteAiInsightCardCore,
+  validateAiInsightCardPatch,
+} from "@/lib/core/aiInsights";
+
+/**
+ * PATCH /api/v1/cards/{id}
+ * Body: { title, body, tag, side? }
+ *
+ * Edits a draft/approved insight card's content (propagates to template
+ * siblings). Trainer-only; ownership of the card enforced. Mirrors the web
+ * `updateAiInsightCard` Server Action.
+ */
+type PatchBody = { title?: string; body?: string; tag?: string; side?: string | null };
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const parsed = await parseJson<PatchBody>(request);
+  if (!parsed.ok) return parsed.res;
+  const { title, body, tag, side } = parsed.body;
+
+  if (typeof title !== "string" || typeof body !== "string" || typeof tag !== "string") {
+    return badRequest("title, body and tag are required");
+  }
+
+  // Validate before the ownership lookup, matching the web action's ordering.
+  const patch = { title, body, tag, side: side ?? null };
+  const validationError = validateAiInsightCardPatch(patch);
+  if (validationError) return badRequest(validationError);
+
+  const guard = await guardCard(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await updateAiInsightCardCore(
+    guard.ctx.supabase,
+    id,
+    guard.ctx.templateId,
+    patch
+  );
+  if ("error" in result) return badRequest(result.error);
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * DELETE /api/v1/cards/{id}
+ *
+ * Deletes an insight card. Trainer-only; ownership enforced. Mirrors the web
+ * `deleteAiInsightCard` Server Action.
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardCard(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await deleteAiInsightCardCore(guard.ctx.supabase, id);
+  if ("error" in result) return badRequest(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/collections/[id]/apply/route.ts
+++ b/src/app/api/v1/collections/[id]/apply/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import {
+  guardSession,
+  parseJson,
+  badRequest,
+  notFound,
+  coreError,
+} from "@/lib/api/respond";
+import {
+  applyCollectionToStudentCore,
+  collectionBelongsToTrainer,
+} from "@/lib/core/insightCards";
+
+/**
+ * POST /api/v1/collections/{id}/apply
+ * Body: { sessionId: string }
+ *
+ * Applies every card template in the collection to the session's student.
+ * Trainer-only; the trainer must own both the collection and the session.
+ * Mirrors the web `applyCollectionToStudent` Server Action.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const parsed = await parseJson<{ sessionId?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.sessionId) return badRequest("sessionId is required");
+
+  // Ownership of the session also establishes the authenticated trainer.
+  const guard = await guardSession(parsed.body.sessionId);
+  if (!guard.ok) return guard.res;
+
+  if (!(await collectionBelongsToTrainer(guard.ctx.supabase, id, guard.ctx.trainerId))) {
+    return notFound("collection not found");
+  }
+
+  const result = await applyCollectionToStudentCore(
+    guard.ctx.supabase,
+    guard.ctx.trainerId,
+    id,
+    parsed.body.sessionId
+  );
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, applied: result.applied });
+}

--- a/src/app/api/v1/collections/[id]/cards/[templateId]/route.ts
+++ b/src/app/api/v1/collections/[id]/cards/[templateId]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { guardTrainer, notFound, coreError } from "@/lib/api/respond";
+import {
+  removeCardFromCollectionCore,
+  collectionBelongsToTrainer,
+} from "@/lib/core/insightCards";
+
+/**
+ * DELETE /api/v1/collections/{id}/cards/{templateId}
+ *
+ * Removes a card template from the collection. Trainer-only; the collection must
+ * belong to the trainer. Mirrors the web `removeCardFromCollection`.
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; templateId: string }> }
+) {
+  const { id, templateId } = await params;
+
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  if (!(await collectionBelongsToTrainer(guard.ctx.supabase, id, guard.ctx.user.id))) {
+    return notFound("collection not found");
+  }
+
+  const result = await removeCardFromCollectionCore(guard.ctx.supabase, id, templateId);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/collections/[id]/cards/route.ts
+++ b/src/app/api/v1/collections/[id]/cards/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { guardTrainer, parseJson, badRequest, notFound, coreError } from "@/lib/api/respond";
+import {
+  addCardToCollectionCore,
+  collectionBelongsToTrainer,
+} from "@/lib/core/insightCards";
+
+/**
+ * POST /api/v1/collections/{id}/cards
+ * Body: { templateId: string }
+ *
+ * Adds a card template to the collection. Trainer-only; the collection must
+ * belong to the trainer. Mirrors the web `addCardToCollection` Server Action.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ templateId?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.templateId) return badRequest("templateId is required");
+
+  if (!(await collectionBelongsToTrainer(guard.ctx.supabase, id, guard.ctx.user.id))) {
+    return notFound("collection not found");
+  }
+
+  const result = await addCardToCollectionCore(guard.ctx.supabase, id, parsed.body.templateId);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/api/v1/collections/route.ts
+++ b/src/app/api/v1/collections/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { guardTrainer, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { createCollectionCore } from "@/lib/core/insightCards";
+
+/**
+ * POST /api/v1/collections
+ * Body: { name: string }
+ *
+ * Creates a card collection owned by the trainer. Trainer-only. Mirrors the web
+ * `createCollection` Server Action.
+ */
+export async function POST(request: Request) {
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ name?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.name?.trim()) return badRequest("name is required");
+
+  const result = await createCollectionCore(guard.ctx.supabase, guard.ctx.user.id, parsed.body.name);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, id: result.id }, { status: 201 });
+}

--- a/src/app/api/v1/goals/[id]/cancel/route.ts
+++ b/src/app/api/v1/goals/[id]/cancel/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { guardGoal, coreError } from "@/lib/api/respond";
+import { cancelGoalCore } from "@/lib/core/goals";
+
+/**
+ * POST /api/v1/goals/{id}/cancel
+ *
+ * Marks the goal as cancelled. Trainer-only; the trainer must own the goal's
+ * student. Mirrors the web `cancelGoal` Server Action (with added ownership).
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardGoal(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await cancelGoalCore(guard.ctx.supabase, id);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/sessions/[id]/cards/reorder/route.ts
+++ b/src/app/api/v1/sessions/[id]/cards/reorder/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { guardSession, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { reorderInsightCardsCore } from "@/lib/core/insightCards";
+
+/**
+ * POST /api/v1/sessions/{id}/cards/reorder
+ * Body: { orderedIds: string[] }
+ *
+ * Reorders the session's insight cards to match `orderedIds`. Trainer-only;
+ * ownership of the session enforced. Mirrors the web `reorderInsightCards`.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardSession(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ orderedIds?: string[] }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!Array.isArray(parsed.body?.orderedIds)) {
+    return badRequest("orderedIds must be an array");
+  }
+
+  const result = await reorderInsightCardsCore(guard.ctx.supabase, id, parsed.body.orderedIds);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/sessions/[id]/insights/generate/route.ts
+++ b/src/app/api/v1/sessions/[id]/insights/generate/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { guardSession } from "@/lib/api/respond";
+import { generateAiInsightsCore } from "@/lib/core/aiInsights";
+
+// LLM analysis of the transcript runs inline and can take a while.
+export const maxDuration = 300;
+
+/**
+ * POST /api/v1/sessions/{id}/insights/generate
+ *
+ * Runs the OpenRouter LLM over the session's ready transcript and creates draft
+ * insight cards. Trainer-only; ownership of the session enforced. Mirrors the
+ * web `generateAiInsights` Server Action.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardSession(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await generateAiInsightsCore(
+    guard.ctx.supabase,
+    id,
+    guard.ctx.studentId,
+    guard.ctx.trainerId
+  );
+
+  if ("error" in result) {
+    // Precondition errors (no ready transcript / already running) → 400.
+    // Errors during analysis (LLM/parse) mark the transcript failed → 502.
+    return NextResponse.json({ error: result.error }, { status: result.mutated ? 502 : 400 });
+  }
+
+  return NextResponse.json({ ok: true, count: result.count });
+}

--- a/src/app/api/v1/sessions/[id]/insights/paste/route.ts
+++ b/src/app/api/v1/sessions/[id]/insights/paste/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { guardSession, parseJson, badRequest } from "@/lib/api/respond";
+import { pasteInsightsFromClaudeCore } from "@/lib/core/aiInsights";
+
+/**
+ * POST /api/v1/sessions/{id}/insights/paste
+ * Body: { markdown: string }
+ *
+ * Parses pasted Claude markdown into draft insight cards. Trainer-only;
+ * ownership of the session enforced. Mirrors the web `pasteInsightsFromClaude`.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardSession(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ markdown?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (typeof parsed.body?.markdown !== "string") {
+    return badRequest("markdown is required");
+  }
+
+  const result = await pasteInsightsFromClaudeCore(
+    guard.ctx.supabase,
+    id,
+    guard.ctx.studentId,
+    guard.ctx.trainerId,
+    parsed.body.markdown
+  );
+
+  if ("error" in result) {
+    // Parse errors carry a line number; surface it as a 400 validation error.
+    return NextResponse.json({ error: result.error, line: result.line }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true, count: result.count });
+}

--- a/src/app/api/v1/sessions/[id]/review-complete/route.ts
+++ b/src/app/api/v1/sessions/[id]/review-complete/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { guardSession, parseJson, coreError } from "@/lib/api/respond";
+import { setTrainerReviewCompletedCore } from "@/lib/core/sessions";
+
+/**
+ * POST /api/v1/sessions/{id}/review-complete
+ * Body: { completed?: boolean }  (default true)
+ *
+ * Marks the trainer review as complete/incomplete. On completion this fires the
+ * "new insights" student push and may transition the session to completed.
+ * Trainer-only; ownership of the session enforced.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardSession(id);
+  if (!guard.ok) return guard.res;
+
+  // Body is optional; default to completing the review.
+  let completed = true;
+  const parsed = await parseJson<{ completed?: boolean }>(request);
+  if (parsed.ok && typeof parsed.body?.completed === "boolean") {
+    completed = parsed.body.completed;
+  }
+
+  const result = await setTrainerReviewCompletedCore(guard.ctx.supabase, id, completed);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/sessions/[id]/templates/apply/route.ts
+++ b/src/app/api/v1/sessions/[id]/templates/apply/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { guardSession, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { applyTemplateToStudentCore } from "@/lib/core/insightCards";
+
+/**
+ * POST /api/v1/sessions/{id}/templates/apply
+ * Body: { templateId: string }
+ *
+ * Applies a saved card template to the session's student (creates an approved
+ * card). Trainer-only; ownership of the session enforced. Mirrors the web
+ * `applyTemplateToStudent` Server Action.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardSession(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ templateId?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.templateId) return badRequest("templateId is required");
+
+  const result = await applyTemplateToStudentCore(
+    guard.ctx.supabase,
+    guard.ctx.trainerId,
+    parsed.body.templateId,
+    id
+  );
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, id: result.id }, { status: 201 });
+}

--- a/src/app/api/v1/sessions/for-student/route.ts
+++ b/src/app/api/v1/sessions/for-student/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { createSessionForStudentCore } from "@/lib/core/sessions";
+
+/**
+ * POST /api/v1/sessions/for-student
+ * Body: { studentId, goalId, scheduledAt?, completedAt?, trainerNotes?, status? }
+ *
+ * Creates a lightweight session (planned or completed) for a student without the
+ * exercise builder. Trainer-only; the trainer must own the student. Mirrors the
+ * web `createSessionForStudent` Server Action.
+ */
+type Body = {
+  studentId?: string;
+  goalId?: string;
+  scheduledAt?: string | null;
+  completedAt?: string | null;
+  trainerNotes?: string | null;
+  status?: "planned" | "completed";
+};
+
+export async function POST(request: Request) {
+  const parsed = await parseJson<Body>(request);
+  if (!parsed.ok) return parsed.res;
+  const { studentId, goalId, scheduledAt, completedAt, trainerNotes, status } = parsed.body;
+
+  if (!studentId || !goalId) {
+    return badRequest("studentId and goalId are required");
+  }
+  if (status && status !== "planned" && status !== "completed") {
+    return badRequest("status must be 'planned' or 'completed'");
+  }
+
+  const guard = await guardStudent(studentId);
+  if (!guard.ok) return guard.res;
+
+  const result = await createSessionForStudentCore(guard.ctx.supabase, studentId, goalId, {
+    scheduledAt,
+    completedAt,
+    trainerNotes,
+    status,
+  });
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, sessionId: result.sessionId }, { status: 201 });
+}

--- a/src/app/api/v1/sessions/route.ts
+++ b/src/app/api/v1/sessions/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { createSessionCore } from "@/lib/core/sessions";
+
+/**
+ * POST /api/v1/sessions
+ * Body: { goalId, studentId, exercises: [{ name, skillNames: [] }] }
+ *
+ * Creates a planned training session with exercises + skills (resolving/creating
+ * them as needed) and bumps skill progress. Trainer-only; the trainer must own
+ * the student. Mirrors the web `createSession` Server Action.
+ */
+type Body = {
+  goalId?: string;
+  studentId?: string;
+  exercises?: { name: string; skillNames: string[] }[];
+};
+
+export async function POST(request: Request) {
+  const parsed = await parseJson<Body>(request);
+  if (!parsed.ok) return parsed.res;
+  const { goalId, studentId, exercises } = parsed.body;
+
+  if (!goalId || !studentId) {
+    return badRequest("goalId and studentId are required");
+  }
+  if (!Array.isArray(exercises)) {
+    return badRequest("exercises must be an array");
+  }
+
+  const guard = await guardStudent(studentId);
+  if (!guard.ok) return guard.res;
+
+  const result = await createSessionCore(guard.ctx.supabase, goalId, studentId, exercises);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, sessionId: result.sessionId }, { status: 201 });
+}

--- a/src/app/api/v1/students/[id]/goals/route.ts
+++ b/src/app/api/v1/students/[id]/goals/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, coreError } from "@/lib/api/respond";
+import { createGoalForStudentCore } from "@/lib/core/goals";
+
+/**
+ * POST /api/v1/students/{id}/goals
+ * Body: { problemId?: number | null, customProblem?: string | null }
+ *
+ * Creates a training goal for the student. Trainer-only; the trainer must own
+ * the student. Mirrors the web `createGoalForStudent` Server Action.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ problemId?: number | null; customProblem?: string | null }>(
+    request
+  );
+  if (!parsed.ok) return parsed.res;
+
+  const result = await createGoalForStudentCore(
+    guard.ctx.supabase,
+    id,
+    parsed.body?.problemId ?? null,
+    parsed.body?.customProblem ?? null
+  );
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, goalId: result.goalId }, { status: 201 });
+}

--- a/src/app/api/v1/students/[id]/invite/regenerate/route.ts
+++ b/src/app/api/v1/students/[id]/invite/regenerate/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { guardStudent, notFound, badRequest } from "@/lib/api/respond";
+import { regenerateClaimTokenCore } from "@/lib/core/students";
+
+/**
+ * POST /api/v1/students/{id}/invite/regenerate
+ *
+ * Issues a fresh claim token + invite link for an unclaimed shadow student.
+ * Trainer-only; the trainer must own the student. Mirrors the web
+ * `regenerateClaimToken` Server Action.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await regenerateClaimTokenCore(guard.ctx.supabase, id);
+  if (!result.success) {
+    if (result.error === "not_found") return notFound();
+    return badRequest(result.error);
+  }
+
+  return NextResponse.json({ ok: true, ...result.result });
+}

--- a/src/app/api/v1/students/[id]/invite/revoke/route.ts
+++ b/src/app/api/v1/students/[id]/invite/revoke/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { guardStudent, coreError } from "@/lib/api/respond";
+import { revokeClaimTokenCore } from "@/lib/core/students";
+
+/**
+ * POST /api/v1/students/{id}/invite/revoke
+ *
+ * Clears the student's claim token so the invite link stops working.
+ * Trainer-only; the trainer must own the student. Mirrors the web
+ * `revokeClaimToken` Server Action.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await revokeClaimTokenCore(guard.ctx.supabase, id);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/students/[id]/master-plan/items/[itemId]/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/items/[itemId]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { guardStudent, notFound, coreError } from "@/lib/api/respond";
+import { deleteMasterPlanItemCore, itemBelongsToStudent } from "@/lib/core/masterPlan";
+
+/**
+ * DELETE /api/v1/students/{id}/master-plan/items/{itemId}
+ *
+ * Deletes a master-plan item. Trainer-only; the trainer must own the student
+ * and the item must belong to that student's plan. Mirrors the web `deleteItem`.
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; itemId: string }> }
+) {
+  const { id, itemId } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  if (!(await itemBelongsToStudent(guard.ctx.supabase, itemId, id))) {
+    return notFound("item not found for student");
+  }
+
+  const result = await deleteMasterPlanItemCore(guard.ctx.supabase, itemId);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/students/[id]/master-plan/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { requireTrainer } from "@/lib/auth/ownership";
 import { getMasterPlanCore } from "@/lib/core/trainerReads";
+import { guardStudent, coreError } from "@/lib/api/respond";
+import { createMasterPlanCore } from "@/lib/core/masterPlan";
 
 /**
  * GET /api/v1/students/{id}/master-plan
@@ -22,4 +24,25 @@ export async function GET(
   }
   const plan = await getMasterPlanCore(ctx.supabase, id);
   return NextResponse.json({ plan });
+}
+
+/**
+ * POST /api/v1/students/{id}/master-plan
+ *
+ * Creates an empty master plan for the student. Trainer-only; the trainer must
+ * own the student. Mirrors the web `createMasterPlan` Server Action.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const result = await createMasterPlanCore(guard.ctx.supabase, guard.ctx.trainerId, id);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, id: result.id }, { status: 201 });
 }

--- a/src/app/api/v1/students/[id]/master-plan/sections/[sectionId]/items/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/sections/[sectionId]/items/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, badRequest, notFound, coreError } from "@/lib/api/respond";
+import { addMasterPlanItemCore, sectionBelongsToStudent } from "@/lib/core/masterPlan";
+
+/**
+ * POST /api/v1/students/{id}/master-plan/sections/{sectionId}/items
+ * Body: { title, description?, imageUrl?, sortOrder? }
+ *
+ * Adds an item to a section. Trainer-only; the trainer must own the student and
+ * the section must belong to that student's plan. Mirrors the web `addItem`.
+ */
+type Body = {
+  title?: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  sortOrder?: number;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string; sectionId: string }> }
+) {
+  const { id, sectionId } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<Body>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.title?.trim()) return badRequest("title is required");
+
+  if (!(await sectionBelongsToStudent(guard.ctx.supabase, sectionId, id))) {
+    return notFound("section not found for student");
+  }
+
+  const result = await addMasterPlanItemCore(guard.ctx.supabase, sectionId, {
+    title: parsed.body.title,
+    description: parsed.body.description,
+    imageUrl: parsed.body.imageUrl,
+    sortOrder: parsed.body.sortOrder,
+  });
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, id: result.id }, { status: 201 });
+}

--- a/src/app/api/v1/students/[id]/master-plan/sections/[sectionId]/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/sections/[sectionId]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { guardStudent, notFound, coreError } from "@/lib/api/respond";
+import { deleteMasterPlanSectionCore, sectionBelongsToStudent } from "@/lib/core/masterPlan";
+
+/**
+ * DELETE /api/v1/students/{id}/master-plan/sections/{sectionId}
+ *
+ * Deletes a section (and its items via cascade). Trainer-only; the trainer must
+ * own the student and the section must belong to that student's plan. Mirrors
+ * the web `deleteSection` Server Action.
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string; sectionId: string }> }
+) {
+  const { id, sectionId } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  if (!(await sectionBelongsToStudent(guard.ctx.supabase, sectionId, id))) {
+    return notFound("section not found for student");
+  }
+
+  const result = await deleteMasterPlanSectionCore(guard.ctx.supabase, sectionId);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/students/[id]/master-plan/sections/route.ts
+++ b/src/app/api/v1/students/[id]/master-plan/sections/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, badRequest, notFound, coreError } from "@/lib/api/respond";
+import { addMasterPlanSectionCore, planBelongsToStudent } from "@/lib/core/masterPlan";
+import type { MasterPlanCategory } from "@/lib/types";
+
+const VALID_CATEGORIES: MasterPlanCategory[] = ["strength", "technique", "tactics", "custom"];
+
+/**
+ * POST /api/v1/students/{id}/master-plan/sections
+ * Body: { planId, title, category, sortOrder? }
+ *
+ * Adds a section to the student's master plan. Trainer-only; the trainer must
+ * own the student and the plan must belong to that student. Mirrors the web
+ * `addSection` Server Action.
+ */
+type Body = {
+  planId?: string;
+  title?: string;
+  category?: MasterPlanCategory;
+  sortOrder?: number;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<Body>(request);
+  if (!parsed.ok) return parsed.res;
+  const { planId, title, category, sortOrder } = parsed.body;
+
+  if (!planId) return badRequest("planId is required");
+  if (!title?.trim()) return badRequest("title is required");
+  if (!category || !VALID_CATEGORIES.includes(category)) {
+    return badRequest("category must be one of: strength, technique, tactics, custom");
+  }
+
+  if (!(await planBelongsToStudent(guard.ctx.supabase, planId, id))) {
+    return notFound("plan not found for student");
+  }
+
+  const result = await addMasterPlanSectionCore(guard.ctx.supabase, planId, {
+    title,
+    category,
+    sortOrder,
+  });
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, id: result.id }, { status: 201 });
+}

--- a/src/app/api/v1/students/[id]/route.ts
+++ b/src/app/api/v1/students/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { requireTrainer } from "@/lib/auth/ownership";
 import { getStudentDetailCore } from "@/lib/core/trainerReads";
+import { guardStudent, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { updateStudentProfileCore } from "@/lib/core/students";
 
 /**
  * GET /api/v1/students/{id}
@@ -24,4 +26,39 @@ export async function GET(
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
   return NextResponse.json(student);
+}
+
+/**
+ * PATCH /api/v1/students/{id}
+ * Body: { full_name?: string | null, avatar_url?: string | null }
+ *
+ * Updates a student's profile fields. Trainer-only; the trainer must own the
+ * student. Mirrors the web `updateStudentProfile` Server Action.
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ full_name?: string | null; avatar_url?: string | null }>(
+    request
+  );
+  if (!parsed.ok) return parsed.res;
+
+  const patch: { full_name?: string | null; avatar_url?: string | null } = {};
+  if ("full_name" in parsed.body) patch.full_name = parsed.body.full_name;
+  if ("avatar_url" in parsed.body) patch.avatar_url = parsed.body.avatar_url;
+
+  if (Object.keys(patch).length === 0) {
+    return badRequest("Nothing to update");
+  }
+
+  const result = await updateStudentProfileCore(guard.ctx.supabase, id, patch);
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/v1/students/[id]/skills/route.ts
+++ b/src/app/api/v1/students/[id]/skills/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { guardStudent, parseJson, badRequest } from "@/lib/api/respond";
+import { addSkillToStudentCore, createAndAddSkillCore } from "@/lib/core/skills";
+
+/**
+ * POST /api/v1/students/{id}/skills
+ *
+ * Adds skill points to the student. Two shapes:
+ *   - { skillId: number, points: number }          → add to an existing skill
+ *   - { nameRu: string, nameEn?: string, points }  → create (upsert) then add
+ *
+ * Trainer-only; the trainer must own the student. Mirrors the web
+ * `addSkillToStudent` / `createAndAddSkill` Server Actions.
+ */
+type Body = {
+  skillId?: number;
+  nameRu?: string;
+  nameEn?: string;
+  points?: number;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const guard = await guardStudent(id);
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<Body>(request);
+  if (!parsed.ok) return parsed.res;
+  const { skillId, nameRu, nameEn, points } = parsed.body;
+
+  if (typeof points !== "number") return badRequest("points is required");
+
+  const result =
+    typeof skillId === "number"
+      ? await addSkillToStudentCore(guard.ctx.supabase, id, skillId, points)
+      : nameRu
+        ? await createAndAddSkillCore(guard.ctx.supabase, id, nameRu, nameEn ?? "", points)
+        : null;
+
+  if (!result) return badRequest("Provide either skillId or nameRu");
+  if ("error" in result) return badRequest(result.error);
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/v1/students/route.ts
+++ b/src/app/api/v1/students/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth/session";
 import { requireTrainer } from "@/lib/auth/ownership";
 import { listStudentsCore } from "@/lib/core/trainerReads";
+import { guardTrainer, parseJson, badRequest, coreError } from "@/lib/api/respond";
+import { createShadowStudentCore } from "@/lib/core/students";
 
 /**
  * GET /api/v1/students
@@ -17,4 +19,29 @@ export async function GET() {
   }
   const students = await listStudentsCore(ctx.supabase);
   return NextResponse.json({ students });
+}
+
+/**
+ * POST /api/v1/students
+ * Body: { full_name: string }
+ *
+ * Creates a shadow student profile (no email yet) plus a claim invitation link.
+ * Trainer-only. Mirrors the web `createShadowStudent` Server Action.
+ */
+export async function POST(request: Request) {
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  const parsed = await parseJson<{ full_name?: string }>(request);
+  if (!parsed.ok) return parsed.res;
+  if (!parsed.body?.full_name?.trim()) return badRequest("full_name is required");
+
+  const result = await createShadowStudentCore(
+    guard.ctx.supabase,
+    guard.ctx.user.id,
+    parsed.body.full_name
+  );
+  if (!result.success) return coreError(result.error);
+
+  return NextResponse.json({ ok: true, ...result.result }, { status: 201 });
 }

--- a/src/lib/actions/masterPlan.ts
+++ b/src/lib/actions/masterPlan.ts
@@ -3,6 +3,13 @@
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
+import {
+  createMasterPlanCore,
+  addMasterPlanSectionCore,
+  deleteMasterPlanSectionCore,
+  addMasterPlanItemCore,
+  deleteMasterPlanItemCore,
+} from "@/lib/core/masterPlan";
 import type { MasterPlan, MasterPlanCategory } from "@/lib/types";
 
 type Result<T = void> =
@@ -50,15 +57,11 @@ export async function createMasterPlan(
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
 
-  const { data, error } = await auth.supabase
-    .from("master_plans")
-    .insert({ student_id: studentId, trainer_id: auth.userId })
-    .select("id")
-    .single();
+  const result = await createMasterPlanCore(auth.supabase, auth.userId, studentId);
+  if (!result.success) return result;
 
-  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
   revalidatePath(`/trainer/students/${studentId}`);
-  return { success: true, id: data.id };
+  return { success: true, id: result.id };
 }
 
 export async function addSection(
@@ -69,20 +72,11 @@ export async function addSection(
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
 
-  const { data, error } = await auth.supabase
-    .from("master_plan_sections")
-    .insert({
-      plan_id: planId,
-      title: payload.title.trim(),
-      category: payload.category,
-      sort_order: payload.sortOrder ?? 0,
-    })
-    .select("id")
-    .single();
+  const result = await addMasterPlanSectionCore(auth.supabase, planId, payload);
+  if (!result.success) return result;
 
-  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
   revalidatePath(`/trainer/students/${studentId}`);
-  return { success: true, id: data.id };
+  return { success: true, id: result.id };
 }
 
 export async function deleteSection(
@@ -92,12 +86,9 @@ export async function deleteSection(
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
 
-  const { error } = await auth.supabase
-    .from("master_plan_sections")
-    .delete()
-    .eq("id", sectionId);
+  const result = await deleteMasterPlanSectionCore(auth.supabase, sectionId);
+  if (!result.success) return result;
 
-  if (error) return { success: false, error: error.message };
   revalidatePath(`/trainer/students/${studentId}`);
   return { success: true };
 }
@@ -110,22 +101,12 @@ export async function addItem(
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
 
-  const { data, error } = await auth.supabase
-    .from("master_plan_items")
-    .insert({
-      section_id: sectionId,
-      title: payload.title.trim(),
-      description: payload.description?.trim() || null,
-      image_url: payload.imageUrl?.trim() || null,
-      sort_order: payload.sortOrder ?? 0,
-    })
-    .select("id")
-    .single();
+  const result = await addMasterPlanItemCore(auth.supabase, sectionId, payload);
+  if (!result.success) return result;
 
-  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
   revalidatePath(`/trainer/students/${studentId}`);
   revalidatePath(`/masterplan`);
-  return { success: true, id: data.id };
+  return { success: true, id: result.id };
 }
 
 export async function deleteItem(
@@ -135,12 +116,9 @@ export async function deleteItem(
   const auth = await requireTrainer();
   if (!auth.ok) return { success: false, error: auth.error };
 
-  const { error } = await auth.supabase
-    .from("master_plan_items")
-    .delete()
-    .eq("id", itemId);
+  const result = await deleteMasterPlanItemCore(auth.supabase, itemId);
+  if (!result.success) return result;
 
-  if (error) return { success: false, error: error.message };
   revalidatePath(`/trainer/students/${studentId}`);
   revalidatePath(`/masterplan`);
   return { success: true };

--- a/src/lib/actions/skills.ts
+++ b/src/lib/actions/skills.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { getSession } from "@/lib/auth/session";
+import {
+  addSkillToStudentCore,
+  createAndAddSkillCore,
+} from "@/lib/core/skills";
 
 async function requireTrainer() {
   const session = await getSession();
@@ -22,35 +26,9 @@ export async function addSkillToStudent(
     return { error: "Forbidden" };
   }
 
-  if (points < 1 || points > 10) return { error: "Баллы должны быть от 1 до 10" };
-
   const supabase = await createClient();
-
-  const { data: existing } = await supabase
-    .from("skill_progress")
-    .select("points")
-    .eq("user_id", studentId)
-    .eq("skill_id", skillId)
-    .maybeSingle();
-
-  let dbError;
-  if (existing) {
-    // Add to existing: points_seen = old points so delta = exactly N added
-    const { error } = await supabase
-      .from("skill_progress")
-      .update({ points: existing.points + points, points_seen: existing.points })
-      .eq("user_id", studentId)
-      .eq("skill_id", skillId);
-    dbError = error;
-  } else {
-    // New skill: points_seen = NULL → shows as NEW badge
-    const { error } = await supabase
-      .from("skill_progress")
-      .insert({ user_id: studentId, skill_id: skillId, points, points_seen: null });
-    dbError = error;
-  }
-
-  if (dbError) return { error: dbError.message };
+  const result = await addSkillToStudentCore(supabase, studentId, skillId, points);
+  if ("error" in result) return result;
 
   revalidatePath(`/trainer/students/${studentId}`);
   revalidatePath("/dashboard");
@@ -69,27 +47,11 @@ export async function createAndAddSkill(
     return { error: "Forbidden" };
   }
 
-  const trimmedRu = nameRu.trim();
-  const trimmedEn = nameEn.trim() || trimmedRu;
-
-  if (!trimmedRu) return { error: "Название обязательно" };
-  if (trimmedRu.length > 40) return { error: "Название не более 40 символов" };
-
   const supabase = await createClient();
+  const result = await createAndAddSkillCore(supabase, studentId, nameRu, nameEn, points);
+  if ("error" in result) return result;
 
-  // ON CONFLICT DO UPDATE SET name = EXCLUDED.name ensures RETURNING works even on conflict
-  const { data: skillRow, error: skillError } = await supabase
-    .from("skills")
-    .upsert(
-      { name: trimmedRu, name_ru: trimmedRu, name_en: trimmedEn },
-      { onConflict: "name" }
-    )
-    .select("id")
-    .single();
-
-  if (skillError || !skillRow) {
-    return { error: skillError?.message ?? "Не удалось создать скил" };
-  }
-
-  return addSkillToStudent(studentId, skillRow.id, points);
+  revalidatePath(`/trainer/students/${studentId}`);
+  revalidatePath("/dashboard");
+  return { success: true };
 }

--- a/src/lib/actions/students.ts
+++ b/src/lib/actions/students.ts
@@ -1,27 +1,14 @@
 "use server";
 
-import { randomBytes } from "crypto";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
-
-const CLAIM_TTL_DAYS = 30;
-
-function generateToken(): string {
-  // 32 bytes → 64 hex chars. URL-safe out of the box.
-  return randomBytes(32).toString("hex");
-}
-
-function expiryFromNow(days = CLAIM_TTL_DAYS): string {
-  const d = new Date();
-  d.setUTCDate(d.getUTCDate() + days);
-  return d.toISOString();
-}
-
-function buildClaimUrl(token: string): string {
-  const base = process.env.NEXT_PUBLIC_NIVEL_URL?.trim();
-  if (!base) throw new Error("NEXT_PUBLIC_NIVEL_URL is not set");
-  return `${base.replace(/\/$/, "")}/invite/${token}`;
-}
+import {
+  createShadowStudentCore,
+  regenerateClaimTokenCore,
+  revokeClaimTokenCore,
+  updateStudentProfileCore,
+  type ShadowStudentResult,
+} from "@/lib/core/students";
 
 async function requireTrainer() {
   const session = await getSession();
@@ -34,51 +21,17 @@ export type CreateShadowStudentInput = {
   full_name: string;
 };
 
-export type CreateShadowStudentResult = {
-  studentId: string;
-  claimUrl: string;
-  claimToken: string;
-  expiresAt: string;
-};
+export type CreateShadowStudentResult = ShadowStudentResult;
 
 export async function createShadowStudent(
   input: CreateShadowStudentInput
 ): Promise<CreateShadowStudentResult> {
   const trainer = await requireTrainer();
-
-  const full_name = input.full_name?.trim();
-  if (!full_name) throw new Error("full_name is required");
-
   const supabase = await createClient();
 
-  const claimToken = generateToken();
-  const expiresAt = expiryFromNow();
-
-  // Email is left NULL on purpose — it will be filled from the Firebase token
-  // when the student claims the profile.
-  const { data: created, error } = await supabase
-    .from("profiles")
-    .insert({
-      email: null,
-      full_name,
-      role: "student",
-      created_by: trainer.id,
-      claim_token: claimToken,
-      claim_expires_at: expiresAt,
-    })
-    .select("id")
-    .single();
-
-  if (error || !created) {
-    throw new Error(`Failed to create shadow student: ${error?.message}`);
-  }
-
-  return {
-    studentId: created.id,
-    claimUrl: buildClaimUrl(claimToken),
-    claimToken,
-    expiresAt,
-  };
+  const result = await createShadowStudentCore(supabase, trainer.id, input.full_name);
+  if (!result.success) throw new Error(result.error);
+  return result.result;
 }
 
 export async function regenerateClaimToken(
@@ -87,40 +40,17 @@ export async function regenerateClaimToken(
   await requireTrainer();
   const supabase = await createClient();
 
-  const { data: existing } = await supabase
-    .from("profiles")
-    .select("id, claimed_at")
-    .eq("id", studentId)
-    .maybeSingle();
-  if (!existing) throw new Error("not_found");
-  if (existing.claimed_at) throw new Error("already_claimed");
-
-  const claimToken = generateToken();
-  const expiresAt = expiryFromNow();
-
-  const { error } = await supabase
-    .from("profiles")
-    .update({ claim_token: claimToken, claim_expires_at: expiresAt })
-    .eq("id", studentId);
-  if (error) throw new Error(`Failed to regenerate token: ${error.message}`);
-
-  return {
-    studentId,
-    claimUrl: buildClaimUrl(claimToken),
-    claimToken,
-    expiresAt,
-  };
+  const result = await regenerateClaimTokenCore(supabase, studentId);
+  if (!result.success) throw new Error(result.error);
+  return result.result;
 }
 
 export async function revokeClaimToken(studentId: string): Promise<void> {
   await requireTrainer();
   const supabase = await createClient();
 
-  const { error } = await supabase
-    .from("profiles")
-    .update({ claim_token: null, claim_expires_at: null })
-    .eq("id", studentId);
-  if (error) throw new Error(`Failed to revoke token: ${error.message}`);
+  const result = await revokeClaimTokenCore(supabase, studentId);
+  if (!result.success) throw new Error(result.error);
 }
 
 export async function updateStudentProfile(
@@ -130,13 +60,7 @@ export async function updateStudentProfile(
   try {
     await requireTrainer();
     const supabase = await createClient();
-
-    const { error } = await supabase
-      .from("profiles")
-      .update(patch)
-      .eq("id", studentId);
-    if (error) return { success: false, error: error.message };
-    return { success: true };
+    return await updateStudentProfileCore(supabase, studentId, patch);
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
   }

--- a/src/lib/api/respond.ts
+++ b/src/lib/api/respond.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import {
+  requireTrainer,
+  requireTrainerOwnsSession,
+  requireTrainerOwnsCard,
+  requireTrainerOwnsStudent,
+  type TrainerContext,
+  type OwnershipContext,
+  type CardOwnershipContext,
+  type StudentOwnershipContext,
+} from "@/lib/auth/ownership";
+
+/**
+ * Shared helpers for /api/v1 write-endpoints. Keep route handlers thin: parse
+ * the body, run the guard, delegate to a `*Core` function, map the result to a
+ * status code. Business logic lives in `src/lib/core/*`; these helpers only deal
+ * with HTTP shape and the standard auth ladder (401 -> 403 -> 400 -> 404 -> 422).
+ */
+
+export type GuardResult<C> =
+  | { ok: true; ctx: C }
+  | { ok: false; res: NextResponse };
+
+const unauthenticated = () =>
+  NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+const forbidden = () => NextResponse.json({ error: "forbidden" }, { status: 403 });
+
+/** 401 if no session, 403 if not a trainer. Returns { user, supabase }. */
+export async function guardTrainer(): Promise<GuardResult<TrainerContext>> {
+  if (!(await getSession())) return { ok: false, res: unauthenticated() };
+  const ctx = await requireTrainer();
+  if (!ctx) return { ok: false, res: forbidden() };
+  return { ok: true, ctx };
+}
+
+/** 401 if no session, 403 if not the trainer who owns the session. */
+export async function guardSession(
+  sessionId: string
+): Promise<GuardResult<OwnershipContext>> {
+  if (!(await getSession())) return { ok: false, res: unauthenticated() };
+  const ctx = await requireTrainerOwnsSession(sessionId);
+  if (!ctx) return { ok: false, res: forbidden() };
+  return { ok: true, ctx };
+}
+
+/** 401 if no session, 403 if not the trainer who created the student. */
+export async function guardStudent(
+  studentId: string
+): Promise<GuardResult<StudentOwnershipContext>> {
+  if (!(await getSession())) return { ok: false, res: unauthenticated() };
+  const ctx = await requireTrainerOwnsStudent(studentId);
+  if (!ctx) return { ok: false, res: forbidden() };
+  return { ok: true, ctx };
+}
+
+/** 401 if no session, 403 if not the trainer who owns the card. */
+export async function guardCard(
+  cardId: string
+): Promise<GuardResult<CardOwnershipContext>> {
+  if (!(await getSession())) return { ok: false, res: unauthenticated() };
+  const ctx = await requireTrainerOwnsCard(cardId);
+  if (!ctx) return { ok: false, res: forbidden() };
+  return { ok: true, ctx };
+}
+
+/** Parse a JSON body; returns null + a 400 response on malformed JSON. */
+export async function parseJson<T = Record<string, unknown>>(
+  request: Request
+): Promise<{ ok: true; body: T } | { ok: false; res: NextResponse }> {
+  try {
+    const body = (await request.json()) as T;
+    return { ok: true, body };
+  } catch {
+    return {
+      ok: false,
+      res: NextResponse.json({ error: "invalid_json" }, { status: 400 }),
+    };
+  }
+}
+
+/** 400 Bad Request with a message. */
+export const badRequest = (error: string) =>
+  NextResponse.json({ error }, { status: 400 });
+
+/** 404 Not Found with a message. */
+export const notFound = (error = "not_found") =>
+  NextResponse.json({ error }, { status: 404 });
+
+/**
+ * Maps a `*Core` failure error string to a status code. Core functions return
+ * free-form messages; "not found" style messages become 404, everything else
+ * is treated as a 400 validation error. Callers that need different mapping can
+ * build the response directly instead.
+ */
+export function coreError(error: string): NextResponse {
+  const lower = error.toLowerCase();
+  if (lower.includes("not found") || lower.includes("не найден")) {
+    return NextResponse.json({ error }, { status: 404 });
+  }
+  return NextResponse.json({ error }, { status: 400 });
+}

--- a/src/lib/api/respond.ts
+++ b/src/lib/api/respond.ts
@@ -5,6 +5,7 @@ import {
   requireTrainerOwnsSession,
   requireTrainerOwnsCard,
   requireTrainerOwnsStudent,
+  requireTrainerOwnsGoal,
   type TrainerContext,
   type OwnershipContext,
   type CardOwnershipContext,
@@ -50,6 +51,16 @@ export async function guardStudent(
 ): Promise<GuardResult<StudentOwnershipContext>> {
   if (!(await getSession())) return { ok: false, res: unauthenticated() };
   const ctx = await requireTrainerOwnsStudent(studentId);
+  if (!ctx) return { ok: false, res: forbidden() };
+  return { ok: true, ctx };
+}
+
+/** 401 if no session, 403 if not the trainer who owns the goal's student. */
+export async function guardGoal(
+  goalId: string
+): Promise<GuardResult<StudentOwnershipContext>> {
+  if (!(await getSession())) return { ok: false, res: unauthenticated() };
+  const ctx = await requireTrainerOwnsGoal(goalId);
   if (!ctx) return { ok: false, res: forbidden() };
   return { ok: true, ctx };
 }

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -91,6 +91,7 @@ export async function requireTrainerOwnsStudent(
     .from("profiles")
     .select("id")
     .eq("id", studentId)
+    .eq("role", "student")
     .eq("created_by", user.id)
     .maybeSingle();
 

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -99,6 +99,37 @@ export async function requireTrainerOwnsStudent(
   return { user, supabase, studentId, trainerId: user.id };
 }
 
+/**
+ * Verifies that the current session belongs to a trainer who owns the student
+ * behind the given goal (goals.user_id → profiles.created_by === trainer.id).
+ * Returns a StudentOwnershipContext (studentId = the goal's owner) or null.
+ */
+export async function requireTrainerOwnsGoal(
+  goalId: string
+): Promise<StudentOwnershipContext | null> {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+
+  const supabase = await createClient();
+
+  const { data: goal } = await supabase
+    .from("goals")
+    .select("user_id")
+    .eq("id", goalId)
+    .maybeSingle();
+  if (!goal) return null;
+
+  const { data: student } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", goal.user_id)
+    .eq("created_by", user.id)
+    .maybeSingle();
+  if (!student) return null;
+
+  return { user, supabase, studentId: goal.user_id as string, trainerId: user.id };
+}
+
 export type CardOwnershipContext = {
   user: SessionUser;
   supabase: SupabaseClient;

--- a/src/lib/auth/ownership.ts
+++ b/src/lib/auth/ownership.ts
@@ -56,7 +56,7 @@ export type TrainerContext = { user: SessionUser; supabase: SupabaseClient };
 
 /**
  * Verifies the current session is a trainer. Returns { user, supabase } or null.
- * For trainer-scoped read endpoints that aren't tied to a single session.
+ * For trainer-scoped operations that aren't tied to a single session/card.
  * Plain module (no "use server") — shared by Server Actions and Route Handlers.
  */
 export async function requireTrainer(): Promise<TrainerContext | null> {
@@ -64,6 +64,39 @@ export async function requireTrainer(): Promise<TrainerContext | null> {
   if (!user || user.role !== "trainer") return null;
   const supabase = await createClient();
   return { user, supabase };
+}
+
+export type StudentOwnershipContext = {
+  user: SessionUser;
+  supabase: SupabaseClient;
+  studentId: string;
+  trainerId: string;
+};
+
+/**
+ * Verifies that the current session belongs to a trainer who created the given
+ * student profile (profiles.created_by === trainer.id). Returns a
+ * StudentOwnershipContext on success, or null otherwise. Plain module
+ * (no "use server") so it can be shared by Server Actions and Route Handlers.
+ */
+export async function requireTrainerOwnsStudent(
+  studentId: string
+): Promise<StudentOwnershipContext | null> {
+  const user = await getSession();
+  if (!user || user.role !== "trainer") return null;
+
+  const supabase = await createClient();
+
+  const { data: student } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("id", studentId)
+    .eq("created_by", user.id)
+    .maybeSingle();
+
+  if (!student) return null;
+
+  return { user, supabase, studentId, trainerId: user.id };
 }
 
 export type CardOwnershipContext = {

--- a/src/lib/core/__tests__/skills.test.ts
+++ b/src/lib/core/__tests__/skills.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { addSkillToStudentCore, createAndAddSkillCore } from "../skills";
+
+// A supabase stub that throws if any query is attempted — these tests only
+// exercise the validation guards, which must short-circuit before touching the DB.
+const exploding = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error("DB should not be touched on the validation path");
+    },
+  }
+) as unknown as SupabaseClient;
+
+describe("addSkillToStudentCore — validation", () => {
+  it("rejects points below 1 without hitting the DB", async () => {
+    const result = await addSkillToStudentCore(exploding, "student", 1, 0);
+    expect(result).toEqual({ error: "Баллы должны быть от 1 до 10" });
+  });
+
+  it("rejects points above 10 without hitting the DB", async () => {
+    const result = await addSkillToStudentCore(exploding, "student", 1, 11);
+    expect(result).toEqual({ error: "Баллы должны быть от 1 до 10" });
+  });
+});
+
+describe("createAndAddSkillCore — validation", () => {
+  it("rejects an empty russian name", async () => {
+    const result = await createAndAddSkillCore(exploding, "student", "   ", "", 5);
+    expect(result).toEqual({ error: "Название обязательно" });
+  });
+
+  it("rejects a russian name longer than 40 chars", async () => {
+    const longName = "а".repeat(41);
+    const result = await createAndAddSkillCore(exploding, "student", longName, "", 5);
+    expect(result).toEqual({ error: "Название не более 40 символов" });
+  });
+});

--- a/src/lib/core/insightCards.ts
+++ b/src/lib/core/insightCards.ts
@@ -373,6 +373,24 @@ export async function applyTemplateToStudentCore(
   return { success: true, id: newCard.id };
 }
 
+/**
+ * Verifies a collection belongs to the given trainer. Used by `/api/v1` to gate
+ * mutations on collections by id (the web actions implicitly trust the UI).
+ */
+export async function collectionBelongsToTrainer(
+  supabase: SupabaseClient,
+  collectionId: string,
+  trainerId: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("insight_collections")
+    .select("id")
+    .eq("id", collectionId)
+    .eq("trainer_id", trainerId)
+    .maybeSingle();
+  return !!data;
+}
+
 export async function createCollectionCore(
   supabase: SupabaseClient,
   trainerId: string,

--- a/src/lib/core/masterPlan.ts
+++ b/src/lib/core/masterPlan.ts
@@ -1,0 +1,99 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MasterPlanCategory } from "@/lib/types";
+
+/**
+ * Business core for master-plan operations (plan, sections, items). Auth-agnostic:
+ * callers verify the user is a trainer and pass a ready `supabase` client plus the
+ * trainer id. No "use server", no revalidate. Wrapped by both web Server Actions
+ * and `/api/v1`.
+ */
+
+type Ok<T = object> = { success: true } & T;
+type Err = { success: false; error: string };
+
+export async function createMasterPlanCore(
+  supabase: SupabaseClient,
+  trainerId: string,
+  studentId: string
+): Promise<Ok<{ id: string }> | Err> {
+  const { data, error } = await supabase
+    .from("master_plans")
+    .insert({ student_id: studentId, trainer_id: trainerId })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  return { success: true, id: data.id };
+}
+
+export async function addMasterPlanSectionCore(
+  supabase: SupabaseClient,
+  planId: string,
+  payload: { title: string; category: MasterPlanCategory; sortOrder?: number }
+): Promise<Ok<{ id: string }> | Err> {
+  const { data, error } = await supabase
+    .from("master_plan_sections")
+    .insert({
+      plan_id: planId,
+      title: payload.title.trim(),
+      category: payload.category,
+      sort_order: payload.sortOrder ?? 0,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  return { success: true, id: data.id };
+}
+
+export async function deleteMasterPlanSectionCore(
+  supabase: SupabaseClient,
+  sectionId: string
+): Promise<Ok | Err> {
+  const { error } = await supabase
+    .from("master_plan_sections")
+    .delete()
+    .eq("id", sectionId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}
+
+export async function addMasterPlanItemCore(
+  supabase: SupabaseClient,
+  sectionId: string,
+  payload: {
+    title: string;
+    description?: string | null;
+    imageUrl?: string | null;
+    sortOrder?: number;
+  }
+): Promise<Ok<{ id: string }> | Err> {
+  const { data, error } = await supabase
+    .from("master_plan_items")
+    .insert({
+      section_id: sectionId,
+      title: payload.title.trim(),
+      description: payload.description?.trim() || null,
+      image_url: payload.imageUrl?.trim() || null,
+      sort_order: payload.sortOrder ?? 0,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) return { success: false, error: error?.message ?? "Failed" };
+  return { success: true, id: data.id };
+}
+
+export async function deleteMasterPlanItemCore(
+  supabase: SupabaseClient,
+  itemId: string
+): Promise<Ok | Err> {
+  const { error } = await supabase
+    .from("master_plan_items")
+    .delete()
+    .eq("id", itemId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}

--- a/src/lib/core/masterPlan.ts
+++ b/src/lib/core/masterPlan.ts
@@ -11,6 +11,59 @@ import type { MasterPlanCategory } from "@/lib/types";
 type Ok<T = object> = { success: true } & T;
 type Err = { success: false; error: string };
 
+/**
+ * Verifies a master-plan section belongs to the given student's plan. Used by
+ * `/api/v1` to confirm the trainer (already verified to own the student) is not
+ * mutating another student's section via id-guessing.
+ */
+export async function sectionBelongsToStudent(
+  supabase: SupabaseClient,
+  sectionId: string,
+  studentId: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("master_plan_sections")
+    .select("id, master_plans!inner(student_id)")
+    .eq("id", sectionId)
+    .maybeSingle();
+  if (!data) return false;
+  const plan = (data as unknown as { master_plans: { student_id: string } }).master_plans;
+  return plan?.student_id === studentId;
+}
+
+/** Verifies a master-plan item belongs to the given student's plan. */
+export async function itemBelongsToStudent(
+  supabase: SupabaseClient,
+  itemId: string,
+  studentId: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("master_plan_items")
+    .select("id, master_plan_sections!inner(master_plans!inner(student_id))")
+    .eq("id", itemId)
+    .maybeSingle();
+  if (!data) return false;
+  const section = (
+    data as unknown as { master_plan_sections: { master_plans: { student_id: string } } }
+  ).master_plan_sections;
+  return section?.master_plans?.student_id === studentId;
+}
+
+/** Verifies a master plan belongs to the given student. */
+export async function planBelongsToStudent(
+  supabase: SupabaseClient,
+  planId: string,
+  studentId: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("master_plans")
+    .select("id")
+    .eq("id", planId)
+    .eq("student_id", studentId)
+    .maybeSingle();
+  return !!data;
+}
+
 export async function createMasterPlanCore(
   supabase: SupabaseClient,
   trainerId: string,

--- a/src/lib/core/skills.ts
+++ b/src/lib/core/skills.ts
@@ -1,0 +1,83 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Business core for skill-progress operations driven by the trainer. Auth-agnostic:
+ * callers verify the user is a trainer and pass a ready `supabase` client. No
+ * "use server", no revalidate. Wrapped by both web Server Actions and `/api/v1`.
+ */
+
+type Ok = { success: true };
+type Err = { error: string };
+
+/**
+ * Adds `points` to the student's progress for the given skill. New skills get
+ * points_seen = NULL (shows a NEW badge); existing skills snapshot the old value
+ * into points_seen so the delta equals exactly the added amount.
+ */
+export async function addSkillToStudentCore(
+  supabase: SupabaseClient,
+  studentId: string,
+  skillId: number,
+  points: number
+): Promise<Ok | Err> {
+  if (points < 1 || points > 10) return { error: "Баллы должны быть от 1 до 10" };
+
+  const { data: existing } = await supabase
+    .from("skill_progress")
+    .select("points")
+    .eq("user_id", studentId)
+    .eq("skill_id", skillId)
+    .maybeSingle();
+
+  let dbError;
+  if (existing) {
+    const { error } = await supabase
+      .from("skill_progress")
+      .update({ points: existing.points + points, points_seen: existing.points })
+      .eq("user_id", studentId)
+      .eq("skill_id", skillId);
+    dbError = error;
+  } else {
+    const { error } = await supabase
+      .from("skill_progress")
+      .insert({ user_id: studentId, skill_id: skillId, points, points_seen: null });
+    dbError = error;
+  }
+
+  if (dbError) return { error: dbError.message };
+  return { success: true };
+}
+
+/**
+ * Upserts a skill by russian/english name, then adds it to the student. Returns
+ * the same shape as addSkillToStudentCore.
+ */
+export async function createAndAddSkillCore(
+  supabase: SupabaseClient,
+  studentId: string,
+  nameRu: string,
+  nameEn: string,
+  points: number
+): Promise<Ok | Err> {
+  const trimmedRu = nameRu.trim();
+  const trimmedEn = nameEn.trim() || trimmedRu;
+
+  if (!trimmedRu) return { error: "Название обязательно" };
+  if (trimmedRu.length > 40) return { error: "Название не более 40 символов" };
+
+  // ON CONFLICT DO UPDATE SET name = EXCLUDED.name ensures RETURNING works even on conflict.
+  const { data: skillRow, error: skillError } = await supabase
+    .from("skills")
+    .upsert(
+      { name: trimmedRu, name_ru: trimmedRu, name_en: trimmedEn },
+      { onConflict: "name" }
+    )
+    .select("id")
+    .single();
+
+  if (skillError || !skillRow) {
+    return { error: skillError?.message ?? "Не удалось создать скил" };
+  }
+
+  return addSkillToStudentCore(supabase, studentId, skillRow.id, points);
+}

--- a/src/lib/core/students.ts
+++ b/src/lib/core/students.ts
@@ -1,0 +1,148 @@
+import { randomBytes } from "crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Business core for trainer-managed student profiles and claim invitations.
+ * Auth-agnostic: callers verify the user is a trainer and pass a ready
+ * `supabase` client plus the trainer id. No "use server", no revalidate.
+ * Both the web Server Actions and `/api/v1` wrap these.
+ */
+
+const CLAIM_TTL_DAYS = 30;
+
+function generateToken(): string {
+  // 32 bytes -> 64 hex chars. URL-safe out of the box.
+  return randomBytes(32).toString("hex");
+}
+
+function expiryFromNow(days = CLAIM_TTL_DAYS): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString();
+}
+
+function buildClaimUrl(token: string): string {
+  const base = process.env.NEXT_PUBLIC_NIVEL_URL?.trim();
+  if (!base) throw new Error("NEXT_PUBLIC_NIVEL_URL is not set");
+  return `${base.replace(/\/$/, "")}/invite/${token}`;
+}
+
+export type ShadowStudentResult = {
+  studentId: string;
+  claimUrl: string;
+  claimToken: string;
+  expiresAt: string;
+};
+
+type Ok<T = object> = { success: true } & T;
+type Err = { success: false; error: string };
+
+export async function createShadowStudentCore(
+  supabase: SupabaseClient,
+  trainerId: string,
+  fullName: string
+): Promise<Ok<{ result: ShadowStudentResult }> | Err> {
+  const full_name = fullName?.trim();
+  if (!full_name) return { success: false, error: "full_name is required" };
+
+  const claimToken = generateToken();
+  const expiresAt = expiryFromNow();
+
+  // Email is left NULL on purpose — it is filled from the Firebase token when
+  // the student claims the profile.
+  const { data: created, error } = await supabase
+    .from("profiles")
+    .insert({
+      email: null,
+      full_name,
+      role: "student",
+      created_by: trainerId,
+      claim_token: claimToken,
+      claim_expires_at: expiresAt,
+    })
+    .select("id")
+    .single();
+
+  if (error || !created) {
+    return {
+      success: false,
+      error: error?.message ?? "Failed to create shadow student",
+    };
+  }
+
+  return {
+    success: true,
+    result: {
+      studentId: created.id,
+      claimUrl: buildClaimUrl(claimToken),
+      claimToken,
+      expiresAt,
+    },
+  };
+}
+
+export async function regenerateClaimTokenCore(
+  supabase: SupabaseClient,
+  studentId: string
+): Promise<Ok<{ result: ShadowStudentResult }> | Err> {
+  const { data: existing } = await supabase
+    .from("profiles")
+    .select("id, claimed_at")
+    .eq("id", studentId)
+    .maybeSingle();
+  if (!existing) return { success: false, error: "not_found" };
+  if (existing.claimed_at) return { success: false, error: "already_claimed" };
+
+  const claimToken = generateToken();
+  const expiresAt = expiryFromNow();
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ claim_token: claimToken, claim_expires_at: expiresAt })
+    .eq("id", studentId);
+  if (error) {
+    return { success: false, error: `Failed to regenerate token: ${error.message}` };
+  }
+
+  return {
+    success: true,
+    result: {
+      studentId,
+      claimUrl: buildClaimUrl(claimToken),
+      claimToken,
+      expiresAt,
+    },
+  };
+}
+
+export async function revokeClaimTokenCore(
+  supabase: SupabaseClient,
+  studentId: string
+): Promise<Ok | Err> {
+  const { error } = await supabase
+    .from("profiles")
+    .update({ claim_token: null, claim_expires_at: null })
+    .eq("id", studentId);
+  if (error) {
+    return { success: false, error: `Failed to revoke token: ${error.message}` };
+  }
+  return { success: true };
+}
+
+export async function updateStudentProfileCore(
+  supabase: SupabaseClient,
+  studentId: string,
+  patch: { full_name?: string | null; avatar_url?: string | null }
+): Promise<Ok | Err> {
+  const update: Record<string, unknown> = {};
+  if (patch.full_name !== undefined) update.full_name = patch.full_name;
+  if (patch.avatar_url !== undefined) update.avatar_url = patch.avatar_url;
+
+  if (Object.keys(update).length === 0) {
+    return { success: false, error: "Nothing to update" };
+  }
+
+  const { error } = await supabase.from("profiles").update(update).eq("id", studentId);
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+}


### PR DESCRIPTION
Closes #186

REST write-endpoints `/api/v1/*` (операции тренера) поверх ядра `src/lib/core/*` (A1) с bearer-авторизацией. Каждый роут сам вызывает `getSession()` + ownership-гард (proxy.ts не защищает `/api/v1/`).

## Эндпоинты

**Сессии**
- `POST /api/v1/sessions` — создать тренировку с упражнениями+навыками (createSessionCore)
- `POST /api/v1/sessions/for-student` — лёгкая сессия (planned/completed)
- `POST /api/v1/sessions/{id}/review-complete` — завершить/снять ревью тренера
- `POST /api/v1/sessions/{id}/cards/reorder` — порядок карточек
- `POST /api/v1/sessions/{id}/insights/generate` — LLM-анализ транскрипта (maxDuration=300)
- `POST /api/v1/sessions/{id}/insights/paste` — вставка markdown → draft-карточки
- `POST /api/v1/sessions/{id}/templates/apply` — применить шаблон к ученику сессии

**Цели**
- `POST /api/v1/students/{id}/goals` — цель для ученика
- `POST /api/v1/goals/{id}/cancel` — отменить цель (ownership по ученику цели)

**Ученики**
- `POST /api/v1/students` — теневой ученик + invite-ссылка
- `PATCH /api/v1/students/{id}` — править профиль
- `POST /api/v1/students/{id}/invite/regenerate` — переиздать приглашение
- `POST /api/v1/students/{id}/invite/revoke` — отозвать приглашение
- `POST /api/v1/students/{id}/skills` — добавить баллы навыка (по id или с созданием)

**Ревью карточек**
- `POST /api/v1/cards/{id}/approve` · `POST /api/v1/cards/{id}/reject`
- `PATCH /api/v1/cards/{id}` (edit) · `DELETE /api/v1/cards/{id}`

**Коллекции / шаблоны**
- `POST /api/v1/collections` · `POST /api/v1/collections/{id}/cards`
- `DELETE /api/v1/collections/{id}/cards/{templateId}` · `POST /api/v1/collections/{id}/apply`

**Мастер-план**
- `POST /api/v1/students/{id}/master-plan`
- `POST .../sections` · `DELETE .../sections/{sectionId}`
- `POST .../sections/{sectionId}/items` · `DELETE .../master-plan/items/{itemId}`

## Архитектура
- Новые auth-agnostic ядра: `core/students.ts`, `core/masterPlan.ts`, `core/skills.ts` + хелперы владения в `core/insightCards.ts` (collection) и `core/masterPlan.ts` (section/item/plan belongs-to). Существующие Server Actions (`actions/students|masterPlan|skills`) отрефакторены под эти ядра — веб и API делят логику, не дублируют.
- Гарды владения в `auth/ownership.ts`: `requireTrainer`, `requireTrainerOwnsStudent` (role=student + created_by), `requireTrainerOwnsGoal`.
- `lib/api/respond.ts` — тонкие HTTP-хелперы (guards, parseJson, badRequest/notFound/coreError). Лесенка статусов 401→403→400→404; generate отдаёт 502 при провале анализа; ClaimError на обмене токена → 422 (в A2).

## Отклонения от плана
- Ревью-карточки и reorder названы `/cards/*` и `/sessions/{id}/cards/reorder` (а не `insight-cards`). Параллельный ранний прогон того же issue запушил частичную версию с другим неймингом и без коллекций/мастер-плана/учеников/навыков — заменено этой полной реализацией (PR на ту версию не открывался).
- `createSessionCore` не сверяет goalId с studentId (паритет с веб-экшеном createSession); владение проверяется на уровне ученика.

## Проверка
- `npx tsc --noEmit` → 0 ошибок
- `npm test` → 28 passed (24 базовых + 4 новых на skills core)
- `npx eslint <изменённые>` → 0 ошибок
- Изменения видны в вебе (общая база), Telegram-уведомления (новые инсайты, завершение ревью) срабатывают через те же core-функции

🤖 Generated with [Claude Code](https://claude.com/claude-code)