### PR TITLE
feat(fcm): серверная отправка push-уведомлений (G2, #31)

### DIFF
--- a/src/app/api/v1/devices/token/route.ts
+++ b/src/app/api/v1/devices/token/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth/session";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * POST /api/v1/devices/token
+ * Body: { token: string, platform?: "android" }
+ *
+ * Registers (upserts) an FCM device token for the authenticated user so the
+ * server can later send push notifications via `sendPushNotification`.
+ * Bearer-authorized like every other /api/v1 route — the cookie gate in
+ * proxy.ts does not protect /api/v1, so we call getSession() here.
+ */
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  let body: { token?: string; platform?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const token = body.token?.trim();
+  if (!token) {
+    return NextResponse.json({ error: "token is required" }, { status: 400 });
+  }
+  const platform = body.platform?.trim() || "android";
+
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("device_tokens")
+    .upsert(
+      {
+        user_id: session.id,
+        token,
+        platform,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id,platform" }
+    );
+
+  if (error) {
+    console.error("[fcm] failed to upsert device token", error);
+    return NextResponse.json({ error: "failed to save token" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/lib/fcm.ts
+++ b/src/lib/fcm.ts
@@ -1,0 +1,172 @@
+// Server-side push notifications via Firebase Cloud Messaging HTTP v1.
+//
+// Mirrors the project's "no firebase-admin" decision (see CLAUDE.md): we mint a
+// Google OAuth2 access token ourselves by signing a JWT with the service-account
+// private key (`jose`), then call the FCM v1 `messages:send` endpoint.
+//
+// Credentials live in the `FCM_SERVICE_ACCOUNT_JSON` env var — the full service
+// account JSON downloaded from Firebase Console → Project Settings → Service
+// accounts → Generate new private key. If it is absent, every helper no-ops
+// gracefully (same posture as Telegram when TELEGRAM_BOT_TOKEN is unset), so
+// missing config never breaks the surrounding Server Action.
+
+import { SignJWT, importPKCS8 } from "jose";
+import { createClient } from "@/lib/supabase/server";
+
+const FCM_SCOPE = "https://www.googleapis.com/auth/firebase.messaging";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+type ServiceAccount = {
+  project_id: string;
+  client_email: string;
+  private_key: string;
+};
+
+export type PushResult = "sent" | "no_token" | "not_configured" | "failed";
+
+function getServiceAccount(): ServiceAccount | null {
+  const raw = process.env.FCM_SERVICE_ACCOUNT_JSON?.trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as ServiceAccount;
+    if (!parsed.project_id || !parsed.client_email || !parsed.private_key) {
+      console.error("[fcm] FCM_SERVICE_ACCOUNT_JSON missing required fields");
+      return null;
+    }
+    // Normalize escaped newlines (common when stored as a single-line env var).
+    parsed.private_key = parsed.private_key.replace(/\\n/g, "\n");
+    return parsed;
+  } catch (e) {
+    console.error("[fcm] FCM_SERVICE_ACCOUNT_JSON is not valid JSON", e);
+    return null;
+  }
+}
+
+// Cache the access token across invocations within a warm lambda.
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+async function getAccessToken(sa: ServiceAccount): Promise<string | null> {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && cachedToken.expiresAt - 60 > now) {
+    return cachedToken.value;
+  }
+
+  try {
+    const key = await importPKCS8(sa.private_key, "RS256");
+    const assertion = await new SignJWT({ scope: FCM_SCOPE })
+      .setProtectedHeader({ alg: "RS256", typ: "JWT" })
+      .setIssuer(sa.client_email)
+      .setSubject(sa.client_email)
+      .setAudience(TOKEN_URL)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 3600)
+      .sign(key);
+
+    const res = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion,
+      }),
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      console.error("[fcm] token exchange failed", res.status, await res.text());
+      return null;
+    }
+    const json = (await res.json()) as { access_token: string; expires_in: number };
+    cachedToken = {
+      value: json.access_token,
+      expiresAt: now + (json.expires_in ?? 3600),
+    };
+    return json.access_token;
+  } catch (e) {
+    console.error("[fcm] failed to mint access token", e);
+    return null;
+  }
+}
+
+async function getDeviceTokens(userId: string): Promise<string[]> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("device_tokens")
+    .select("token")
+    .eq("user_id", userId);
+  return (data ?? []).map((r) => (r as { token: string }).token).filter(Boolean);
+}
+
+async function deleteDeviceToken(token: string): Promise<void> {
+  const supabase = await createClient();
+  await supabase.from("device_tokens").delete().eq("token", token);
+}
+
+/**
+ * Send a push notification to every registered device of `userId`.
+ *
+ * `data` is delivered as FCM data payload (string values only) — the Android
+ * client reads e.g. `data.deeplink` to open the right screen on tap.
+ * Never throws: returns a status enum so callers can fire-and-forget.
+ */
+export async function sendPushNotification(
+  userId: string,
+  title: string,
+  body: string,
+  data: Record<string, string> = {}
+): Promise<PushResult> {
+  const sa = getServiceAccount();
+  if (!sa) return "not_configured";
+
+  try {
+    const tokens = await getDeviceTokens(userId);
+    if (tokens.length === 0) return "no_token";
+
+    const accessToken = await getAccessToken(sa);
+    if (!accessToken) return "failed";
+
+    const endpoint = `https://fcm.googleapis.com/v1/projects/${sa.project_id}/messages:send`;
+
+    let anySent = false;
+    let anyFailed = false;
+
+    await Promise.all(
+      tokens.map(async (token) => {
+        const res = await fetch(endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            message: {
+              token,
+              notification: { title, body },
+              data,
+              android: { priority: "HIGH" },
+            },
+          }),
+          cache: "no-store",
+        });
+
+        if (res.ok) {
+          anySent = true;
+          return;
+        }
+        anyFailed = true;
+        // 404 UNREGISTERED / 400 invalid token → drop the stale token.
+        if (res.status === 404 || res.status === 400) {
+          await deleteDeviceToken(token);
+        } else {
+          console.error("[fcm] send failed", res.status, await res.text());
+        }
+      })
+    );
+
+    if (anySent) return "sent";
+    return anyFailed ? "failed" : "no_token";
+  } catch (e) {
+    console.error("[fcm] sendPushNotification failed", e);
+    return "failed";
+  }
+}

