### PR TITLE
fix(sessions): корректное время тренировки между dashboard и Telegram (#148)

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -178,7 +178,7 @@ export default function DashboardView({ data, locale, editable, previewMode, all
                     {allItems.map((item) => {
                       if (item.kind === "session") {
                         const dateStr = item.scheduled_at
-                          ? new Date(item.scheduled_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit", timeZone: "UTC" })
+                          ? new Date(item.scheduled_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", hour: "2-digit", minute: "2-digit", timeZone: "Europe/Madrid" })
                           : null;
                         return (
                           <Link
@@ -390,13 +390,13 @@ export default function DashboardView({ data, locale, editable, previewMode, all
                         <p className="font-semibold text-sm">
                           {(() => {
                             const d = new Date(session.scheduled_at ?? session.created_at);
-                            const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long", timeZone: "UTC" }).format(d);
-                            const time = new Intl.DateTimeFormat(dateLocale, { hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC" }).format(d);
+                            const weekday = new Intl.DateTimeFormat(dateLocale, { weekday: "long", timeZone: "Europe/Madrid" }).format(d);
+                            const time = new Intl.DateTimeFormat(dateLocale, { hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "Europe/Madrid" }).format(d);
                             return `${weekday.charAt(0).toUpperCase()}${weekday.slice(1)} ${time}`;
                           })()}
                         </p>
                         <p className="text-[11px] text-on-surface-variant">
-                          {new Date(session.scheduled_at ?? session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", timeZone: "UTC" })}
+                          {new Date(session.scheduled_at ?? session.created_at).toLocaleDateString(dateLocale, { day: "numeric", month: "long", timeZone: "Europe/Madrid" })}
                           {session.status === "completed" && ` · ${t(locale, "common.completed")}`}
                         </p>
                       </div>

--- a/src/components/dashboard/edit/InlineSessionCreator.tsx
+++ b/src/components/dashboard/edit/InlineSessionCreator.tsx
@@ -5,6 +5,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { createSessionForStudent } from "@/lib/actions/sessions";
 import type { DashboardGoal } from "@/lib/dashboard/data";
+import { madridLocalToUtcISO } from "@/lib/time/madrid";
 
 interface Props {
   studentId: string;
@@ -26,8 +27,9 @@ export default function InlineSessionCreator({ studentId, goals }: Props) {
       return;
     }
     startTransition(async () => {
-      // datetime-local has no timezone — append Z to treat the entered time as UTC literally
-      const iso = date ? `${date}:00.000Z` : null;
+      // datetime-local не несёт таймзоны — трактуем ввод как местное время Europe/Madrid
+      // и сохраняем настоящий UTC-инстант (согласовано с показом на /dashboard и Telegram-напоминанием).
+      const iso = date ? madridLocalToUtcISO(date) : null;
       const res = await createSessionForStudent(studentId, goalId, {
         scheduledAt: iso,
         completedAt: completed ? iso ?? new Date().toISOString() : null,

--- a/src/lib/time/madrid.test.ts
+++ b/src/lib/time/madrid.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { madridLocalToUtcISO } from "./madrid";
+
+describe("madridLocalToUtcISO", () => {
+  it("трактует летний ввод как CEST (UTC+2)", () => {
+    // 15:00 в Мадриде летом = 13:00 UTC
+    expect(madridLocalToUtcISO("2026-07-10T15:00")).toBe("2026-07-10T13:00:00.000Z");
+  });
+
+  it("трактует зимний ввод как CET (UTC+1)", () => {
+    // 15:00 в Мадриде зимой = 14:00 UTC
+    expect(madridLocalToUtcISO("2026-01-10T15:00")).toBe("2026-01-10T14:00:00.000Z");
+  });
+
+  it("round-trip: показ сохранённого инстанта в Europe/Madrid даёт исходное время", () => {
+    const iso = madridLocalToUtcISO("2026-07-10T15:00");
+    const shown = new Date(iso).toLocaleTimeString("ru-RU", {
+      timeZone: "Europe/Madrid",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    expect(shown).toBe("15:00");
+  });
+});

--- a/src/lib/time/madrid.ts
+++ b/src/lib/time/madrid.ts
@@ -1,0 +1,47 @@
+// src/lib/time/madrid.ts
+// Nivel работает в одном часовом поясе — Europe/Madrid (см. также src/lib/telegram/notify.ts).
+// Тренер вводит время тренировки во «wall-clock» Мадрида, а в БД (sessions.scheduled_at, timestamptz)
+// мы храним НАСТОЯЩИЙ UTC-инстант. Это держит согласованными: dashboard, Telegram-напоминание
+// и оконный запрос cron'а (который сравнивает scheduled_at с реальным «сейчас»).
+
+export const APP_TIMEZONE = "Europe/Madrid";
+
+// Смещение Europe/Madrid (в минутах) для конкретного UTC-инстанта. DST-aware.
+function madridOffsetMinutes(date: Date): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: APP_TIMEZONE,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p = dtf.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+  const asUTC = Date.UTC(
+    +p.year,
+    +p.month - 1,
+    +p.day,
+    +p.hour,
+    +p.minute,
+    +p.second
+  );
+  return (asUTC - date.getTime()) / 60000;
+}
+
+/**
+ * Конвертирует значение `input[type=datetime-local]` ("YYYY-MM-DDTHH:mm"),
+ * трактуя его как местное время Europe/Madrid, в UTC ISO-строку.
+ * DST-корректно для лета (CEST, UTC+2) и зимы (CET, UTC+1).
+ */
+export function madridLocalToUtcISO(local: string): string {
+  // Сначала трактуем строку как UTC, чтобы получить приблизительный инстант,
+  // затем вычитаем фактическое мадридское смещение для этого инстанта.
+  const naive = new Date(`${local}:00.000Z`);
+  const offset = madridOffsetMinutes(naive);
+  return new Date(naive.getTime() - offset * 60000).toISOString();
+}


### PR DESCRIPTION
Closes #148

## Отклонения от плана

Issue был помечен `blocked` с комментарием «в кодовой базе нет UI выбора времени». **Это устарело** — с тех пор появился `InlineSessionCreator` с `datetime-local`, который пишет `scheduled_at`. Баг стал воспроизводимым, блокер снят, реализовал фикс.

## Найденная причина

`scheduled_at` трактовался в трёх местах по-разному:

1. **`InlineSessionCreator`** сохранял введённое `datetime-local` как UTC-литерал: `15:00` → `15:00Z` (явный комментарий в коде «append Z to treat as UTC literally»).
2. **`DashboardView`** показывал с `timeZone: "UTC"` → `15:00`. Согласовано с (1).
3. **Telegram-напоминание** (`notify.ts`) форматировало в `Europe/Madrid` → `15:00Z` = `17:00`. ❌

Плюс: cron (`/api/cron/session-reminders`) ищет сессии по реальному UTC-инстанту, а хранился сдвинутый wall-clock → напоминания приходили не в то реальное время.

## Фикс

- Новый DST-корректный helper `src/lib/time/madrid.ts` → `madridLocalToUtcISO()`: трактует ввод как местное время `Europe/Madrid` и возвращает **настоящий UTC-инстант** (корректно для CEST +2 и CET +1).
- `InlineSessionCreator` использует helper вместо хака с `Z`.
- Показ `scheduled_at` на `/dashboard` переведён с `UTC` на `Europe/Madrid` (4 места).
- Тесты `src/lib/time/madrid.test.ts` (лето/зима/round-trip).

Теперь dashboard, Telegram-напоминание и cron-окно согласованы.

## Проверка

- `tsc --noEmit` ✓, `eslint` ✓, `vitest` (3/3) ✓
- Ввод `15:00` (лето) → хранится `13:00Z` → dashboard и напоминание показывают `15:00`.

## ⚠️ Существующие данные

Сессии, созданные до фикса, хранят wall-clock-as-UTC и на dashboard теперь сместятся на оффсет (1-2 ч). На раннем этапе записей мало; при необходимости можно одноразово скорректировать через SQL (с учётом DST). Отдельным шагом, не входит в этот PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)