### PR TITLE
feat(matches): карточка матча в стиле Playtomic + компактная шапка (#150)

### DIFF
--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { redirect, notFound } from "next/navigation";
-import Link from "next/link";
 import { getSession } from "@/lib/auth/session";
 import { createClient } from "@/lib/supabase/server";
 import { getLocale } from "@/lib/i18n";
@@ -7,6 +6,7 @@ import { t } from "@/lib/i18n/dict";
 import AttachInsightModal from "@/components/matches/AttachInsightModal";
 import ReflectionTextarea from "@/components/matches/ReflectionTextarea";
 import { getVaultCards } from "@/lib/actions/insightCards";
+import { formatScore } from "@/lib/playtomic/score";
 import BackButton from "@/components/navigation/BackButton";
 
 const UPCOMING_STATUSES = ["PENDING", "CONFIRMED"];
@@ -41,49 +41,6 @@ function formatDate(iso: string): string {
 function extractTeams(raw: unknown): Team[] {
   if (!Array.isArray(raw)) return [];
   return raw as Team[];
-}
-
-/**
- * Parses the Playtomic `results` jsonb into a human-readable score string.
- * Playtomic results can be an array of game objects like:
- *   [{ sets: [{local_score: 6, visitor_score: 3}, ...] }]
- * or a flat array of score objects.
- * Returns a formatted string like "6-3, 4-6, 6-4", or null if not parseable.
- */
-function formatScore(results: unknown): string | null {
-  if (results == null || typeof results !== "object") return null;
-  if (!Array.isArray(results)) return null;
-
-  const sets: string[] = [];
-
-  for (const item of results) {
-    if (!item || typeof item !== "object") continue;
-    const obj = item as Record<string, unknown>;
-
-    // Shape: { sets: [{local_score, visitor_score}] }
-    if (Array.isArray(obj["sets"])) {
-      for (const s of obj["sets"] as unknown[]) {
-        if (!s || typeof s !== "object") continue;
-        const setObj = s as Record<string, unknown>;
-        const local =
-          setObj["local_score"] ?? setObj["team1"] ?? setObj["home"];
-        const visitor =
-          setObj["visitor_score"] ?? setObj["team2"] ?? setObj["away"];
-        if (local != null && visitor != null) {
-          sets.push(`${local}-${visitor}`);
-        }
-      }
-    } else {
-      // Flat shape: [{local_score, visitor_score}]
-      const local = obj["local_score"] ?? obj["team1"] ?? obj["home"];
-      const visitor = obj["visitor_score"] ?? obj["team2"] ?? obj["away"];
-      if (local != null && visitor != null) {
-        sets.push(`${local}-${visitor}`);
-      }
-    }
-  }
-
-  return sets.length > 0 ? sets.join(", ") : null;
 }
 
 export default async function MatchDetailPage({ params }: PageProps) {

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -58,6 +58,7 @@ export default async function MatchesPage({ searchParams }: PageProps) {
         resource_name,
         status,
         teams,
+        results,
         match_goals(count)
       `
       )
@@ -72,6 +73,7 @@ export default async function MatchesPage({ searchParams }: PageProps) {
       resource_name: string | null;
       status: string | null;
       teams: unknown;
+      results: unknown;
       match_goals: Array<{ count: number }>;
     }>;
 
@@ -83,6 +85,7 @@ export default async function MatchesPage({ searchParams }: PageProps) {
       resource_name: r.resource_name,
       status: r.status,
       teams: r.teams,
+      results: r.results,
       goalsCount: r.match_goals?.[0]?.count ?? 0,
     }));
 

--- a/src/components/matches/AddMatchByUrlModal.tsx
+++ b/src/components/matches/AddMatchByUrlModal.tsx
@@ -43,10 +43,11 @@ export default function AddMatchByUrlModal({ locale }: Props) {
     <>
       <button
         onClick={handleOpen}
-        className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-primary/10 text-xs font-black uppercase tracking-widest text-primary hover:bg-primary/20 transition-colors"
+        aria-label={t(locale, "matches.addByUrl")}
+        title={t(locale, "matches.addByUrl")}
+        className="flex items-center justify-center h-11 w-11 rounded-xl bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
       >
-        <span className="material-symbols-outlined text-[18px]">add_link</span>
-        {t(locale, "matches.addByUrl")}
+        <span className="material-symbols-outlined text-[20px]">add_link</span>
       </button>
 
       {open && (

--- a/src/components/matches/MatchCard.tsx
+++ b/src/components/matches/MatchCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Locale } from "@/lib/i18n/dict";
 import { t } from "@/lib/i18n/dict";
+import { parseSetScores, computeWinner } from "@/lib/playtomic/score";
 
 interface Player {
   name?: string;
@@ -21,6 +22,7 @@ export interface MatchRow {
   resource_name: string | null;
   status: string | null;
   teams: unknown;
+  results?: unknown;
   goalsCount?: number;
 }
 
@@ -40,38 +42,39 @@ function formatDate(iso: string): string {
   });
 }
 
-function extractPlayers(teams: unknown): Player[] {
+function extractTeams(teams: unknown): Team[] {
   if (!Array.isArray(teams)) return [];
-  const players: Player[] = [];
-  for (const team of teams as Team[]) {
-    if (Array.isArray(team.players)) {
-      for (const p of team.players as Player[]) {
-        players.push(p);
-      }
-    }
-  }
-  return players.slice(0, 4);
+  return (teams as Team[]).slice(0, 2);
+}
+
+function teamNames(team: Team | undefined): string[] {
+  if (!team || !Array.isArray(team.players)) return [];
+  return (team.players as Player[]).slice(0, 2).map((p) => p.name ?? "—");
 }
 
 export default function MatchCard({ match, isUpcoming, locale }: Props) {
-  const players = extractPlayers(match.teams);
+  const teams = extractTeams(match.teams);
+  const sets = parseSetScores(match.results);
+  const winner = computeWinner(match.results);
+  const hasScore = sets.length > 0;
+
+  // Счёт по сетам для конкретной команды (0 = local, 1 = visitor).
+  const teamSetScores = (teamIdx: 0 | 1) =>
+    sets.map((s) => (teamIdx === 0 ? s.local : s.visitor));
 
   return (
     <Link
       href={`/matches/${match.id}`}
-      className="block bg-surface-card rounded-2xl p-4 space-y-3 hover:bg-surface-elevated transition-colors"
+      className="block bg-surface-card rounded-2xl overflow-hidden hover:bg-surface-elevated transition-colors"
     >
-      {/* Date + location */}
-      <div className="flex items-start justify-between gap-2">
-        <div className="space-y-0.5">
+      {/* Header: дата/место + статус */}
+      <div className="flex items-start justify-between gap-2 px-4 pt-3.5 pb-2.5">
+        <div className="min-w-0 space-y-0.5">
           <p className="text-sm font-bold text-on-surface">
             {formatDate(match.start_date)}
           </p>
           {match.location && (
-            <p className="text-xs text-on-surface-variant">{match.location}</p>
-          )}
-          {match.resource_name && (
-            <p className="text-xs text-on-surface-variant">{match.resource_name}</p>
+            <p className="text-xs text-on-surface-variant truncate">{match.location}</p>
           )}
         </div>
         <span
@@ -85,35 +88,74 @@ export default function MatchCard({ match, isUpcoming, locale }: Props) {
         </span>
       </div>
 
-      {/* Players */}
-      {players.length > 0 && (
-        <div className="grid grid-cols-2 gap-1.5">
-          {players.map((p, i) => (
-            <div
-              key={i}
-              className="flex items-center gap-1.5 bg-surface-elevated rounded-xl px-2.5 py-1.5"
-            >
-              <span className="material-symbols-outlined text-[16px] text-on-surface-variant">
-                person
-              </span>
-              <div className="min-w-0">
-                <p className="text-xs font-semibold text-on-surface truncate">
-                  {p.name ?? "—"}
-                </p>
-                {p.level != null && (
-                  <p className="text-[10px] text-on-surface-variant">
-                    {Number(p.level).toFixed(1)}
-                  </p>
+      {/* Teams + score (Playtomic-style: две строки команд, счёт по сетам справа) */}
+      {teams.length > 0 && (
+        <div className="border-t border-border-dim/60">
+          {([0, 1] as const).map((teamIdx) => {
+            const names = teamNames(teams[teamIdx]);
+            const isWinner = winner === teamIdx;
+            const scores = teamSetScores(teamIdx);
+            return (
+              <div
+                key={teamIdx}
+                className={`flex items-center justify-between gap-2 px-4 py-2.5 ${
+                  teamIdx === 0 ? "border-b border-border-dim/40" : ""
+                } ${isWinner ? "bg-primary/[0.07]" : ""}`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {hasScore && (
+                    <span
+                      className={`material-symbols-outlined text-[16px] shrink-0 ${
+                        isWinner ? "text-primary" : "text-transparent"
+                      }`}
+                    >
+                      emoji_events
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    {names.length > 0 ? (
+                      names.map((n, i) => (
+                        <p
+                          key={i}
+                          className={`text-xs truncate ${
+                            isWinner
+                              ? "font-bold text-on-surface"
+                              : "font-medium text-on-surface-variant"
+                          }`}
+                        >
+                          {n}
+                        </p>
+                      ))
+                    ) : (
+                      <p className="text-xs text-on-surface-variant">—</p>
+                    )}
+                  </div>
+                </div>
+                {hasScore && (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    {scores.map((sc, i) => (
+                      <span
+                        key={i}
+                        className={`w-5 text-center text-sm tabular-nums ${
+                          isWinner
+                            ? "font-black text-on-surface"
+                            : "font-semibold text-on-surface-variant"
+                        }`}
+                      >
+                        {sc}
+                      </span>
+                    ))}
+                  </div>
                 )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 
       {/* Goals CTA (upcoming only) */}
       {isUpcoming && (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 px-4 py-2.5 border-t border-border-dim/60">
           <span className="material-symbols-outlined text-[16px] text-primary">
             flag
           </span>

--- a/src/components/matches/RefreshMatchesButton.tsx
+++ b/src/components/matches/RefreshMatchesButton.tsx
@@ -22,14 +22,15 @@ export default function RefreshMatchesButton({ locale }: Props) {
     <button
       onClick={handleRefresh}
       disabled={isPending}
-      className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-surface-elevated text-xs font-black uppercase tracking-widest text-on-surface-variant hover:text-on-surface disabled:opacity-40 transition-colors"
+      aria-label={isPending ? t(locale, "matches.refreshing") : t(locale, "matches.refresh")}
+      title={isPending ? t(locale, "matches.refreshing") : t(locale, "matches.refresh")}
+      className="flex items-center justify-center h-11 w-11 rounded-xl bg-surface-elevated text-on-surface-variant hover:text-on-surface disabled:opacity-40 transition-colors"
     >
       <span
-        className={`material-symbols-outlined text-[18px] ${isPending ? "animate-spin" : ""}`}
+        className={`material-symbols-outlined text-[20px] ${isPending ? "animate-spin" : ""}`}
       >
         refresh
       </span>
-      {isPending ? t(locale, "matches.refreshing") : t(locale, "matches.refresh")}
     </button>
   );
 }

--- a/src/lib/playtomic/score.test.ts
+++ b/src/lib/playtomic/score.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseSetScores, formatScore, computeWinner } from "./score";
+
+const nested = [{ sets: [{ local_score: 6, visitor_score: 3 }, { local_score: 4, visitor_score: 6 }, { local_score: 6, visitor_score: 4 }] }];
+const flat = [{ local_score: 6, visitor_score: 2 }, { local_score: 6, visitor_score: 1 }];
+
+describe("playtomic score", () => {
+  it("парсит вложенную форму { sets: [...] }", () => {
+    expect(parseSetScores(nested)).toEqual([
+      { local: 6, visitor: 3 },
+      { local: 4, visitor: 6 },
+      { local: 6, visitor: 4 },
+    ]);
+  });
+
+  it("парсит плоскую форму", () => {
+    expect(parseSetScores(flat)).toEqual([
+      { local: 6, visitor: 2 },
+      { local: 6, visitor: 1 },
+    ]);
+  });
+
+  it("formatScore собирает строку по сетам", () => {
+    expect(formatScore(nested)).toBe("6-3, 4-6, 6-4");
+    expect(formatScore(null)).toBeNull();
+    expect(formatScore([])).toBeNull();
+  });
+
+  it("computeWinner: local выиграл 2:1 -> 0", () => {
+    expect(computeWinner(nested)).toBe(0);
+  });
+
+  it("computeWinner: visitor выиграл -> 1", () => {
+    expect(computeWinner([{ local_score: 3, visitor_score: 6 }, { local_score: 2, visitor_score: 6 }])).toBe(1);
+  });
+
+  it("computeWinner: ничья по сетам или нет данных -> null", () => {
+    expect(computeWinner([{ local_score: 6, visitor_score: 3 }, { local_score: 3, visitor_score: 6 }])).toBeNull();
+    expect(computeWinner(null)).toBeNull();
+  });
+});

--- a/src/lib/playtomic/score.ts
+++ b/src/lib/playtomic/score.ts
@@ -1,0 +1,67 @@
+// src/lib/playtomic/score.ts
+// Разбор Playtomic-результата (jsonb `matches.results`) в структуру по сетам.
+// teams[0] = local (хозяева), teams[1] = visitor (гости); local_score/visitor_score
+// в каждом сете соответствуют этим же двум командам.
+
+export interface SetScore {
+  local: number;
+  visitor: number;
+}
+
+/**
+ * Парсит `results` в массив сетов. Поддерживает обе формы Playtomic:
+ *   [{ sets: [{local_score, visitor_score}, ...] }]  и  [{local_score, visitor_score}, ...]
+ * Возвращает [] если распарсить нечего.
+ */
+export function parseSetScores(results: unknown): SetScore[] {
+  if (results == null || typeof results !== "object" || !Array.isArray(results)) {
+    return [];
+  }
+
+  const sets: SetScore[] = [];
+
+  const pushFrom = (obj: Record<string, unknown>) => {
+    const local = obj["local_score"] ?? obj["team1"] ?? obj["home"];
+    const visitor = obj["visitor_score"] ?? obj["team2"] ?? obj["away"];
+    if (local != null && visitor != null) {
+      sets.push({ local: Number(local), visitor: Number(visitor) });
+    }
+  };
+
+  for (const item of results) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    if (Array.isArray(obj["sets"])) {
+      for (const s of obj["sets"] as unknown[]) {
+        if (s && typeof s === "object") pushFrom(s as Record<string, unknown>);
+      }
+    } else {
+      pushFrom(obj);
+    }
+  }
+
+  return sets;
+}
+
+/** "6-3, 4-6, 6-4" или null. */
+export function formatScore(results: unknown): string | null {
+  const sets = parseSetScores(results);
+  return sets.length > 0 ? sets.map((s) => `${s.local}-${s.visitor}`).join(", ") : null;
+}
+
+/**
+ * Индекс команды-победителя по числу выигранных сетов: 0 (local), 1 (visitor)
+ * или null (нет данных / ничья).
+ */
+export function computeWinner(results: unknown): 0 | 1 | null {
+  const sets = parseSetScores(results);
+  if (sets.length === 0) return null;
+  let local = 0;
+  let visitor = 0;
+  for (const s of sets) {
+    if (s.local > s.visitor) local++;
+    else if (s.visitor > s.local) visitor++;
+  }
+  if (local === visitor) return null;
+  return local > visitor ? 0 : 1;
+}


### PR DESCRIPTION
Closes #150

## Отклонения от плана

Issue был помечен `blocked` («раздела Матчи не существует»). **Это устарело** — раздел `src/app/matches/` уже реализован (Epic 3): список, вкладки upcoming/past, детальная страница, синк с Playtomic. Блокер снят, выполнил исходную задачу: компактная шапка + карточка в стиле Playtomic.

## Что сделано

**1. Карточка матча (`MatchCard`) → структура Playtomic:**
- Две команды отдельными строками (по 2 игрока), а не плоской 2-кол. сеткой.
- Счёт по сетам справа от каждой команды (`6 4 6`), выровнен по столбцам.
- Подсветка победителя: кубок + лёгкий фон + жирный шрифт у выигравшей команды.
- Для upcoming-матчей (без счёта) — только команды + CTA по целям, как раньше.

**2. Шапка раздела — компактные кнопки:**
- «Обновить» и «Добавить» из широких пилюль с текстом → icon-only `44×44` квадраты.
- Тап-зона ≥44px сохранена (mobile-first), добавлены `aria-label`/`title`.

**3. Рефакторинг (DRY):**
- Новый общий helper `src/lib/playtomic/score.ts`: `parseSetScores` / `formatScore` / `computeWinner` + тесты (6 кейсов: обе формы Playtomic-results, победитель/ничья/пусто).
- Детальная страница `matches/[id]` переиспользует `formatScore` вместо своей копии (убрано дублирование ~40 строк). Заодно убран неиспользуемый импорт `Link`.
- В запрос списка матчей добавлен `results` (нужен карточке для счёта).

## Проверка

- `tsc --noEmit` ✓, `eslint` ✓ (0 warnings), `vitest` 6/6 ✓, `npm run build` ✓ (Compiled successfully).
- Ветка создана от свежего `origin/main` (после мержа #196).

## Что проверить вручную (UI)

- Прошедший матч со счётом: команды в две строки, счёт по сетам, победитель подсвечен.
- Предстоящий матч: команды + блок целей.
- Шапка на ~390px: компактные иконки, удобно жать пальцем.

🤖 Generated with [Claude Code](https://claude.com/claude-code)