--- a/src/lib/telegram/notify.ts
+++ b/src/lib/telegram/notify.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { sendMessage, type InlineKeyboard } from "./client";
+import { sendPushNotification } from "@/lib/fcm";
 
 const APP_URL = process.env.NEXT_PUBLIC_NIVEL_URL ?? "https://nivel-five.vercel.app";
 
@@ -38,10 +39,18 @@ export async function notifyNewInsights(
   sessionId: string,
   count: number
 ): Promise<NotifyResult> {
+  // Push (FCM) fires independently of the Telegram link — best-effort.
+  const word = plural(count, "новый разбор", "новых разбора", "новых разборов");
+  void sendPushNotification(
+    profileId,
+    "Новые разборы",
+    `Тренер прислал ${count} ${word} с тренировки.`,
+    { deeplink: `nivel://session/${sessionId}`, type: "new_insights", sessionId }
+  );
+
   try {
     const chatId = await getActiveChat(profileId);
     if (chatId === null) return "no_link";
-    const word = plural(count, "новый разбор", "новых разбора", "новых разборов");
     const text = `🎾 Тренер прислал ${count} ${word} с тренировки.`;
     const keyboard: InlineKeyboard = {
       inline_keyboard: [
@@ -66,16 +75,24 @@ export async function notifySessionReminder(
   scheduledAt: string,
   hoursBefore: number
 ): Promise<NotifyResult> {
+  const word = plural(hoursBefore, "час", "часа", "часов");
+  const date = new Date(scheduledAt);
+  const time = date.toLocaleTimeString("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/Madrid",
+  });
+
+  void sendPushNotification(
+    profileId,
+    "Скоро тренировка",
+    `Через ${hoursBefore} ${word} тренировка (в ${time}).`,
+    { deeplink: `nivel://session/${sessionId}`, type: "session_reminder", sessionId }
+  );
+
   try {
     const chatId = await getActiveChat(profileId);
     if (chatId === null) return "no_link";
-    const word = plural(hoursBefore, "час", "часа", "часов");
-    const date = new Date(scheduledAt);
-    const time = date.toLocaleTimeString("ru-RU", {
-      hour: "2-digit",
-      minute: "2-digit",
-      timeZone: "Europe/Madrid",
-    });
     const text = `⏰ Через ${hoursBefore} ${word} тренировка (в ${time}).`;
     const keyboard: InlineKeyboard = {
       inline_keyboard: [
@@ -100,6 +117,13 @@ export async function notifyStudentCompletedReview(
   studentName: string,
   sessionNumber: number
 ): Promise<NotifyResult> {
+  void sendPushNotification(
+    trainerProfileId,
+    "Разбор завершён",
+    `${studentName} завершил разбор тренировки #${sessionNumber}.`,
+    { deeplink: `nivel://session/${sessionId}`, type: "review_complete", sessionId }
+  );
+
   try {
     const chatId = await getActiveChat(trainerProfileId);
     if (chatId === null) return "no_link";

--- a/supabase/migrations/021_device_tokens.sql
+++ b/supabase/migrations/021_device_tokens.sql
@@ -1,0 +1,12 @@
+-- FCM device tokens for native push notifications.
+-- One row per (user, platform). Token updated on each FCM onNewToken.
+create table if not exists device_tokens (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references profiles(id) on delete cascade,
+  token text not null,
+  platform text not null default 'android',
+  updated_at timestamptz default now(),
+  unique (user_id, platform)
+);
+
+create index if not exists device_tokens_user_id_idx on device_tokens (user_id);


### PR DESCRIPTION
Серверная половина FCM push-уведомлений (G2). Парная задача в `nivel-android`.

## Что сделано
- **`src/lib/fcm.ts`** — `sendPushNotification(userId, title, body, data)`:
  - читает токены из `device_tokens` по `user_id`;
  - минтит Google OAuth2 access token из service account через `jose` (без `firebase-admin`, в духе решения проекта «нет firebase-admin»);
  - шлёт через **FCM HTTP v1** `messages:send`;
  - кэширует access token в тёплой лямбде, удаляет мёртвые токены (404 UNREGISTERED / 400);
  - **no-op** без `FCM_SERVICE_ACCOUNT_JSON` (как Telegram без бот-токена) — отсутствие конфига не ломает Server Action.
- **`POST /api/v1/devices/token`** — апсерт FCM-токена устройства по `(user_id, platform)`. Bearer-авторизация через `getSession()` (роут сам себя защищает, `/api/v1/` исключён из cookie-гейта `proxy.ts`).
- **Миграция `021_device_tokens.sql`** — таблица `device_tokens`. **Уже применена** на проде через Management API.
- Пуши шлются **рядом с Telegram-уведомлениями** в `src/lib/telegram/notify.ts` (одна точка): новые разборы, напоминание о тренировке, завершение разбора. Deeplink (`nivel://session/{id}`) едет в `data`-payload — Android открывает нужный экран по тапу.

## Требуется ENV (Vercel)
- **`FCM_SERVICE_ACCOUNT_JSON`** — полный JSON сервис-аккаунта Firebase (Project Settings → Service accounts → Generate new private key) проекта `grechka-6bdb7`, как одна строка. Без него push тихо отключён (Telegram продолжает работать).

## Проверка
- `npm run build` — зелёный, роут `/api/v1/devices/token` в манифесте.
- `device_tokens` создана и проверена в Supabase.

## Отклонения от плана
- План предлагал `google-auth-library`/firebase-admin ИЛИ Legacy Server Key. Legacy FCM API отключён Google (deprecated, ушёл в 2024), поэтому реализовано через **FCM v1 + self-signed JWT на `jose`** — переиспользует уже имеющуюся зависимость, не тянет firebase-admin/service-account-файл.

Closes #31 (серверная часть; Android — отдельный PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)