### PR TITLE
feat(api/v1): read-endpoints библиотеки карточек — GET /cards + /collections

### DIFF
--- a/src/app/api/v1/cards/route.ts
+++ b/src/app/api/v1/cards/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { guardTrainer } from "@/lib/api/respond";
+import { getCardLibraryCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/cards
+ *
+ * Trainer-only. The card template library: the trainer's insight cards
+ * deduplicated by `template_id` with per-template student stats, plus the
+ * student list used by the apply sheet. Mirrors the web `trainer/cards` page.
+ *
+ * Response: { templates: CardLibraryTemplate[], students: CardLibraryStudentRef[] }
+ */
+export async function GET() {
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  const data = await getCardLibraryCore(guard.ctx.supabase, guard.ctx.user.id);
+  return NextResponse.json(data);
+}

--- a/src/app/api/v1/collections/route.ts
+++ b/src/app/api/v1/collections/route.ts
@@ -1,6 +1,26 @@
 import { NextResponse } from "next/server";
 import { guardTrainer, parseJson, badRequest, coreError } from "@/lib/api/respond";
 import { createCollectionCore } from "@/lib/core/insightCards";
+import { listTrainerCollectionsCore } from "@/lib/core/trainerReads";
+
+/**
+ * GET /api/v1/collections
+ *
+ * Trainer-only. The trainer's card collections with their template ids and
+ * count. Mirrors the web `trainer/cards` page (Collections tab).
+ *
+ * Response: { collections: TrainerCollection[] }
+ */
+export async function GET() {
+  const guard = await guardTrainer();
+  if (!guard.ok) return guard.res;
+
+  const collections = await listTrainerCollectionsCore(
+    guard.ctx.supabase,
+    guard.ctx.user.id
+  );
+  return NextResponse.json({ collections });
+}
 
 /**
  * POST /api/v1/collections

--- a/src/lib/core/__tests__/apiContract.test.ts
+++ b/src/lib/core/__tests__/apiContract.test.ts
@@ -6,6 +6,8 @@ import {
   getSessionInsightCardsCore,
   getReferenceCore,
   getMasterPlanCore,
+  getCardLibraryCore,
+  listTrainerCollectionsCore,
 } from "../trainerReads";
 import { getTranscriptStatusCore, requestAudioUploadUrlCore } from "../audio";
 
@@ -135,6 +137,7 @@ describe("GET /api/v1/sessions/{id} — getSessionDetailCore", () => {
         rows: [{
           id: "se1", goal_id: "g1", session_number: 1, status: "planned",
           trainer_notes: null, scheduled_at: null, completed_at: null,
+          trainer_review_completed: false,
         }],
       },
       session_exercises: { rows: [{ id: 10, sort_order: 1, exercises: { name: "Стенка" } }] },
@@ -142,7 +145,7 @@ describe("GET /api/v1/sessions/{id} — getSessionDetailCore", () => {
     const r = await getSessionDetailCore(sb, "se1");
     expectKeys(r, [
       "id", "goal_id", "session_number", "status", "trainer_notes",
-      "scheduled_at", "completed_at", "exercises",
+      "scheduled_at", "completed_at", "trainer_review_completed", "exercises",
     ]);
     expectKeys(r!.exercises[0], ["id", "name", "sort_order"]);
     expect(r!.exercises[0]).toEqual({ id: 10, name: "Стенка", sort_order: 1 });
@@ -198,6 +201,60 @@ describe("GET /api/v1/students/{id}/master-plan — getMasterPlanCore", () => {
 
   it("нет плана → null", async () => {
     expect(await getMasterPlanCore(makeSupabaseStub({}), "s1")).toBeNull();
+  });
+});
+
+describe("GET /api/v1/cards — getCardLibraryCore", () => {
+  it("шейп шаблона/ученика стабилен; дедуп по template_id, агрегация решений", async () => {
+    const sb = makeSupabaseStub({
+      insight_cards: {
+        rows: [
+          {
+            id: "c1", template_id: "tpl", title: "T", body: "B", quote: null, tags: ["техника"],
+            trainer_status: "approved", created_at: "2026-01-02",
+            student_id: "s1", student_decision: "taken",
+          },
+          {
+            id: "c2", template_id: "tpl", title: "T", body: "B", quote: null, tags: ["техника"],
+            trainer_status: "approved", created_at: "2026-01-01",
+            student_id: "s2", student_decision: null,
+          },
+        ],
+      },
+      profiles: { rows: [{ id: "s1", full_name: "Иван", avatar_url: null }] },
+    });
+    const r = await getCardLibraryCore(sb, "t1");
+    expectKeys(r, ["templates", "students"]);
+    // два ряда с одним template_id схлопываются в один шаблон
+    expect(r.templates).toHaveLength(1);
+    expectKeys(r.templates[0], [
+      "id", "template_id", "title", "body", "quote", "tags", "trainer_status",
+      "created_at", "student_count", "taken_count", "skipped_count", "pending_count", "student_ids",
+    ]);
+    expect(r.templates[0].student_count).toBe(2);
+    expect(r.templates[0].taken_count).toBe(1);
+    expect(r.templates[0].pending_count).toBe(1);
+    expect(r.templates[0].student_ids).toEqual(["s1", "s2"]);
+    expectKeys(r.students[0], ["id", "full_name", "avatar_url"]);
+  });
+});
+
+describe("GET /api/v1/collections — listTrainerCollectionsCore", () => {
+  it("шейп коллекции стабилен; card_count и template_ids из вложенных карточек", async () => {
+    const sb = makeSupabaseStub({
+      insight_collections: {
+        rows: [{
+          id: "col1", name: "Подача", created_at: "2026-01-01",
+          insight_collection_cards: [{ template_id: "tpl1" }, { template_id: "tpl2" }],
+        }],
+      },
+    });
+    const r = await listTrainerCollectionsCore(sb, "t1");
+    expect(r).toHaveLength(1);
+    expectKeys(r[0], ["id", "trainer_id", "name", "created_at", "card_count", "template_ids"]);
+    expect(r[0].card_count).toBe(2);
+    expect(r[0].template_ids).toEqual(["tpl1", "tpl2"]);
+    expect(r[0].trainer_id).toBe("t1");
   });
 });
 

--- a/src/lib/core/trainerReads.ts
+++ b/src/lib/core/trainerReads.ts
@@ -209,6 +209,139 @@ export async function getSessionInsightCardsCore(
   }));
 }
 
+export type CardLibraryTemplate = {
+  id: string;
+  template_id: string | null;
+  title: string | null;
+  body: string | null;
+  quote: string | null;
+  tags: string[] | null;
+  trainer_status: string;
+  created_at: string;
+  student_count: number;
+  taken_count: number;
+  skipped_count: number;
+  pending_count: number;
+  student_ids: string[];
+};
+
+export type CardLibraryStudentRef = {
+  id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+};
+
+export type CardLibraryData = {
+  templates: CardLibraryTemplate[];
+  students: CardLibraryStudentRef[];
+};
+
+/**
+ * Card template library shown on the trainer "Карточки" page: the trainer's
+ * insight cards deduplicated by `template_id` with per-template student stats
+ * (taken / skipped / pending), plus the student list used by the apply sheet.
+ *
+ * Mirrors the aggregation in `src/app/trainer/cards/page.tsx` so the native
+ * screen can be a one-to-one port. The web page reads Supabase directly; this
+ * is the `/api/v1` equivalent.
+ */
+export async function getCardLibraryCore(
+  supabase: SupabaseClient,
+  trainerId: string
+): Promise<CardLibraryData> {
+  const [{ data: allCards }, { data: students }] = await Promise.all([
+    supabase
+      .from("insight_cards")
+      .select(
+        "id, template_id, title, body, quote, tags, trainer_status, created_at, student_id, student_decision"
+      )
+      .eq("trainer_id", trainerId)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("profiles")
+      .select("id, full_name, avatar_url")
+      .eq("role", "student")
+      .order("full_name"),
+  ]);
+
+  // Deduplicate by template_id (fall back to card id), aggregate decision stats.
+  const templateMap = new Map<string, CardLibraryTemplate>();
+  for (const raw of allCards ?? []) {
+    const card = raw as Record<string, unknown>;
+    const cardId = card.id as string;
+    const key = (card.template_id as string | null) ?? cardId;
+    if (!templateMap.has(key)) {
+      templateMap.set(key, {
+        id: cardId,
+        template_id: (card.template_id as string | null) ?? null,
+        title: (card.title as string | null) ?? null,
+        body: (card.body as string | null) ?? null,
+        quote: (card.quote as string | null) ?? null,
+        tags: (card.tags as string[] | null) ?? null,
+        trainer_status: (card.trainer_status as string | null) ?? "draft",
+        created_at: card.created_at as string,
+        student_count: 0,
+        taken_count: 0,
+        skipped_count: 0,
+        pending_count: 0,
+        student_ids: [],
+      });
+    }
+    const t = templateMap.get(key)!;
+    t.student_count++;
+    t.student_ids.push(card.student_id as string);
+    const decision = card.student_decision as string | null;
+    if (decision === "taken") t.taken_count++;
+    else if (decision === "skipped") t.skipped_count++;
+    else t.pending_count++;
+  }
+
+  return {
+    templates: Array.from(templateMap.values()),
+    students: (students ?? []).map((s: Record<string, unknown>) => ({
+      id: s.id as string,
+      full_name: (s.full_name as string | null) ?? null,
+      avatar_url: (s.avatar_url as string | null) ?? null,
+    })),
+  };
+}
+
+export type TrainerCollection = {
+  id: string;
+  trainer_id: string;
+  name: string;
+  created_at: string;
+  card_count: number;
+  template_ids: string[];
+};
+
+/**
+ * The trainer's card collections with their template ids and count. Mirrors the
+ * `collectionsWithCount` mapping in `src/app/trainer/cards/page.tsx`.
+ */
+export async function listTrainerCollectionsCore(
+  supabase: SupabaseClient,
+  trainerId: string
+): Promise<TrainerCollection[]> {
+  const { data } = await supabase
+    .from("insight_collections")
+    .select("id, name, created_at, insight_collection_cards(template_id)")
+    .eq("trainer_id", trainerId)
+    .order("created_at", { ascending: false });
+
+  return (data ?? []).map((raw: Record<string, unknown>) => {
+    const cards = (raw.insight_collection_cards as { template_id: string }[]) ?? [];
+    return {
+      id: raw.id as string,
+      trainer_id: trainerId,
+      name: raw.name as string,
+      created_at: raw.created_at as string,
+      card_count: cards.length,
+      template_ids: cards.map((c) => c.template_id),
+    };
+  });
+}
+
 export type ReferenceData = {
   problem_categories: Array<{ id: number; name: string; sort_order: number | null }>;
   problems: Array<{ id: number; category_id: number; name: string; sort_order: number | null }>;


### PR DESCRIPTION
Closes #200

Разблокирует nivel-android#27 (E4 — библиотека карточек-шаблонов и коллекции): write-эндпоинты для библиотеки уже были, но read-эндпоинтов не было, и нативный экран было нечем наполнять.

## Что сделано

Два тренер-scoped GET-эндпоинта поверх общего read-ядра. Форма ответа зеркалит агрегации веб-страницы `src/app/trainer/cards/page.tsx` (источник правды — она читает Supabase напрямую), чтобы нативный экран портировался один-в-один.

- **`GET /api/v1/cards`** → `{ templates, students }`
  - `templates` — insight-карточки тренера, дедуплицированные по `template_id` (фолбэк — id карточки), с агрегацией решений ученика (`student_count / taken_count / skipped_count / pending_count / student_ids`).
  - `students` — `{ id, full_name, avatar_url }` для шита «применить к ученику».
- **`GET /api/v1/collections`** → `{ collections }` — коллекции тренера (`id, trainer_id, name, created_at, card_count, template_ids`). Добавлен в существующий `collections/route.ts` рядом с `POST`.
- **Core** (`src/lib/core/trainerReads.ts`): `getCardLibraryCore`, `listTrainerCollectionsCore` — auth-agnostic, как остальные `*Core`.
- **Контракт-тесты** (`apiContract.test.ts`): точные наборы ключей DTO + проверка дедупа/агрегации/`card_count`. Шейпы мапятся в Android-DTO, тесты падают при дрейфе формы.

Авторизация — `guardTrainer()` (401 без сессии, 403 не-тренеру), как у остальных `/api/v1`.

## Отклонения от плана
- **Новый issue (#200), а не существующий.** A3 (#184) был закрыт без read-эндпоинтов библиотеки; завёл подзадачу A3.1 под эпиком #181.
- **`trainer_status` дефолтится в `"draft"` при `null`** — веб делает небезопасный каст `null → InsightTrainerStatus`; для нативного DTO конкретный не-null безопаснее.
- **Попутная правка устаревшего теста.** `getSessionDetailCore` уже возвращал `trainer_review_completed` (добавлено вне этого PR), но контракт-тест это поле не перечислял и падал на main — добавил поле в ожидаемый набор и фикстуру.

## Как проверить
- `npx vitest run src/lib/core/__tests__/apiContract.test.ts` — 14 passed.
- `npx tsc --noEmit`, `npx eslint` по изменённым файлам — чисто.
- С bearer-токеном тренера: `GET /api/v1/cards` и `GET /api/v1/collections` возвращают данные той же страницы «Карточки», что видит тренер в вебе; без сессии — 401, не-тренеру — 403.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156hcAGkWirSPp8aRsCSqVD)_